### PR TITLE
feat: implement webhook service for publishing events

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -100,15 +100,15 @@
       "json",
       "ts"
     ],
-    "rootDir": "src",
+    "rootDir": ".",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
     "collectCoverageFrom": [
-      "**/*.(t|j)s"
+      "src/**/*.(t|j)s"
     ],
-    "coverageDirectory": "../coverage",
+    "coverageDirectory": "coverage",
     "testEnvironment": "node"
   }
 }

--- a/backend/src/database/entities/webhook-configuration.entity.ts
+++ b/backend/src/database/entities/webhook-configuration.entity.ts
@@ -7,6 +7,7 @@ import {
   Index,
   OneToMany,
 } from 'typeorm';
+import { WebhookDeliveryLogEntity } from './webhook-delivery-log.entity';
 
 export enum WebhookEvent {
   PAYMENT_REQUEST_CREATED = 'payment_request.created',
@@ -20,7 +21,7 @@ export enum WebhookEvent {
 @Entity('webhook_configurations')
 @Index(['isActive'])
 @Index(['createdAt'])
-export class WebhookConfiguration {
+export class WebhookConfigurationEntity {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
 
@@ -43,13 +44,40 @@ export class WebhookConfiguration {
   @Column({ name: 'is_active', type: 'boolean', default: true })
   isActive!: boolean;
 
+  @Column({ name: 'failure_count', type: 'int', default: 0 })
+  failureCount!: number;
+
+  @Column({ name: 'last_delivered_at', type: 'timestamp', nullable: true })
+  lastDeliveredAt?: Date;
+
+  @Column({ name: 'last_failed_at', type: 'timestamp', nullable: true })
+  lastFailedAt?: Date;
+
+  @Column({ name: 'disabled_at', type: 'timestamp', nullable: true })
+  disabledAt?: Date;
+
+  @Column({ name: 'disabled_reason', type: 'varchar', length: 255, nullable: true })
+  disabledReason?: string;
+
+  @Column({ name: 'max_failure_count', type: 'int', default: 5 })
+  maxFailureCount!: number;
+
+  @Column({ name: 'batch_enabled', type: 'boolean', default: false })
+  batchEnabled!: boolean;
+
+  @Column({ name: 'batch_max_size', type: 'int', default: 20 })
+  batchMaxSize!: number;
+
+  @Column({ name: 'batch_window_ms', type: 'int', default: 2000 })
+  batchWindowMs!: number;
+
   @Column({ name: 'retry_attempts', type: 'int', default: 3 })
   retryAttempts!: number;
 
   @Column({ name: 'retry_delay_ms', type: 'int', default: 1000 })
   retryDelayMs!: number;
 
-  @Column({ name: 'timeout_ms', type: 'int', default: 30000 })
+  @Column({ name: 'timeout_ms', type: 'int', default: 5000 })
   timeoutMs!: number;
 
   @CreateDateColumn({
@@ -67,6 +95,6 @@ export class WebhookConfiguration {
   })
   updatedAt!: Date;
 
-  @OneToMany('WebhookDeliveryLog', 'webhookConfiguration')
-  deliveryLogs!: any[];
+  @OneToMany(() => WebhookDeliveryLogEntity, (log) => log.webhookConfiguration)
+  deliveryLogs!: WebhookDeliveryLogEntity[];
 }

--- a/backend/src/database/migrations/1769342977091-CreateWebhookDeliveryLogsTable.ts
+++ b/backend/src/database/migrations/1769342977091-CreateWebhookDeliveryLogsTable.ts
@@ -87,6 +87,17 @@ export class CreateWebhookDeliveryLogsTable1769342977091 implements MigrationInt
             isNullable: true,
           },
           {
+            name: 'payload_snapshot_encoding',
+            type: 'varchar',
+            length: '50',
+            isNullable: true,
+          },
+          {
+            name: 'payload_snapshot_size',
+            type: 'int',
+            isNullable: true,
+          },
+          {
             name: 'sent_at',
             type: 'timestamp',
             isNullable: true,
@@ -112,8 +123,31 @@ export class CreateWebhookDeliveryLogsTable1769342977091 implements MigrationInt
             default: 30,
           },
           {
+            name: 'retention_until',
+            type: 'timestamp',
+            isNullable: true,
+          },
+          {
             name: 'debug_info',
             type: 'jsonb',
+            isNullable: true,
+          },
+          {
+            name: 'request_id',
+            type: 'varchar',
+            length: '128',
+            isNullable: true,
+          },
+          {
+            name: 'correlation_id',
+            type: 'varchar',
+            length: '128',
+            isNullable: true,
+          },
+          {
+            name: 'trace_id',
+            type: 'varchar',
+            length: '128',
             isNullable: true,
           },
           {

--- a/backend/src/webhook/controllers/webhook.controller.ts
+++ b/backend/src/webhook/controllers/webhook.controller.ts
@@ -1,0 +1,182 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  Query,
+  HttpStatus,
+  Version,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { WebhookService } from '../services/webhook.service';
+import { WebhookDeliveryService } from '../services/webhook-delivery.service';
+import {
+  CreateWebhookDto,
+  WebhookResponseDto,
+  WebhookTestRequestDto,
+  WebhookVerificationRequestDto,
+} from '../dto/webhook.dto';
+import { SuccessResponseDto } from '../../common/dto/common-response.dto';
+
+@ApiTags('Webhooks')
+@ApiBearerAuth('JWT-auth')
+@Controller('webhooks')
+export class WebhookController {
+  constructor(
+    private readonly webhookService: WebhookService,
+    private readonly webhookDeliveryService: WebhookDeliveryService,
+  ) {}
+
+  @Version('1')
+  @Post()
+  @ApiOperation({
+    summary: 'Create a webhook subscription',
+    description: 'Registers a new webhook endpoint for receiving settlement events',
+  })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: 'Webhook created successfully',
+    type: WebhookResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Invalid webhook configuration',
+  })
+  async create(
+    @Body() createWebhookDto: CreateWebhookDto,
+  ): Promise<SuccessResponseDto<WebhookResponseDto>> {
+    const result = await this.webhookService.create(createWebhookDto);
+    return {
+      data: result,
+      requestId: 'req-123456-789',
+    };
+  }
+
+  @Version('1')
+  @Get()
+  @ApiOperation({
+    summary: 'List all webhooks',
+    description: 'Retrieves all configured webhook subscriptions',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Webhooks list retrieved',
+    isArray: true,
+    type: WebhookResponseDto,
+  })
+  async findAll() {
+    return this.webhookService.findAll();
+  }
+
+  @Version('1')
+  @Get(':id')
+  @ApiParam({
+    name: 'id',
+    description: 'Webhook unique identifier',
+  })
+  @ApiOperation({
+    summary: 'Get webhook details',
+  })
+  async findOne(@Param('id') id: string) {
+    return this.webhookService.findOne(id);
+  }
+
+  @Version('1')
+  @Put(':id')
+  @ApiParam({
+    name: 'id',
+    description: 'Webhook unique identifier',
+  })
+  @ApiOperation({
+    summary: 'Update webhook configuration',
+  })
+  async update(
+    @Param('id') id: string,
+    @Body() updateWebhookDto: CreateWebhookDto,
+  ) {
+    return this.webhookService.update(id, updateWebhookDto);
+  }
+
+  @Version('1')
+  @Delete(':id')
+  @ApiParam({
+    name: 'id',
+    description: 'Webhook unique identifier',
+  })
+  @ApiOperation({
+    summary: 'Delete webhook subscription',
+  })
+  async delete(@Param('id') id: string): Promise<void> {
+    await this.webhookService.delete(id);
+  }
+
+  @Version('1')
+  @Post(':id/test')
+  @ApiParam({
+    name: 'id',
+    description: 'Webhook unique identifier',
+  })
+  @ApiOperation({
+    summary: 'Send a test webhook event',
+  })
+  async testWebhook(
+    @Param('id') id: string,
+    @Body() body: WebhookTestRequestDto,
+  ): Promise<void> {
+    await this.webhookDeliveryService.enqueueDelivery(id, 'webhook.test', body?.payload ?? {}, {});
+  }
+
+  @Version('1')
+  @Post(':id/replay/:deliveryLogId')
+  @ApiParam({
+    name: 'id',
+    description: 'Webhook unique identifier',
+  })
+  @ApiParam({
+    name: 'deliveryLogId',
+    description: 'Delivery log identifier to replay',
+  })
+  @ApiOperation({
+    summary: 'Replay a previous webhook delivery',
+  })
+  async replayWebhook(@Param('deliveryLogId') deliveryLogId: string): Promise<void> {
+    await this.webhookDeliveryService.replayDelivery(deliveryLogId);
+  }
+
+  @Version('1')
+  @Post(':id/verify')
+  @ApiOperation({
+    summary: 'Verify a webhook signature',
+  })
+  async verifyWebhookSignature(
+    @Param('id') id: string,
+    @Body() body: WebhookVerificationRequestDto,
+  ): Promise<{ valid: boolean }> {
+    const webhook = await this.webhookService.findOne(id);
+    const payloadString = this.webhookDeliveryService.serializePayloadForVerification(body.payload ?? {});
+    const valid = this.webhookDeliveryService.verifySignature(payloadString, webhook.secret, body.signature);
+    return { valid };
+  }
+
+  @Version('1')
+  @Get(':id/analytics')
+  @ApiOperation({
+    summary: 'Get webhook delivery analytics',
+  })
+  async analytics(
+    @Param('id') id: string,
+    @Query('from') _from?: string,
+    @Query('to') _to?: string,
+  ) {
+    return this.webhookService.getDeliveryAnalytics(id);
+  }
+}

--- a/backend/src/webhook/dto/webhook.dto.ts
+++ b/backend/src/webhook/dto/webhook.dto.ts
@@ -1,0 +1,170 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsUrl, IsArray, IsEnum, IsString, IsOptional, IsBoolean, IsInt, Min } from 'class-validator';
+import { WebhookEvent } from '../../database/entities/webhook-configuration.entity';
+
+export class CreateWebhookDto {
+  @ApiProperty({
+    description: 'Webhook endpoint URL',
+    example: 'https://example.com/webhooks/settlement',
+    format: 'uri',
+  })
+  @IsUrl()
+  url: string;
+
+  @ApiProperty({
+    description: 'List of events to subscribe to',
+    example: [WebhookEvent.PAYMENT_REQUEST_CREATED, WebhookEvent.SETTLEMENT_COMPLETED],
+    isArray: true,
+    enum: Object.values(WebhookEvent),
+  })
+  @IsArray()
+  @IsEnum(WebhookEvent, { each: true })
+  events: WebhookEvent[];
+
+  @ApiPropertyOptional({
+    description: 'Custom webhook secret for HMAC signature verification',
+    example: 'secret-key-123',
+    minLength: 32,
+  })
+  @IsOptional()
+  @IsString()
+  secret?: string;
+
+  @ApiPropertyOptional({
+    description: 'Whether webhook is active',
+    example: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Maximum number of retry attempts',
+    example: 3,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  retryAttempts?: number;
+
+  @ApiPropertyOptional({
+    description: 'Base retry delay in milliseconds',
+    example: 1000,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  retryDelayMs?: number;
+
+  @ApiPropertyOptional({
+    description: 'Webhook timeout in milliseconds (max 5000)',
+    example: 5000,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1000)
+  timeoutMs?: number;
+
+  @ApiPropertyOptional({
+    description: 'Maximum consecutive failures before disabling webhook',
+    example: 5,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  maxFailureCount?: number;
+
+  @ApiPropertyOptional({
+    description: 'Enable event batching for this webhook',
+    example: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  batchEnabled?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Maximum number of events per batch',
+    example: 20,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  batchMaxSize?: number;
+
+  @ApiPropertyOptional({
+    description: 'Batching window in milliseconds',
+    example: 2000,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(100)
+  batchWindowMs?: number;
+}
+
+export class WebhookResponseDto {
+  @ApiProperty({
+    description: 'Webhook configuration unique identifier',
+    example: 'wh_123456789',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: 'Webhook endpoint URL',
+    example: 'https://example.com/webhooks/settlement',
+  })
+  url: string;
+
+  @ApiProperty({
+    description: 'Subscribed events',
+    isArray: true,
+  })
+  events: WebhookEvent[];
+
+  @ApiProperty({
+    description: 'Webhook active status',
+    example: true,
+  })
+  isActive: boolean;
+
+  @ApiProperty({
+    description: 'Last successful delivery timestamp',
+    example: '2024-01-20T10:30:00Z',
+  })
+  lastDeliveredAt: Date;
+
+  @ApiProperty({
+    description: 'Number of failed delivery attempts',
+    example: 0,
+  })
+  failureCount: number;
+
+  @ApiProperty({
+    description: 'Configuration creation timestamp',
+    example: '2024-01-20T10:00:00Z',
+  })
+  createdAt: Date;
+}
+
+export class WebhookTestRequestDto {
+  @ApiPropertyOptional({
+    description: 'Optional custom payload to send with the test event',
+    example: { ping: 'pong' },
+  })
+  @IsOptional()
+  payload?: Record<string, unknown>;
+}
+
+export class WebhookVerificationRequestDto {
+  @ApiProperty({
+    description: 'Raw payload that was received',
+    example: { id: 'evt_123', event: 'payment_request.created' },
+  })
+  payload: Record<string, unknown>;
+
+  @ApiProperty({
+    description: 'Signature header value (e.g. t=123,v1=abcdef)',
+    example: 't=1700000000,v1=abcdef123',
+  })
+  @IsString()
+  signature: string;
+}

--- a/backend/src/webhook/services/webhook-delivery-log-maintenance.service.spec.ts
+++ b/backend/src/webhook/services/webhook-delivery-log-maintenance.service.spec.ts
@@ -1,0 +1,37 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { WebhookDeliveryLogMaintenanceService } from './webhook-delivery-log-maintenance.service';
+import { WebhookDeliveryLogEntity } from '../../database/entities/webhook-delivery-log.entity';
+
+const mockRepository = {
+  query: jest.fn(),
+};
+
+describe('WebhookDeliveryLogMaintenanceService', () => {
+  let service: WebhookDeliveryLogMaintenanceService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhookDeliveryLogMaintenanceService,
+        {
+          provide: getRepositoryToken(WebhookDeliveryLogEntity),
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<WebhookDeliveryLogMaintenanceService>(
+      WebhookDeliveryLogMaintenanceService,
+    );
+    mockRepository.query.mockReset();
+  });
+
+  it('should cleanup expired logs', async () => {
+    mockRepository.query.mockResolvedValue({ rowCount: 2 });
+
+    await service.cleanupExpiredLogs();
+
+    expect(mockRepository.query).toHaveBeenCalled();
+  });
+});

--- a/backend/src/webhook/services/webhook-delivery-log-maintenance.service.ts
+++ b/backend/src/webhook/services/webhook-delivery-log-maintenance.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { WebhookDeliveryLogEntity } from '../../database/entities/webhook-delivery-log.entity';
+
+@Injectable()
+export class WebhookDeliveryLogMaintenanceService {
+  private readonly logger = new Logger(WebhookDeliveryLogMaintenanceService.name);
+
+  constructor(
+    @InjectRepository(WebhookDeliveryLogEntity)
+    private readonly deliveryLogRepository: Repository<WebhookDeliveryLogEntity>,
+  ) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async cleanupExpiredLogs(): Promise<void> {
+    try {
+      const result = await this.deliveryLogRepository.query(`
+        DELETE FROM webhook_delivery_logs
+        WHERE (
+          retention_until IS NOT NULL AND retention_until < NOW()
+        )
+        OR (
+          retention_until IS NULL
+          AND created_at < (NOW() - (retention_days || ' days')::interval)
+        )
+      `) as { rowCount?: number } | unknown[];
+
+      const deletedCount = Array.isArray(result) ? result.length : (result?.rowCount ?? 0);
+      if (deletedCount > 0) {
+        this.logger.log(`Deleted ${deletedCount} expired webhook delivery logs.`);
+      }
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      this.logger.error('Failed to cleanup expired webhook delivery logs.', err);
+    }
+  }
+}

--- a/backend/src/webhook/services/webhook-delivery.service.spec.ts
+++ b/backend/src/webhook/services/webhook-delivery.service.spec.ts
@@ -1,0 +1,181 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { WebhookDeliveryService } from './webhook-delivery.service';
+import { WebhookConfigurationEntity } from '../../database/entities/webhook-configuration.entity';
+import {
+  WebhookDeliveryLogEntity,
+  WebhookDeliveryStatus,
+} from '../../database/entities/webhook-delivery-log.entity';
+import { createHmac } from 'crypto';
+
+const mockConfigRepository = {
+  findOne: jest.fn(),
+  save: jest.fn((data: WebhookConfigurationEntity) => Promise.resolve(data)),
+};
+
+const mockLogRepository: {
+  create: jest.Mock<
+    WebhookDeliveryLogEntity,
+    [Partial<WebhookDeliveryLogEntity>]
+  >;
+  save: jest.Mock<
+    Promise<WebhookDeliveryLogEntity>,
+    [WebhookDeliveryLogEntity]
+  >;
+} = {
+  create: jest.fn(
+    (data: Partial<WebhookDeliveryLogEntity>) =>
+      ({
+        ...data,
+      }) as WebhookDeliveryLogEntity,
+  ),
+  save: jest.fn((data: WebhookDeliveryLogEntity) => Promise.resolve(data)),
+};
+
+const getHeaderValue = (
+  headers: HeadersInit | undefined,
+  name: string,
+): string | undefined => {
+  if (!headers) {
+    return undefined;
+  }
+  if (headers instanceof Headers) {
+    return headers.get(name) ?? undefined;
+  }
+  if (Array.isArray(headers)) {
+    return headers.find(([key]) => key === name)?.[1];
+  }
+  return headers[name];
+};
+
+describe('WebhookDeliveryService', () => {
+  let service: WebhookDeliveryService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhookDeliveryService,
+        {
+          provide: getRepositoryToken(WebhookConfigurationEntity),
+          useValue: mockConfigRepository,
+        },
+        {
+          provide: getRepositoryToken(WebhookDeliveryLogEntity),
+          useValue: mockLogRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<WebhookDeliveryService>(WebhookDeliveryService);
+
+    mockConfigRepository.findOne.mockReset();
+    mockConfigRepository.save.mockClear();
+    mockLogRepository.create.mockClear();
+    mockLogRepository.save.mockClear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should log a successful webhook delivery', async () => {
+    mockConfigRepository.findOne.mockResolvedValue({
+      id: 'wh_1',
+      url: 'https://example.com/webhook',
+      isActive: true,
+      events: ['payment_request.created'],
+      retryAttempts: 1,
+      retryDelayMs: 10,
+      timeoutMs: 3000,
+      secret: 'test-secret',
+      maxFailureCount: 5,
+      failureCount: 0,
+      batchEnabled: false,
+    });
+
+    const fetchMock = jest.spyOn(global, 'fetch' as any).mockResolvedValue({
+      status: 200,
+      headers: new Map([['content-type', 'application/json']]),
+      text: () => Promise.resolve('ok'),
+    } as any);
+
+    await service.deliverWebhook('wh_1', 'payment_request.created', {
+      foo: 'bar',
+    });
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(mockLogRepository.save).toHaveBeenCalledTimes(1);
+
+    const savedLog = mockLogRepository.save.mock.calls[0][0];
+    expect(savedLog.status).toBe(WebhookDeliveryStatus.DELIVERED);
+    expect(savedLog.payloadSnapshotEncoding).toBe('gzip');
+    expect(savedLog.payloadSnapshotSize).toBeGreaterThan(0);
+
+    const fetchOptions = fetchMock.mock.calls[0]?.[1] as
+      | RequestInit
+      | undefined;
+    const signatureHeader = getHeaderValue(
+      fetchOptions?.headers,
+      'X-Dabdub-Signature',
+    );
+    expect(signatureHeader).toBeDefined();
+  });
+
+  it('should retry and log failed attempts', async () => {
+    mockConfigRepository.findOne.mockResolvedValue({
+      id: 'wh_2',
+      url: 'https://example.com/webhook',
+      isActive: true,
+      events: ['payment_request.created'],
+      retryAttempts: 2,
+      retryDelayMs: 1,
+      timeoutMs: 3000,
+      secret: 'test-secret',
+      maxFailureCount: 5,
+      failureCount: 0,
+      batchEnabled: false,
+    });
+
+    const fetchMock = jest
+      .spyOn(global, 'fetch' as any)
+      .mockRejectedValueOnce(new Error('Network error'))
+      .mockResolvedValueOnce({
+        status: 204,
+        headers: new Map(),
+        text: () => Promise.resolve(''),
+      } as any);
+
+    jest.spyOn(service as any, 'sleep').mockResolvedValue(undefined);
+
+    await service.deliverWebhook('wh_2', 'payment_request.created', {
+      foo: 'bar',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(mockLogRepository.save).toHaveBeenCalledTimes(2);
+
+    const firstLog = mockLogRepository.save.mock.calls[0][0];
+    const secondLog = mockLogRepository.save.mock.calls[1][0];
+
+    expect(firstLog.status).toBe(WebhookDeliveryStatus.FAILED);
+    expect(firstLog.nextRetryAt).toBeDefined();
+    expect(secondLog.status).toBe(WebhookDeliveryStatus.DELIVERED);
+  });
+
+  it('should verify webhook signatures', () => {
+    const payload = { id: 'evt_1', event: 'payment_request.created' };
+    const payloadString = service.serializePayloadForVerification(payload);
+    const timestamp = 1700000000;
+    const signature = createHmac('sha256', 'verify-secret')
+      .update(`${timestamp}.${payloadString}`)
+      .digest('hex');
+
+    const header = `t=${timestamp},v1=${signature}`;
+    const isValid = service.verifySignature(
+      payloadString,
+      'verify-secret',
+      header,
+    );
+    expect(isValid).toBe(true);
+  });
+});

--- a/backend/src/webhook/services/webhook-delivery.service.ts
+++ b/backend/src/webhook/services/webhook-delivery.service.ts
@@ -1,0 +1,554 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { gzipSync } from 'zlib';
+import { createHmac, timingSafeEqual, randomUUID } from 'crypto';
+import { WebhookConfigurationEntity } from '../../database/entities/webhook-configuration.entity';
+import { WebhookEvent } from '../../database/entities/webhook-configuration.entity';
+import {
+  WebhookDeliveryLogEntity,
+  WebhookDeliveryStatus,
+} from '../../database/entities/webhook-delivery-log.entity';
+
+export interface WebhookDeliveryContext {
+  paymentRequestId?: string;
+  requestId?: string;
+  correlationId?: string;
+  traceId?: string;
+  userAgent?: string;
+  ipAddress?: string;
+}
+
+interface WebhookQueueItem {
+  webhookConfigId: string;
+  event: string;
+  payload: unknown;
+  context: WebhookDeliveryContext;
+}
+
+interface WebhookBatchEntry {
+  event: string;
+  payload: unknown;
+  context?: WebhookDeliveryContext;
+}
+
+@Injectable()
+export class WebhookDeliveryService {
+  private readonly logger = new Logger(WebhookDeliveryService.name);
+  private readonly queue: WebhookQueueItem[] = [];
+  private processing = false;
+  private readonly batchBuffers = new Map<
+    string,
+    { entries: WebhookBatchEntry[]; timer?: NodeJS.Timeout }
+  >();
+
+  constructor(
+    @InjectRepository(WebhookConfigurationEntity)
+    private readonly webhookConfigRepository: Repository<WebhookConfigurationEntity>,
+    @InjectRepository(WebhookDeliveryLogEntity)
+    private readonly deliveryLogRepository: Repository<WebhookDeliveryLogEntity>,
+  ) {}
+
+  async enqueueDelivery(
+    webhookConfigId: string,
+    event: string,
+    payload: unknown,
+    context: WebhookDeliveryContext = {},
+  ): Promise<void> {
+    const config = await this.webhookConfigRepository.findOne({
+      where: { id: webhookConfigId },
+    });
+    if (!config || !config.isActive) {
+      return;
+    }
+
+    if (!this.isWebhookEvent(event) || !config.events?.includes(event)) {
+      return;
+    }
+
+    if (config.batchEnabled) {
+      this.logger.debug(`Buffering webhook event ${event} for ${config.id}`);
+      this.bufferBatch(config, { event, payload, context });
+      return;
+    }
+
+    this.logger.debug(`Enqueued webhook event ${event} for ${webhookConfigId}`);
+    this.queue.push({ webhookConfigId, event, payload, context });
+    void this.processQueue();
+  }
+
+  async enqueueBatchDelivery(
+    webhookConfigId: string,
+    entries: WebhookBatchEntry[],
+  ): Promise<void> {
+    if (!entries.length) {
+      return;
+    }
+
+    const config = await this.webhookConfigRepository.findOne({
+      where: { id: webhookConfigId },
+    });
+    if (!config || !config.isActive) {
+      return;
+    }
+
+    if (!config.batchEnabled) {
+      entries.forEach((entry) => {
+        this.queue.push({
+          webhookConfigId,
+          event: entry.event,
+          payload: entry.payload,
+          context: entry.context ?? {},
+        });
+      });
+      this.logger.debug(
+        `Enqueued ${entries.length} webhook events for ${webhookConfigId}`,
+      );
+      void this.processQueue();
+      return;
+    }
+
+    const envelope = this.buildBatchEnvelope(entries);
+    this.queue.push({
+      webhookConfigId,
+      event: 'webhook.batch',
+      payload: envelope,
+      context: {},
+    });
+    void this.processQueue();
+  }
+
+  async deliverWebhook(
+    webhookConfigId: string,
+    event: string,
+    payload: unknown,
+    context: WebhookDeliveryContext = {},
+  ): Promise<void> {
+    const config = await this.webhookConfigRepository.findOne({
+      where: { id: webhookConfigId },
+    });
+    if (!config || !config.isActive) {
+      return;
+    }
+
+    if (event !== 'webhook.batch') {
+      if (!this.isWebhookEvent(event) || !config.events?.includes(event)) {
+        return;
+      }
+    }
+
+    const maxAttempts = Math.max(1, config.retryAttempts ?? 1);
+    const timeoutMs = Math.min(Math.max(1000, config.timeoutMs ?? 5000), 5000);
+    const retryDelayMs = Math.max(0, config.retryDelayMs ?? 1000);
+
+    this.logger.debug(
+      `Delivering webhook ${event} to ${config.url} (attempts: ${maxAttempts})`,
+    );
+
+    const envelope =
+      event === 'webhook.batch'
+        ? payload
+        : this.buildEventEnvelope(event, payload, context);
+    const payloadString = this.serializePayload(envelope);
+    const payloadSnapshot = gzipSync(Buffer.from(payloadString));
+    const payloadSnapshotSize = payloadSnapshot.length;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      const deliveryId = randomUUID();
+      const signatureHeader = this.createSignatureHeader(
+        payloadString,
+        config.secret,
+      );
+      const requestHeaders = this.buildRequestHeaders(
+        event,
+        signatureHeader,
+        deliveryId,
+      );
+
+      const log = this.deliveryLogRepository.create({
+        id: deliveryId,
+        webhookConfigId: config.id,
+        paymentRequestId: context.paymentRequestId,
+        event,
+        payload: envelope,
+        status: WebhookDeliveryStatus.PENDING,
+        attemptNumber: attempt,
+        maxAttempts,
+        requestHeaders,
+        requestBody: payloadString,
+        payloadSnapshot,
+        payloadSnapshotEncoding: 'gzip',
+        payloadSnapshotSize,
+        requestId: context.requestId,
+        correlationId: context.correlationId,
+        traceId: context.traceId,
+        userAgent: context.userAgent,
+        ipAddress: context.ipAddress,
+        debugInfo: signatureHeader ? { signatureHeader } : undefined,
+      });
+
+      const startTime = Date.now();
+      log.sentAt = new Date();
+      log.status = WebhookDeliveryStatus.SENT;
+
+      try {
+        const response = await this.sendRequest(
+          config.url,
+          payloadString,
+          timeoutMs,
+          requestHeaders,
+        );
+        log.responseTimeMs = Date.now() - startTime;
+        log.httpStatusCode = response.status;
+        log.responseHeaders = response.headers;
+        log.responseBody = response.body;
+
+        if (response.status >= 200 && response.status < 300) {
+          log.status = WebhookDeliveryStatus.DELIVERED;
+          log.deliveredAt = new Date();
+          await this.deliveryLogRepository.save(log);
+          await this.recordSuccess(config);
+          this.logger.log(`Webhook ${event} delivered to ${config.id}`);
+          return;
+        }
+
+        log.status = WebhookDeliveryStatus.FAILED;
+        log.failedAt = new Date();
+        log.errorMessage = `Non-2xx response: ${response.status}`;
+      } catch (error) {
+        log.status = WebhookDeliveryStatus.FAILED;
+        log.failedAt = new Date();
+        log.errorMessage = (error as Error).message;
+      }
+
+      if (attempt < maxAttempts) {
+        log.nextRetryAt = new Date(
+          Date.now() + this.calculateBackoffDelay(retryDelayMs, attempt),
+        );
+      }
+
+      await this.deliveryLogRepository.save(log);
+      await this.recordFailure(config, log.errorMessage ?? 'Delivery failed');
+
+      if (!config.isActive) {
+        this.logger.warn(`Webhook ${config.id} disabled during retry cycle.`);
+        return;
+      }
+
+      if (attempt < maxAttempts) {
+        await this.sleep(this.calculateBackoffDelay(retryDelayMs, attempt));
+      }
+    }
+
+    this.logger.warn(
+      `Webhook delivery failed after ${maxAttempts} attempts for ${config.id}`,
+    );
+  }
+
+  async replayDelivery(deliveryLogId: string): Promise<void> {
+    const log = await this.deliveryLogRepository.findOne({
+      where: { id: deliveryLogId },
+    });
+    if (!log) {
+      return;
+    }
+
+    await this.enqueueDelivery(log.webhookConfigId, log.event, log.payload, {
+      paymentRequestId: log.paymentRequestId,
+      requestId: log.requestId,
+      correlationId: log.correlationId,
+      traceId: log.traceId,
+      userAgent: log.userAgent,
+      ipAddress: log.ipAddress,
+    });
+  }
+
+  verifySignature(
+    payloadString: string,
+    secret: string | undefined,
+    signatureHeader: string,
+  ): boolean {
+    if (!secret) {
+      return false;
+    }
+    const parsed = this.parseSignatureHeader(signatureHeader);
+    if (!parsed) {
+      return false;
+    }
+
+    const expected = this.signPayload(payloadString, secret, parsed.timestamp);
+    const expectedBuffer = Buffer.from(expected, 'hex');
+    const providedBuffer = Buffer.from(parsed.signature, 'hex');
+    if (expectedBuffer.length !== providedBuffer.length) {
+      return false;
+    }
+
+    return timingSafeEqual(expectedBuffer, providedBuffer);
+  }
+
+  serializePayloadForVerification(payload: unknown): string {
+    return this.serializePayload(payload);
+  }
+
+  private async sendRequest(
+    url: string,
+    body: string,
+    timeoutMs: number,
+    requestHeaders: Record<string, string>,
+  ): Promise<{
+    status: number;
+    headers: Record<string, string>;
+    body: string;
+  }> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: requestHeaders,
+        body,
+        signal: controller.signal,
+      });
+
+      const responseHeaders: Record<string, string> = {};
+      response.headers.forEach((value, key) => {
+        responseHeaders[key] = value;
+      });
+
+      const responseBody = await response.text();
+
+      return {
+        status: response.status,
+        headers: responseHeaders,
+        body: responseBody,
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private async processQueue(): Promise<void> {
+    if (this.processing) {
+      return;
+    }
+    this.processing = true;
+    while (this.queue.length) {
+      const item = this.queue.shift();
+      if (!item) {
+        continue;
+      }
+      await this.deliverWebhook(
+        item.webhookConfigId,
+        item.event,
+        item.payload,
+        item.context,
+      );
+    }
+    this.processing = false;
+  }
+
+  private bufferBatch(
+    config: WebhookConfigurationEntity,
+    entry: WebhookBatchEntry,
+  ): void {
+    const buffer = this.batchBuffers.get(config.id) ?? { entries: [] };
+    buffer.entries.push(entry);
+
+    if (buffer.entries.length >= (config.batchMaxSize ?? 20)) {
+      void this.flushBatch(config.id);
+      return;
+    }
+
+    if (!buffer.timer) {
+      const batchWindowMs = Number(config.batchWindowMs ?? 2000);
+      buffer.timer = setTimeout(() => {
+        void this.flushBatch(config.id);
+      }, batchWindowMs);
+    }
+
+    this.batchBuffers.set(config.id, buffer);
+  }
+
+  private async flushBatch(webhookConfigId: string): Promise<void> {
+    const buffer = this.batchBuffers.get(webhookConfigId);
+    if (!buffer || !buffer.entries.length) {
+      return;
+    }
+
+    if (buffer.timer) {
+      clearTimeout(buffer.timer);
+    }
+    this.batchBuffers.delete(webhookConfigId);
+
+    const config = await this.webhookConfigRepository.findOne({
+      where: { id: webhookConfigId },
+    });
+    if (!config || !config.isActive) {
+      return;
+    }
+
+    const envelope = this.buildBatchEnvelope(buffer.entries);
+    this.logger.debug(
+      `Flushing batch of ${buffer.entries.length} events for ${webhookConfigId}`,
+    );
+    this.queue.push({
+      webhookConfigId,
+      event: 'webhook.batch',
+      payload: envelope,
+      context: {},
+    });
+    void this.processQueue();
+  }
+
+  private buildEventEnvelope(
+    event: string,
+    payload: unknown,
+    context: WebhookDeliveryContext,
+  ): Record<string, unknown> {
+    return {
+      id: `evt_${randomUUID()}`,
+      event,
+      createdAt: new Date().toISOString(),
+      data: payload ?? {},
+      context,
+    };
+  }
+
+  private buildBatchEnvelope(
+    entries: WebhookBatchEntry[],
+  ): Record<string, unknown> {
+    return {
+      id: `batch_${randomUUID()}`,
+      type: 'batch',
+      createdAt: new Date().toISOString(),
+      events: entries.map((entry) =>
+        this.buildEventEnvelope(
+          entry.event,
+          entry.payload,
+          entry.context ?? {},
+        ),
+      ),
+    };
+  }
+
+  private serializePayload(payload: unknown): string {
+    return JSON.stringify(payload, this.stableJsonReplacer());
+  }
+
+  private stableJsonReplacer(): (key: string, value: unknown) => unknown {
+    return (_key, value) => {
+      if (this.isPlainObject(value)) {
+        const sortedKeys = Object.keys(value).sort();
+        return sortedKeys.reduce<Record<string, unknown>>((acc, key) => {
+          acc[key] = value[key];
+          return acc;
+        }, {});
+      }
+      return value;
+    };
+  }
+
+  private buildRequestHeaders(
+    event: string,
+    signatureHeader: string | null,
+    deliveryId: string,
+  ): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+      'User-Agent': 'Dabdub-Webhook/1.0',
+      'X-Dabdub-Event': event,
+      'X-Dabdub-Delivery': deliveryId,
+      ...(signatureHeader ? { 'X-Dabdub-Signature': signatureHeader } : {}),
+    };
+  }
+
+  private createSignatureHeader(
+    payloadString: string,
+    secret?: string,
+  ): string | null {
+    if (!secret) {
+      return null;
+    }
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signature = this.signPayload(payloadString, secret, timestamp);
+    return `t=${timestamp},v1=${signature}`;
+  }
+
+  private signPayload(
+    payloadString: string,
+    secret: string,
+    timestamp: number,
+  ): string {
+    return createHmac('sha256', secret)
+      .update(`${timestamp}.${payloadString}`)
+      .digest('hex');
+  }
+
+  private parseSignatureHeader(
+    header: string,
+  ): { timestamp: number; signature: string } | null {
+    const parts = header.split(',').map((part) => part.trim());
+    const timestampPart = parts.find((part) => part.startsWith('t='));
+    const signaturePart = parts.find((part) => part.startsWith('v1='));
+    if (!timestampPart || !signaturePart) {
+      return null;
+    }
+    const timestamp = Number(timestampPart.replace('t=', ''));
+    const signature = signaturePart.replace('v1=', '');
+    if (!Number.isFinite(timestamp) || !signature) {
+      return null;
+    }
+    return { timestamp, signature };
+  }
+
+  private calculateBackoffDelay(baseDelay: number, attempt: number): number {
+    const exponential = baseDelay * Math.pow(2, attempt - 1);
+    const jitter = Math.floor(Math.random() * 250);
+    return exponential + jitter;
+  }
+
+  private async recordFailure(
+    config: WebhookConfigurationEntity,
+    reason: string,
+  ): Promise<void> {
+    const currentFailureCount = Number(config.failureCount ?? 0);
+    config.failureCount = currentFailureCount + 1;
+    config.lastFailedAt = new Date();
+
+    if (
+      config.maxFailureCount &&
+      config.failureCount >= config.maxFailureCount
+    ) {
+      config.isActive = false;
+      config.disabledAt = new Date();
+      config.disabledReason = reason;
+      this.logger.warn(
+        `Disabling webhook ${config.id} after ${config.failureCount} failures.`,
+      );
+    }
+
+    await this.webhookConfigRepository.save(config);
+  }
+
+  private async recordSuccess(
+    config: WebhookConfigurationEntity,
+  ): Promise<void> {
+    config.failureCount = 0;
+    config.lastDeliveredAt = new Date();
+    config.lastFailedAt = undefined;
+    await this.webhookConfigRepository.save(config);
+  }
+
+  private isPlainObject(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+  }
+
+  private isWebhookEvent(event: string): event is WebhookEvent {
+    return (Object.values(WebhookEvent) as string[]).includes(event);
+  }
+
+  protected async sleep(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/backend/src/webhook/services/webhook-health-monitor.service.ts
+++ b/backend/src/webhook/services/webhook-health-monitor.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { WebhookConfigurationEntity } from '../../database/entities/webhook-configuration.entity';
+
+@Injectable()
+export class WebhookHealthMonitorService {
+  private readonly logger = new Logger(WebhookHealthMonitorService.name);
+
+  constructor(
+    @InjectRepository(WebhookConfigurationEntity)
+    private readonly webhookRepository: Repository<WebhookConfigurationEntity>,
+  ) {}
+
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  async monitorHealth(): Promise<void> {
+    const activeWebhooks = await this.webhookRepository.find({ where: { isActive: true } });
+    const now = new Date();
+
+    await Promise.all(
+      activeWebhooks.map(async (webhook) => {
+        if (webhook.maxFailureCount && webhook.failureCount >= webhook.maxFailureCount) {
+          webhook.isActive = false;
+          webhook.disabledAt = now;
+          webhook.disabledReason = 'Exceeded maximum failure count';
+          await this.webhookRepository.save(webhook);
+          this.logger.warn(`Paused unhealthy webhook ${webhook.id}`);
+        }
+      }),
+    );
+  }
+}

--- a/backend/src/webhook/services/webhook.service.ts
+++ b/backend/src/webhook/services/webhook.service.ts
@@ -1,0 +1,203 @@
+import { Injectable, NotFoundException, BadRequestException, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { WebhookConfigurationEntity } from '../../database/entities/webhook-configuration.entity';
+import { CreateWebhookDto } from '../dto/webhook.dto';
+import { randomUUID } from 'crypto';
+import { WebhookDeliveryService, WebhookDeliveryContext } from './webhook-delivery.service';
+import { WebhookDeliveryLogEntity, WebhookDeliveryStatus } from '../../database/entities/webhook-delivery-log.entity';
+
+@Injectable()
+export class WebhookService {
+  private readonly logger = new Logger(WebhookService.name);
+
+  constructor(
+    @InjectRepository(WebhookConfigurationEntity)
+    private readonly webhookRepository: Repository<WebhookConfigurationEntity>,
+    @InjectRepository(WebhookDeliveryLogEntity)
+    private readonly deliveryLogRepository: Repository<WebhookDeliveryLogEntity>,
+    private readonly webhookDeliveryService: WebhookDeliveryService,
+  ) {}
+
+  async create(createWebhookDto: CreateWebhookDto): Promise<any> {
+    // Validate webhook URL is reachable
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    try {
+      const response = await fetch(createWebhookDto.url, { method: 'HEAD', signal: controller.signal });
+      if (!response.ok && response.status !== 404) {
+        throw new BadRequestException('Webhook URL is not reachable');
+      }
+    } catch (error) {
+      throw new BadRequestException('Webhook URL validation failed: ' + (error as Error).message);
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    const webhook = this.webhookRepository.create({
+      id: `wh_${randomUUID()}`,
+      url: createWebhookDto.url,
+      events: createWebhookDto.events,
+      secret: createWebhookDto.secret,
+      isActive: createWebhookDto.isActive ?? true,
+      retryAttempts: createWebhookDto.retryAttempts ?? 3,
+      retryDelayMs: createWebhookDto.retryDelayMs ?? 1000,
+      timeoutMs: Math.min(createWebhookDto.timeoutMs ?? 5000, 5000),
+      maxFailureCount: createWebhookDto.maxFailureCount ?? 5,
+      batchEnabled: createWebhookDto.batchEnabled ?? false,
+      batchMaxSize: createWebhookDto.batchMaxSize ?? 20,
+      batchWindowMs: createWebhookDto.batchWindowMs ?? 2000,
+      failureCount: 0,
+    });
+
+    return this.webhookRepository.save(webhook);
+  }
+
+  async findAll(): Promise<WebhookConfigurationEntity[]> {
+    return this.webhookRepository.find({
+      order: {
+        createdAt: 'DESC',
+      },
+    });
+  }
+
+  async findOne(id: string): Promise<WebhookConfigurationEntity> {
+    const webhook = await this.webhookRepository.findOne({ where: { id } });
+    if (!webhook) {
+      throw new NotFoundException(`Webhook ${id} not found`);
+    }
+    return webhook;
+  }
+
+  async update(id: string, updateWebhookDto: CreateWebhookDto): Promise<WebhookConfigurationEntity> {
+    const webhook = await this.findOne(id);
+
+    if (updateWebhookDto.url) {
+      webhook.url = updateWebhookDto.url;
+    }
+    if (updateWebhookDto.events) {
+      webhook.events = updateWebhookDto.events;
+    }
+    if (updateWebhookDto.secret !== undefined) {
+      webhook.secret = updateWebhookDto.secret;
+    }
+    if (updateWebhookDto.isActive !== undefined) {
+      webhook.isActive = updateWebhookDto.isActive;
+    }
+    if (updateWebhookDto.retryAttempts !== undefined) {
+      webhook.retryAttempts = updateWebhookDto.retryAttempts;
+    }
+    if (updateWebhookDto.retryDelayMs !== undefined) {
+      webhook.retryDelayMs = updateWebhookDto.retryDelayMs;
+    }
+    if (updateWebhookDto.timeoutMs !== undefined) {
+      webhook.timeoutMs = Math.min(updateWebhookDto.timeoutMs, 5000);
+    }
+    if (updateWebhookDto.maxFailureCount !== undefined) {
+      webhook.maxFailureCount = updateWebhookDto.maxFailureCount;
+    }
+    if (updateWebhookDto.batchEnabled !== undefined) {
+      webhook.batchEnabled = updateWebhookDto.batchEnabled;
+    }
+    if (updateWebhookDto.batchMaxSize !== undefined) {
+      webhook.batchMaxSize = updateWebhookDto.batchMaxSize;
+    }
+    if (updateWebhookDto.batchWindowMs !== undefined) {
+      webhook.batchWindowMs = updateWebhookDto.batchWindowMs;
+    }
+
+    webhook.updatedAt = new Date();
+    return this.webhookRepository.save(webhook);
+  }
+
+  async delete(id: string): Promise<void> {
+    const webhook = await this.findOne(id);
+    await this.webhookRepository.remove(webhook);
+  }
+
+  async incrementFailureCount(id: string): Promise<void> {
+    await this.webhookRepository.increment({ id }, 'failureCount', 1);
+  }
+
+  async resetFailureCount(id: string): Promise<void> {
+    await this.webhookRepository.update({ id }, { failureCount: 0, lastDeliveredAt: new Date() });
+  }
+
+  async publishEvent(
+    event: string,
+    payload: unknown,
+    context: WebhookDeliveryContext = {},
+  ): Promise<void> {
+    const activeWebhooks = await this.webhookRepository.find({ where: { isActive: true } });
+    const targets = activeWebhooks.filter((config) => config.events?.includes(event as any));
+
+    await Promise.all(
+      targets.map((config) => this.webhookDeliveryService.enqueueDelivery(config.id, event, payload, context)),
+    );
+  }
+
+  async publishEventsBatch(
+    events: Array<{ event: string; payload: unknown; context?: WebhookDeliveryContext }>,
+  ): Promise<void> {
+    if (!events.length) {
+      return;
+    }
+
+    const activeWebhooks = await this.webhookRepository.find({ where: { isActive: true } });
+    const byWebhook = new Map<string, Array<{ event: string; payload: unknown; context?: WebhookDeliveryContext }>>();
+
+    for (const entry of events) {
+      for (const config of activeWebhooks) {
+        if (!config.events?.includes(entry.event as any)) {
+          continue;
+        }
+        const bucket = byWebhook.get(config.id) ?? [];
+        bucket.push(entry);
+        byWebhook.set(config.id, bucket);
+      }
+    }
+
+    await Promise.all(
+      Array.from(byWebhook.entries()).map(([webhookId, bucket]) =>
+        this.webhookDeliveryService.enqueueBatchDelivery(webhookId, bucket),
+      ),
+    );
+  }
+
+  async getDeliveryAnalytics(webhookConfigId: string): Promise<{
+    total: number;
+    delivered: number;
+    failed: number;
+    avgResponseTimeMs: number;
+    lastDeliveredAt?: Date;
+  }> {
+    const [total, delivered, failed] = await Promise.all([
+      this.deliveryLogRepository.count({ where: { webhookConfigId } }),
+      this.deliveryLogRepository.count({ where: { webhookConfigId, status: WebhookDeliveryStatus.DELIVERED } }),
+      this.deliveryLogRepository.count({ where: { webhookConfigId, status: WebhookDeliveryStatus.FAILED } }),
+    ]);
+
+    const avgResult = await this.deliveryLogRepository
+      .createQueryBuilder('log')
+      .select('AVG(log.responseTimeMs)', 'avg')
+      .where('log.webhookConfigId = :webhookConfigId', { webhookConfigId })
+      .getRawOne<{ avg: string | null }>();
+
+    const lastDeliveredLog = await this.deliveryLogRepository.findOne({
+      where: { webhookConfigId, status: WebhookDeliveryStatus.DELIVERED },
+      order: { deliveredAt: 'DESC' },
+    });
+
+    const avgResponseTimeMs = avgResult?.avg ? Math.round(Number(avgResult.avg)) : 0;
+
+    this.logger.debug(`Webhook analytics computed for ${webhookConfigId}`);
+
+    return {
+      total,
+      delivered,
+      failed,
+      avgResponseTimeMs,
+      lastDeliveredAt: lastDeliveredLog?.deliveredAt,
+    };
+  }
+}

--- a/backend/src/webhook/webhook.module.ts
+++ b/backend/src/webhook/webhook.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { WebhookController } from './controllers/webhook.controller';
+import { WebhookService } from './services/webhook.service';
+import { WebhookConfigurationEntity } from '../database/entities/webhook-configuration.entity';
+import { WebhookDeliveryLogEntity } from '../database/entities/webhook-delivery-log.entity';
+import { WebhookDeliveryLogMaintenanceService } from './services/webhook-delivery-log-maintenance.service';
+import { WebhookDeliveryService } from './services/webhook-delivery.service';
+import { WebhookHealthMonitorService } from './services/webhook-health-monitor.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([WebhookConfigurationEntity, WebhookDeliveryLogEntity])],
+  controllers: [WebhookController],
+  providers: [
+    WebhookService,
+    WebhookDeliveryLogMaintenanceService,
+    WebhookDeliveryService,
+    WebhookHealthMonitorService,
+  ],
+  exports: [WebhookService, WebhookDeliveryService],
+})
+export class WebhookModule {}


### PR DESCRIPTION
# implement webhook service for publishing events Closes #25

Implement webhook service for publishing events to merchant endpoints with retry logic and signature verification.


## TASKS

- [x] Create WebhookService with event publishing
- [x] Implement webhook signature generation (HMAC)
- [x] Add event payload serialization
- [x] Create webhook delivery queue
- [x] Implement retry logic with exponential backoff
- [x] Add webhook timeout handling
- [x] Create delivery status tracking
- [x] Implement webhook verification
- [x] Add event batching support
- [x] Create webhook health monitoring
- [x] Implement automatic webhook disabling on repeated failures
- [x] Add webhook delivery analytics
- [x] Create webhook testing endpoint
- [x] Implement webhook replay functionality
- [x] Add comprehensive logging
- [x] Create unit tests with HTTP mocking