### PR TITLE
feat: add NetworkConfiguration entity for blockchain network settings…

### DIFF
--- a/backend/src/blockchain/blockchain.module.ts
+++ b/backend/src/blockchain/blockchain.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { BlockchainNetwork } from './entities/blockchain-network.entity';
 import { BlockchainBlockCursor } from './entities/blockchain-block-cursor.entity';
 import { PaymentRequest } from './entities/payment-request.entity';
+import { NetworkConfiguration } from './entities/network-configuration.entity';
 import { BlockchainMonitoringService } from './services/blockchain-monitoring.service';
 import { StellarClientService } from './services/stellar-client.service';
 import { StacksService } from './services/stacks.service';
@@ -16,6 +17,7 @@ import { BlockchainMonitoringController } from './controllers/blockchain-monitor
       BlockchainNetwork,
       BlockchainBlockCursor,
       PaymentRequest,
+      NetworkConfiguration,
     ]),
   ],
   controllers: [BlockchainMonitoringController],
@@ -32,4 +34,4 @@ import { BlockchainMonitoringController } from './controllers/blockchain-monitor
     StacksService,
   ],
 })
-export class BlockchainModule { }
+export class BlockchainModule {}

--- a/backend/src/blockchain/entities/network-configuration.entity.ts
+++ b/backend/src/blockchain/entities/network-configuration.entity.ts
@@ -1,0 +1,135 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export enum NetworkStatus {
+  ACTIVE = 'active',
+  MAINTENANCE = 'maintenance',
+  DEPRECATED = 'deprecated',
+}
+
+@Entity('network_configs')
+@Index(['network'])
+@Index(['status'])
+@Index(['isActive'])
+export class NetworkConfiguration {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'network', type: 'varchar', length: 100, unique: true })
+  network: string;
+
+  @Column({ name: 'rpc_url', type: 'text' })
+  rpcUrl: string;
+
+  @Column({ name: 'chain_id', type: 'int' })
+  chainId: number;
+
+  @Column({ name: 'is_active', type: 'boolean', default: true })
+  isActive: boolean;
+
+  @Column({ name: 'block_time', type: 'int', nullable: true })
+  blockTime: number | null;
+
+  @Column({
+    name: 'status',
+    type: 'enum',
+    enum: NetworkStatus,
+    enumName: 'network_status_enum',
+    default: NetworkStatus.ACTIVE,
+  })
+  status: NetworkStatus;
+
+  @Column({
+    name: 'usdc_contract_address',
+    type: 'varchar',
+    length: 255,
+    nullable: true,
+  })
+  usdcContractAddress: string | null;
+
+  @Column({
+    name: 'settlement_contract_address',
+    type: 'varchar',
+    length: 255,
+    nullable: true,
+  })
+  settlementContractAddress: string | null;
+
+  @Column({ name: 'required_confirmations', type: 'int', default: 12 })
+  requiredConfirmations: number;
+
+  @Column({
+    name: 'current_gas_price',
+    type: 'decimal',
+    precision: 20,
+    scale: 8,
+    nullable: true,
+  })
+  currentGasPrice: number | null;
+
+  @Column({
+    name: 'max_gas_price',
+    type: 'decimal',
+    precision: 20,
+    scale: 8,
+    nullable: true,
+  })
+  maxGasPrice: number | null;
+
+  @Column({ name: 'last_block_number', type: 'int', nullable: true })
+  lastBlockNumber: number | null;
+
+  @Column({ name: 'last_health_check', type: 'timestamp', nullable: true })
+  lastHealthCheck: Date | null;
+
+  @Column({ name: 'is_healthy', type: 'boolean', default: true })
+  isHealthy: boolean;
+
+  @Column({ name: 'fallback_rpc_urls', type: 'simple-array', nullable: true })
+  fallbackRpcUrls: string[] | null;
+
+  @Column({ name: 'last_scanned_block', type: 'int', nullable: true })
+  lastScannedBlock: number | null;
+
+  @Column({
+    name: 'base_fee_per_gas',
+    type: 'decimal',
+    precision: 20,
+    scale: 8,
+    nullable: true,
+  })
+  baseFeePerGas: number | null;
+
+  @Column({
+    name: 'priority_fee_per_gas',
+    type: 'decimal',
+    precision: 20,
+    scale: 8,
+    nullable: true,
+  })
+  priorityFeePerGas: number | null;
+
+  @Column({ name: 'network_settings', type: 'jsonb', nullable: true })
+  networkSettings: Record<string, unknown> | null;
+
+  @Column({ name: 'supports_eip1559', type: 'boolean', default: false })
+  supportsEIP1559: boolean;
+
+  @Column({ name: 'supports_flashbots', type: 'boolean', default: false })
+  supportsFlashbots: boolean;
+
+  @Column({ name: 'supports_erc20', type: 'boolean', default: true })
+  supportsERC20: boolean;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/backend/src/database/migrations/1771900000000-CreateNetworkConfigsTable.ts
+++ b/backend/src/database/migrations/1771900000000-CreateNetworkConfigsTable.ts
@@ -1,0 +1,153 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateNetworkConfigsTable1771900000000 implements MigrationInterface {
+  name = 'CreateNetworkConfigsTable1771900000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1
+          FROM pg_type t
+          JOIN pg_namespace n ON n.oid = t.typnamespace
+          WHERE t.typname = 'network_status_enum' AND n.nspname = 'public'
+        ) THEN
+          CREATE TYPE "public"."network_status_enum" AS ENUM ('active', 'maintenance', 'deprecated');
+        END IF;
+      END
+      $$;
+    `);
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'network_configs',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          { name: 'network', type: 'varchar', length: '100', isUnique: true },
+          { name: 'rpc_url', type: 'text' },
+          { name: 'chain_id', type: 'int' },
+          { name: 'is_active', type: 'boolean', default: true },
+          { name: 'block_time', type: 'int', isNullable: true },
+          {
+            name: 'status',
+            type: 'enum',
+            enumName: 'network_status_enum',
+            enum: ['active', 'maintenance', 'deprecated'],
+            default: "'active'",
+          },
+          {
+            name: 'usdc_contract_address',
+            type: 'varchar',
+            length: '255',
+            isNullable: true,
+          },
+          {
+            name: 'settlement_contract_address',
+            type: 'varchar',
+            length: '255',
+            isNullable: true,
+          },
+          { name: 'required_confirmations', type: 'int', default: 12 },
+          {
+            name: 'current_gas_price',
+            type: 'decimal',
+            precision: 20,
+            scale: 8,
+            isNullable: true,
+          },
+          {
+            name: 'max_gas_price',
+            type: 'decimal',
+            precision: 20,
+            scale: 8,
+            isNullable: true,
+          },
+          { name: 'last_block_number', type: 'int', isNullable: true },
+          { name: 'last_health_check', type: 'timestamp', isNullable: true },
+          { name: 'is_healthy', type: 'boolean', default: true },
+          { name: 'fallback_rpc_urls', type: 'text', isNullable: true },
+          { name: 'last_scanned_block', type: 'int', isNullable: true },
+          {
+            name: 'base_fee_per_gas',
+            type: 'decimal',
+            precision: 20,
+            scale: 8,
+            isNullable: true,
+          },
+          {
+            name: 'priority_fee_per_gas',
+            type: 'decimal',
+            precision: 20,
+            scale: 8,
+            isNullable: true,
+          },
+          { name: 'network_settings', type: 'jsonb', isNullable: true },
+          { name: 'supports_eip1559', type: 'boolean', default: false },
+          { name: 'supports_flashbots', type: 'boolean', default: false },
+          { name: 'supports_erc20', type: 'boolean', default: true },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'network_configs',
+      new TableIndex({
+        name: 'IDX_network_configs_network',
+        columnNames: ['network'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'network_configs',
+      new TableIndex({
+        name: 'IDX_network_configs_status',
+        columnNames: ['status'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'network_configs',
+      new TableIndex({
+        name: 'IDX_network_configs_is_active',
+        columnNames: ['is_active'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex(
+      'network_configs',
+      'IDX_network_configs_is_active',
+    );
+    await queryRunner.dropIndex(
+      'network_configs',
+      'IDX_network_configs_status',
+    );
+    await queryRunner.dropIndex(
+      'network_configs',
+      'IDX_network_configs_network',
+    );
+    await queryRunner.dropTable('network_configs', true);
+    await queryRunner.query(
+      `DROP TYPE IF EXISTS "public"."network_status_enum"`,
+    );
+  }
+}

--- a/backend/src/database/seeds/network-config.seeder.ts
+++ b/backend/src/database/seeds/network-config.seeder.ts
@@ -1,18 +1,16 @@
 import { DataSource } from 'typeorm';
 
 export interface NetworkConfig {
-  id: string;
-  name: string;
   network: string;
   rpcUrl: string;
   chainId: number;
-  nativeCurrency: {
-    name: string;
-    symbol: string;
-    decimals: number;
-  };
-  blockExplorer: string;
   isActive: boolean;
+  requiredConfirmations: number;
+  fallbackRpcUrls?: string[];
+  networkSettings?: Record<string, unknown>;
+  supportsEIP1559?: boolean;
+  supportsFlashbots?: boolean;
+  supportsERC20?: boolean;
 }
 
 export class NetworkConfigSeeder {
@@ -23,95 +21,200 @@ export class NetworkConfigSeeder {
     await queryRunner.query(`
       CREATE TABLE IF NOT EXISTS network_configs (
         id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-        name VARCHAR(100) NOT NULL,
         network VARCHAR(50) NOT NULL UNIQUE,
         rpc_url TEXT NOT NULL,
         chain_id INTEGER NOT NULL,
-        native_currency JSONB NOT NULL,
-        block_explorer TEXT NOT NULL,
         is_active BOOLEAN DEFAULT true,
+        block_time INTEGER NULL,
+        status VARCHAR(30) DEFAULT 'active',
+        usdc_contract_address VARCHAR(255) NULL,
+        settlement_contract_address VARCHAR(255) NULL,
+        required_confirmations INTEGER DEFAULT 12,
+        current_gas_price DECIMAL(20, 8) NULL,
+        max_gas_price DECIMAL(20, 8) NULL,
+        last_block_number INTEGER NULL,
+        last_health_check TIMESTAMP NULL,
+        is_healthy BOOLEAN DEFAULT true,
+        fallback_rpc_urls TEXT NULL,
+        last_scanned_block INTEGER NULL,
+        base_fee_per_gas DECIMAL(20, 8) NULL,
+        priority_fee_per_gas DECIMAL(20, 8) NULL,
+        network_settings JSONB NULL,
+        supports_eip1559 BOOLEAN DEFAULT false,
+        supports_flashbots BOOLEAN DEFAULT false,
+        supports_erc20 BOOLEAN DEFAULT true,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        CONSTRAINT chk_network_config_status
+          CHECK (status IN ('active', 'maintenance', 'deprecated'))
       )
     `);
 
     const networks = [
       {
-        name: 'Ethereum Mainnet',
         network: 'ethereum',
         rpc_url: 'https://eth.llamarpc.com',
         chain_id: 1,
-        native_currency: JSON.stringify({
-          name: 'Ether',
-          symbol: 'ETH',
-          decimals: 18,
+        network_settings: JSON.stringify({
+          name: 'Ethereum Mainnet',
+          blockExplorer: 'https://etherscan.io',
+          nativeCurrency: {
+            name: 'Ether',
+            symbol: 'ETH',
+            decimals: 18,
+          },
         }),
-        block_explorer: 'https://etherscan.io',
+        fallback_rpc_urls:
+          'https://rpc.ankr.com/eth,https://ethereum.publicnode.com',
+        required_confirmations: 12,
+        supports_eip1559: true,
+        supports_flashbots: true,
+        supports_erc20: true,
         is_active: true,
       },
       {
-        name: 'Polygon Mainnet',
         network: 'polygon',
         rpc_url: 'https://polygon-rpc.com',
         chain_id: 137,
-        native_currency: JSON.stringify({
-          name: 'MATIC',
-          symbol: 'MATIC',
-          decimals: 18,
+        network_settings: JSON.stringify({
+          name: 'Polygon Mainnet',
+          blockExplorer: 'https://polygonscan.com',
+          nativeCurrency: {
+            name: 'MATIC',
+            symbol: 'MATIC',
+            decimals: 18,
+          },
         }),
-        block_explorer: 'https://polygonscan.com',
+        fallback_rpc_urls:
+          'https://rpc-mainnet.maticvigil.com,https://polygon-bor-rpc.publicnode.com',
+        required_confirmations: 64,
+        supports_eip1559: true,
+        supports_flashbots: false,
+        supports_erc20: true,
         is_active: true,
       },
       {
-        name: 'Stellar Testnet',
         network: 'stellar-testnet',
         rpc_url: 'https://horizon-testnet.stellar.org',
         chain_id: 0,
-        native_currency: JSON.stringify({
-          name: 'Stellar Lumens',
-          symbol: 'XLM',
-          decimals: 7,
+        network_settings: JSON.stringify({
+          name: 'Stellar Testnet',
+          blockExplorer: 'https://stellar.expert/explorer/testnet',
+          nativeCurrency: {
+            name: 'Stellar Lumens',
+            symbol: 'XLM',
+            decimals: 7,
+          },
         }),
-        block_explorer: 'https://stellar.expert/explorer/testnet',
+        fallback_rpc_urls: 'https://horizon-testnet.stellar.lobstr.co',
+        required_confirmations: 1,
+        supports_eip1559: false,
+        supports_flashbots: false,
+        supports_erc20: false,
         is_active: true,
       },
       {
-        name: 'Stellar Mainnet',
         network: 'stellar-mainnet',
         rpc_url: 'https://horizon.stellar.org',
         chain_id: 0,
-        native_currency: JSON.stringify({
-          name: 'Stellar Lumens',
-          symbol: 'XLM',
-          decimals: 7,
+        network_settings: JSON.stringify({
+          name: 'Stellar Mainnet',
+          blockExplorer: 'https://stellar.expert/explorer/public',
+          nativeCurrency: {
+            name: 'Stellar Lumens',
+            symbol: 'XLM',
+            decimals: 7,
+          },
         }),
-        block_explorer: 'https://stellar.expert/explorer/public',
+        fallback_rpc_urls: 'https://horizon.stellar.lobstr.co',
+        required_confirmations: 1,
+        supports_eip1559: false,
+        supports_flashbots: false,
+        supports_erc20: false,
         is_active: true,
       },
       {
-        name: 'Base Mainnet',
         network: 'base',
         rpc_url: 'https://mainnet.base.org',
         chain_id: 8453,
-        native_currency: JSON.stringify({
-          name: 'Ether',
-          symbol: 'ETH',
-          decimals: 18,
+        network_settings: JSON.stringify({
+          name: 'Base Mainnet',
+          blockExplorer: 'https://basescan.org',
+          nativeCurrency: {
+            name: 'Ether',
+            symbol: 'ETH',
+            decimals: 18,
+          },
         }),
-        block_explorer: 'https://basescan.org',
+        fallback_rpc_urls:
+          'https://base-rpc.publicnode.com,https://1rpc.io/base',
+        required_confirmations: 12,
+        supports_eip1559: true,
+        supports_flashbots: true,
+        supports_erc20: true,
         is_active: true,
       },
       {
-        name: 'Arbitrum One',
         network: 'arbitrum',
         rpc_url: 'https://arb1.arbitrum.io/rpc',
         chain_id: 42161,
-        native_currency: JSON.stringify({
-          name: 'Ether',
-          symbol: 'ETH',
-          decimals: 18,
+        network_settings: JSON.stringify({
+          name: 'Arbitrum One',
+          blockExplorer: 'https://arbiscan.io',
+          nativeCurrency: {
+            name: 'Ether',
+            symbol: 'ETH',
+            decimals: 18,
+          },
         }),
-        block_explorer: 'https://arbiscan.io',
+        fallback_rpc_urls:
+          'https://rpc.ankr.com/arbitrum,https://arbitrum-one-rpc.publicnode.com',
+        required_confirmations: 20,
+        supports_eip1559: true,
+        supports_flashbots: true,
+        supports_erc20: true,
+        is_active: true,
+      },
+      {
+        network: 'optimism',
+        rpc_url: 'https://mainnet.optimism.io',
+        chain_id: 10,
+        network_settings: JSON.stringify({
+          name: 'Optimism',
+          blockExplorer: 'https://optimistic.etherscan.io',
+          nativeCurrency: {
+            name: 'Ether',
+            symbol: 'ETH',
+            decimals: 18,
+          },
+        }),
+        fallback_rpc_urls:
+          'https://optimism.publicnode.com,https://rpc.ankr.com/optimism',
+        required_confirmations: 12,
+        supports_eip1559: true,
+        supports_flashbots: false,
+        supports_erc20: true,
+        is_active: true,
+      },
+      {
+        network: 'bsc',
+        rpc_url: 'https://bsc-dataseed.binance.org',
+        chain_id: 56,
+        network_settings: JSON.stringify({
+          name: 'BNB Smart Chain',
+          blockExplorer: 'https://bscscan.com',
+          nativeCurrency: {
+            name: 'BNB',
+            symbol: 'BNB',
+            decimals: 18,
+          },
+        }),
+        fallback_rpc_urls:
+          'https://rpc.ankr.com/bsc,https://bsc.publicnode.com',
+        required_confirmations: 15,
+        supports_eip1559: false,
+        supports_flashbots: false,
+        supports_erc20: true,
         is_active: true,
       },
     ];
@@ -124,21 +227,34 @@ export class NetworkConfigSeeder {
 
       if (exists.length === 0) {
         await queryRunner.query(
-          `INSERT INTO network_configs (name, network, rpc_url, chain_id, native_currency, block_explorer, is_active)
-           VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+          `INSERT INTO network_configs (
+            network,
+            rpc_url,
+            chain_id,
+            is_active,
+            required_confirmations,
+            fallback_rpc_urls,
+            network_settings,
+            supports_eip1559,
+            supports_flashbots,
+            supports_erc20
+          ) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10)`,
           [
-            network.name,
             network.network,
             network.rpc_url,
             network.chain_id,
-            network.native_currency,
-            network.block_explorer,
             network.is_active,
+            network.required_confirmations,
+            network.fallback_rpc_urls ?? null,
+            network.network_settings ?? JSON.stringify({}),
+            network.supports_eip1559 ?? false,
+            network.supports_flashbots ?? false,
+            network.supports_erc20 ?? true,
           ],
         );
-        console.log(`✓ Created network config: ${network.name}`);
+        console.log(`✓ Created network config: ${network.network}`);
       } else {
-        console.log(`- Network config already exists: ${network.name}`);
+        console.log(`- Network config already exists: ${network.network}`);
       }
     }
   }


### PR DESCRIPTION
… (#19)

Closes #19

Title: feat: add NetworkConfiguration entity for blockchain network management (#19)
Description:
Summary
Creates the NetworkConfiguration entity to manage blockchain network settings and operational status across all 8 supported networks.
Changes

Entity: NetworkConfiguration with fields: id, network, rpcUrl, chainId, isActive, blockTime
Status Enum: NetworkStatus with active, maintenance, and deprecated states
Contract Addresses: USDC and settlement contract address fields
Confirmation Requirements: Per-network configurable confirmation thresholds
Gas Tracking: currentGasPrice, maxGasPrice, baseFeePerGas, priorityFeePerGas
Health Metrics: isHealthy, lastHealthCheck, lastBlockNumber
Fallback RPCs: fallbackRpcUrls array for RPC failover support
Block Scanning: lastScannedBlock cursor for resume-after-restart support
Network Settings: networkSettings JSONB field for network-specific config
Capability Flags: supportsEIP1559, supportsFlashbots, supportsERC20
Migration: Creates network_configs table with indexes on network and isActive

Acceptance Criteria

 All 8 networks can be configured via the entity
 RPC failover supported via fallbackRpcUrls
 Network health trackable via health metric fields
 Block scanning cursor persists across restarts via lastScannedBlock

Testing
bashnpx typeorm migration:run
Verify the network_configs table is created with all columns and indexes.
