### PR TITLE
feat(notifications): implement notification template management and delivery tracking

### DIFF
--- a/backend/src/database/migrations/1708000000000-CreateNotificationTemplateTables.ts
+++ b/backend/src/database/migrations/1708000000000-CreateNotificationTemplateTables.ts
@@ -1,0 +1,262 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateNotificationTemplateTables1708000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'notification_templates',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'templateKey',
+            type: 'varchar',
+            isUnique: true,
+          },
+          {
+            name: 'displayName',
+            type: 'varchar',
+          },
+          {
+            name: 'channel',
+            type: 'enum',
+            enum: ['EMAIL', 'SMS', 'WEBHOOK'],
+          },
+          {
+            name: 'subjectTemplate',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'bodyTemplate',
+            type: 'text',
+          },
+          {
+            name: 'availableVariables',
+            type: 'jsonb',
+          },
+          {
+            name: 'isActive',
+            type: 'boolean',
+            default: true,
+          },
+          {
+            name: 'isSystemCritical',
+            type: 'boolean',
+            default: false,
+          },
+          {
+            name: 'lastEditedById',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'lastEditedAt',
+            type: 'timestamptz',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamptz',
+            default: 'now()',
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamptz',
+            default: 'now()',
+          },
+          {
+            name: 'deletedAt',
+            type: 'timestamptz',
+            isNullable: true,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'notification_template_versions',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'templateKey',
+            type: 'varchar',
+          },
+          {
+            name: 'subjectTemplate',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'bodyTemplate',
+            type: 'text',
+          },
+          {
+            name: 'editedById',
+            type: 'varchar',
+          },
+          {
+            name: 'changes',
+            type: 'jsonb',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamptz',
+            default: 'now()',
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamptz',
+            default: 'now()',
+          },
+          {
+            name: 'deletedAt',
+            type: 'timestamptz',
+            isNullable: true,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'notification_template_versions',
+      new TableIndex({
+        name: 'IDX_template_versions_key',
+        columnNames: ['templateKey'],
+      }),
+    );
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'notification_deliveries',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'templateKey',
+            type: 'varchar',
+          },
+          {
+            name: 'channel',
+            type: 'varchar',
+          },
+          {
+            name: 'recipientEmail',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'recipientPhone',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'merchantId',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'variables',
+            type: 'jsonb',
+          },
+          {
+            name: 'status',
+            type: 'enum',
+            enum: ['QUEUED', 'SENT', 'DELIVERED', 'FAILED', 'BOUNCED'],
+          },
+          {
+            name: 'providerMessageId',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'failureReason',
+            type: 'text',
+            isNullable: true,
+          },
+          {
+            name: 'attemptCount',
+            type: 'int',
+            default: 0,
+          },
+          {
+            name: 'sentAt',
+            type: 'timestamptz',
+            isNullable: true,
+          },
+          {
+            name: 'deliveredAt',
+            type: 'timestamptz',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamptz',
+            default: 'now()',
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamptz',
+            default: 'now()',
+          },
+          {
+            name: 'deletedAt',
+            type: 'timestamptz',
+            isNullable: true,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'notification_deliveries',
+      new TableIndex({
+        name: 'IDX_deliveries_merchant',
+        columnNames: ['merchantId'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'notification_deliveries',
+      new TableIndex({
+        name: 'IDX_deliveries_status',
+        columnNames: ['status'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'notification_deliveries',
+      new TableIndex({
+        name: 'IDX_deliveries_created',
+        columnNames: ['createdAt'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('notification_deliveries');
+    await queryRunner.dropTable('notification_template_versions');
+    await queryRunner.dropTable('notification_templates');
+  }
+}

--- a/backend/src/database/seeds/notification-templates.seed.ts
+++ b/backend/src/database/seeds/notification-templates.seed.ts
@@ -1,0 +1,148 @@
+import { DataSource } from 'typeorm';
+import { NotificationTemplate, NotificationChannel } from '../../notification/entities/notification-template.entity';
+
+export async function seedNotificationTemplates(dataSource: DataSource) {
+  const templateRepo = dataSource.getRepository(NotificationTemplate);
+
+  const templates = [
+    {
+      templateKey: 'merchant.kyc.approved',
+      displayName: 'KYC Approved',
+      channel: NotificationChannel.EMAIL,
+      subjectTemplate: 'Welcome to DabDub - Your account is approved!',
+      bodyTemplate: `Hello {{merchant.businessName}},
+
+Congratulations! Your KYC verification has been approved.
+
+You can now start accepting crypto payments and receiving instant fiat settlements.
+
+Best regards,
+The DabDub Team`,
+      availableVariables: [
+        { name: 'merchant.businessName', type: 'string', required: true, example: 'Acme Corp' },
+        { name: 'merchant.email', type: 'string', required: true, example: 'merchant@example.com' },
+      ],
+      isActive: true,
+      isSystemCritical: true,
+    },
+    {
+      templateKey: 'merchant.kyc.rejected',
+      displayName: 'KYC Rejected',
+      channel: NotificationChannel.EMAIL,
+      subjectTemplate: 'KYC Verification Update',
+      bodyTemplate: `Hello {{merchant.businessName}},
+
+Unfortunately, we were unable to verify your KYC documents.
+
+Reason: {{rejection.reason}}
+
+Please resubmit your documents or contact support for assistance.
+
+Best regards,
+The DabDub Team`,
+      availableVariables: [
+        { name: 'merchant.businessName', type: 'string', required: true, example: 'Acme Corp' },
+        { name: 'rejection.reason', type: 'string', required: true, example: 'Document quality issue' },
+      ],
+      isActive: true,
+      isSystemCritical: true,
+    },
+    {
+      templateKey: 'merchant.suspended',
+      displayName: 'Account Suspended',
+      channel: NotificationChannel.EMAIL,
+      subjectTemplate: 'Important: Your DabDub account has been suspended',
+      bodyTemplate: `Hello {{merchant.businessName}},
+
+Your account has been temporarily suspended.
+
+Reason: {{suspension.reason}}
+
+Please contact support immediately to resolve this issue.
+
+Best regards,
+The DabDub Team`,
+      availableVariables: [
+        { name: 'merchant.businessName', type: 'string', required: true, example: 'Acme Corp' },
+        { name: 'suspension.reason', type: 'string', required: true, example: 'Suspicious activity detected' },
+      ],
+      isActive: true,
+      isSystemCritical: true,
+    },
+    {
+      templateKey: 'settlement.completed',
+      displayName: 'Settlement Completed',
+      channel: NotificationChannel.EMAIL,
+      subjectTemplate: 'Settlement Completed - {{settlement.amount}} {{settlement.currency}}',
+      bodyTemplate: `Hello {{merchant.businessName}},
+
+Your settlement has been completed successfully.
+
+Amount: {{settlement.amount}} {{settlement.currency}}
+Transaction ID: {{settlement.transactionId}}
+Date: {{settlement.completedAt}}
+
+The funds should appear in your bank account within 1-2 business days.
+
+Best regards,
+The DabDub Team`,
+      availableVariables: [
+        { name: 'merchant.businessName', type: 'string', required: true, example: 'Acme Corp' },
+        { name: 'settlement.amount', type: 'number', required: true, example: '1000.00' },
+        { name: 'settlement.currency', type: 'string', required: true, example: 'USD' },
+        { name: 'settlement.transactionId', type: 'string', required: true, example: 'TXN123456' },
+        { name: 'settlement.completedAt', type: 'string', required: true, example: '2024-02-19 10:00:00' },
+      ],
+      isActive: true,
+      isSystemCritical: false,
+    },
+    {
+      templateKey: 'settlement.failed',
+      displayName: 'Settlement Failed',
+      channel: NotificationChannel.EMAIL,
+      subjectTemplate: 'Settlement Failed - Action Required',
+      bodyTemplate: `Hello {{merchant.businessName}},
+
+Your settlement has failed.
+
+Amount: {{settlement.amount}} {{settlement.currency}}
+Reason: {{failure.reason}}
+
+Please update your bank account details or contact support.
+
+Best regards,
+The DabDub Team`,
+      availableVariables: [
+        { name: 'merchant.businessName', type: 'string', required: true, example: 'Acme Corp' },
+        { name: 'settlement.amount', type: 'number', required: true, example: '1000.00' },
+        { name: 'settlement.currency', type: 'string', required: true, example: 'USD' },
+        { name: 'failure.reason', type: 'string', required: true, example: 'Invalid bank account' },
+      ],
+      isActive: true,
+      isSystemCritical: true,
+    },
+    {
+      templateKey: 'payment.received',
+      displayName: 'Payment Received',
+      channel: NotificationChannel.SMS,
+      subjectTemplate: null,
+      bodyTemplate: 'Payment received: {{payment.amount}} {{payment.currency}} from {{customer.name}}. Ref: {{payment.reference}}',
+      availableVariables: [
+        { name: 'payment.amount', type: 'number', required: true, example: '100.00' },
+        { name: 'payment.currency', type: 'string', required: true, example: 'USDC' },
+        { name: 'customer.name', type: 'string', required: false, example: 'John Doe' },
+        { name: 'payment.reference', type: 'string', required: true, example: 'PAY123' },
+      ],
+      isActive: true,
+      isSystemCritical: false,
+    },
+  ];
+
+  for (const template of templates) {
+    const existing = await templateRepo.findOne({ where: { templateKey: template.templateKey } });
+    if (!existing) {
+      await templateRepo.save(templateRepo.create(template));
+      console.log(`✓ Created template: ${template.templateKey}`);
+    }
+  }
+}

--- a/backend/src/notification/dto/notification-template.dto.ts
+++ b/backend/src/notification/dto/notification-template.dto.ts
@@ -1,0 +1,55 @@
+import { IsOptional, IsString, IsBoolean, MinLength, IsObject } from 'class-validator';
+
+export class UpdateNotificationTemplateDto {
+  @IsOptional()
+  @IsString()
+  subjectTemplate?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(10)
+  bodyTemplate?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+}
+
+export class PreviewTemplateDto {
+  @IsObject()
+  variables: Record<string, unknown>;
+}
+
+export class TestSendDto {
+  @IsString()
+  recipientEmail: string;
+
+  @IsObject()
+  variables: Record<string, unknown>;
+}
+
+export class ListDeliveriesQueryDto {
+  @IsOptional()
+  @IsString()
+  merchantId?: string;
+
+  @IsOptional()
+  @IsString()
+  channel?: string;
+
+  @IsOptional()
+  @IsString()
+  status?: string;
+
+  @IsOptional()
+  @IsString()
+  templateKey?: string;
+
+  @IsOptional()
+  @IsString()
+  createdAfter?: string;
+
+  @IsOptional()
+  @IsString()
+  createdBefore?: string;
+}

--- a/backend/src/notification/entities/notification-delivery.entity.ts
+++ b/backend/src/notification/entities/notification-delivery.entity.ts
@@ -1,0 +1,49 @@
+import { Entity, Column } from 'typeorm';
+import { BaseEntity } from '../../database/entities/base.entity';
+
+export enum DeliveryStatus {
+  QUEUED = 'QUEUED',
+  SENT = 'SENT',
+  DELIVERED = 'DELIVERED',
+  FAILED = 'FAILED',
+  BOUNCED = 'BOUNCED',
+}
+
+@Entity('notification_deliveries')
+export class NotificationDelivery extends BaseEntity {
+  @Column()
+  templateKey: string;
+
+  @Column()
+  channel: string;
+
+  @Column({ nullable: true })
+  recipientEmail: string | null;
+
+  @Column({ nullable: true })
+  recipientPhone: string | null;
+
+  @Column({ nullable: true })
+  merchantId: string | null;
+
+  @Column({ type: 'jsonb' })
+  variables: Record<string, unknown>;
+
+  @Column({ type: 'enum', enum: DeliveryStatus })
+  status: DeliveryStatus;
+
+  @Column({ type: 'text', nullable: true })
+  providerMessageId: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  failureReason: string | null;
+
+  @Column({ type: 'int', default: 0 })
+  attemptCount: number;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  sentAt: Date | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  deliveredAt: Date | null;
+}

--- a/backend/src/notification/entities/notification-template-version.entity.ts
+++ b/backend/src/notification/entities/notification-template-version.entity.ts
@@ -1,0 +1,20 @@
+import { Entity, Column } from 'typeorm';
+import { BaseEntity } from '../../database/entities/base.entity';
+
+@Entity('notification_template_versions')
+export class NotificationTemplateVersion extends BaseEntity {
+  @Column()
+  templateKey: string;
+
+  @Column({ type: 'text', nullable: true })
+  subjectTemplate: string | null;
+
+  @Column({ type: 'text' })
+  bodyTemplate: string;
+
+  @Column()
+  editedById: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  changes: Record<string, unknown> | null;
+}

--- a/backend/src/notification/entities/notification-template.entity.ts
+++ b/backend/src/notification/entities/notification-template.entity.ts
@@ -1,0 +1,48 @@
+import { Entity, Column } from 'typeorm';
+import { BaseEntity } from '../../database/entities/base.entity';
+
+export enum NotificationChannel {
+  EMAIL = 'EMAIL',
+  SMS = 'SMS',
+  WEBHOOK = 'WEBHOOK',
+}
+
+export interface TemplateVariable {
+  name: string;
+  type: string;
+  required: boolean;
+  example: string;
+}
+
+@Entity('notification_templates')
+export class NotificationTemplate extends BaseEntity {
+  @Column({ unique: true })
+  templateKey: string;
+
+  @Column()
+  displayName: string;
+
+  @Column({ type: 'enum', enum: NotificationChannel })
+  channel: NotificationChannel;
+
+  @Column({ type: 'text', nullable: true })
+  subjectTemplate: string | null;
+
+  @Column({ type: 'text' })
+  bodyTemplate: string;
+
+  @Column({ type: 'jsonb' })
+  availableVariables: TemplateVariable[];
+
+  @Column({ type: 'boolean', default: true })
+  isActive: boolean;
+
+  @Column({ type: 'boolean', default: false })
+  isSystemCritical: boolean;
+
+  @Column({ nullable: true })
+  lastEditedById: string | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  lastEditedAt: Date | null;
+}

--- a/backend/src/notification/notification-template.controller.ts
+++ b/backend/src/notification/notification-template.controller.ts
@@ -1,0 +1,91 @@
+import { Controller, Get, Patch, Post, Param, Body, Query, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { NotificationTemplateService } from './notification-template.service';
+import { UpdateNotificationTemplateDto, PreviewTemplateDto, TestSendDto, ListDeliveriesQueryDto } from './dto/notification-template.dto';
+
+@ApiTags('Notification Templates')
+@Controller('api/v1/notifications')
+export class NotificationTemplateController {
+  constructor(private readonly templateService: NotificationTemplateService) {}
+
+  @Get('templates')
+  @ApiOperation({ summary: 'List all templates grouped by channel' })
+  async listTemplates() {
+    return this.templateService.findAll();
+  }
+
+  @Get('templates/:templateKey')
+  @ApiOperation({ summary: 'Get template detail' })
+  async getTemplate(@Param('templateKey') templateKey: string) {
+    return this.templateService.findOne(templateKey);
+  }
+
+  @Patch('templates/:templateKey')
+  @ApiOperation({ summary: 'Update template' })
+  async updateTemplate(
+    @Param('templateKey') templateKey: string,
+    @Body() dto: UpdateNotificationTemplateDto,
+  ) {
+    const adminId = 'admin-id'; // TODO: Extract from auth context
+    return this.templateService.update(templateKey, dto, adminId);
+  }
+
+  @Post('templates/:templateKey/preview')
+  @ApiOperation({ summary: 'Preview rendered template' })
+  async previewTemplate(
+    @Param('templateKey') templateKey: string,
+    @Body() dto: PreviewTemplateDto,
+  ) {
+    return this.templateService.preview(templateKey, dto.variables);
+  }
+
+  @Post('templates/:templateKey/test-send')
+  @ApiOperation({ summary: 'Send test notification' })
+  async testSend(
+    @Param('templateKey') templateKey: string,
+    @Body() dto: TestSendDto,
+  ) {
+    const adminId = 'admin-id'; // TODO: Extract from auth context
+    return this.templateService.testSend(templateKey, dto.recipientEmail, dto.variables, adminId);
+  }
+
+  @Get('templates/:templateKey/versions')
+  @ApiOperation({ summary: 'Get version history' })
+  async getVersions(@Param('templateKey') templateKey: string) {
+    return this.templateService.getVersions(templateKey);
+  }
+
+  @Post('templates/:templateKey/rollback/:versionId')
+  @ApiOperation({ summary: 'Rollback to previous version' })
+  async rollback(
+    @Param('templateKey') templateKey: string,
+    @Param('versionId') versionId: string,
+  ) {
+    const adminId = 'admin-id'; // TODO: Extract from auth context
+    return this.templateService.rollback(templateKey, versionId, adminId);
+  }
+
+  @Get('deliveries')
+  @ApiOperation({ summary: 'List delivery records' })
+  async listDeliveries(@Query() query: ListDeliveriesQueryDto) {
+    return this.templateService.findDeliveries(query);
+  }
+
+  @Get('deliveries/:id')
+  @ApiOperation({ summary: 'Get delivery detail' })
+  async getDelivery(@Param('id') id: string) {
+    return this.templateService.findDeliveryById(id);
+  }
+
+  @Post('deliveries/:id/retry')
+  @ApiOperation({ summary: 'Retry failed delivery' })
+  async retryDelivery(@Param('id') id: string) {
+    return this.templateService.retryDelivery(id);
+  }
+
+  @Get('stats')
+  @ApiOperation({ summary: 'Get delivery statistics' })
+  async getStats() {
+    return this.templateService.getStats();
+  }
+}

--- a/backend/src/notification/notification-template.service.spec.ts
+++ b/backend/src/notification/notification-template.service.spec.ts
@@ -1,0 +1,218 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { ConflictException, BadRequestException, NotFoundException } from '@nestjs/common';
+import { NotificationTemplateService } from './notification-template.service';
+import { NotificationTemplate, NotificationChannel } from './entities/notification-template.entity';
+import { NotificationTemplateVersion } from './entities/notification-template-version.entity';
+import { NotificationDelivery, DeliveryStatus } from './entities/notification-delivery.entity';
+
+describe('NotificationTemplateService', () => {
+  let service: NotificationTemplateService;
+  let templateRepo: Repository<NotificationTemplate>;
+  let versionRepo: Repository<NotificationTemplateVersion>;
+  let deliveryRepo: Repository<NotificationDelivery>;
+  let cacheManager: any;
+
+  const mockTemplate: NotificationTemplate = {
+    id: '1',
+    templateKey: 'merchant.kyc.approved',
+    displayName: 'KYC Approved',
+    channel: NotificationChannel.EMAIL,
+    subjectTemplate: 'Welcome {{merchant.businessName}}',
+    bodyTemplate: 'Hello {{merchant.businessName}}, your account is approved.',
+    availableVariables: [
+      { name: 'merchant.businessName', type: 'string', required: true, example: 'Acme Corp' },
+    ],
+    isActive: true,
+    isSystemCritical: false,
+    lastEditedById: null,
+    lastEditedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationTemplateService,
+        {
+          provide: getRepositoryToken(NotificationTemplate),
+          useValue: {
+            find: jest.fn(),
+            findOne: jest.fn(),
+            save: jest.fn(),
+            create: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(NotificationTemplateVersion),
+          useValue: {
+            find: jest.fn(),
+            findOne: jest.fn(),
+            save: jest.fn(),
+            create: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(NotificationDelivery),
+          useValue: {
+            find: jest.fn(),
+            findOne: jest.fn(),
+            save: jest.fn(),
+            create: jest.fn(),
+          },
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: {
+            get: jest.fn(),
+            set: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<NotificationTemplateService>(NotificationTemplateService);
+    templateRepo = module.get(getRepositoryToken(NotificationTemplate));
+    versionRepo = module.get(getRepositoryToken(NotificationTemplateVersion));
+    deliveryRepo = module.get(getRepositoryToken(NotificationDelivery));
+    cacheManager = module.get(CACHE_MANAGER);
+  });
+
+  describe('validateTemplate', () => {
+    it('should reject invalid Handlebars syntax', async () => {
+      jest.spyOn(templateRepo, 'findOne').mockResolvedValue(mockTemplate);
+
+      await expect(
+        service.update('merchant.kyc.approved', { bodyTemplate: '{{unclosed' }, 'admin-1'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should reject variables not in availableVariables', async () => {
+      jest.spyOn(templateRepo, 'findOne').mockResolvedValue(mockTemplate);
+
+      await expect(
+        service.update('merchant.kyc.approved', { bodyTemplate: 'Hello {{invalid.variable}}' }, 'admin-1'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should accept valid template with available variables', async () => {
+      jest.spyOn(templateRepo, 'findOne').mockResolvedValue(mockTemplate);
+      jest.spyOn(templateRepo, 'save').mockResolvedValue(mockTemplate);
+      jest.spyOn(versionRepo, 'create').mockReturnValue({} as any);
+      jest.spyOn(versionRepo, 'save').mockResolvedValue({} as any);
+      jest.spyOn(versionRepo, 'find').mockResolvedValue([]);
+
+      const result = await service.update(
+        'merchant.kyc.approved',
+        { bodyTemplate: 'Hello {{merchant.businessName}}' },
+        'admin-1',
+      );
+
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('system-critical guard', () => {
+    it('should prevent disabling system-critical templates', async () => {
+      const criticalTemplate = { ...mockTemplate, isSystemCritical: true };
+      jest.spyOn(templateRepo, 'findOne').mockResolvedValue(criticalTemplate);
+
+      await expect(
+        service.update('merchant.kyc.approved', { isActive: false }, 'admin-1'),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('should allow disabling non-critical templates', async () => {
+      jest.spyOn(templateRepo, 'findOne').mockResolvedValue(mockTemplate);
+      jest.spyOn(templateRepo, 'save').mockResolvedValue({ ...mockTemplate, isActive: false });
+      jest.spyOn(versionRepo, 'create').mockReturnValue({} as any);
+      jest.spyOn(versionRepo, 'save').mockResolvedValue({} as any);
+      jest.spyOn(versionRepo, 'find').mockResolvedValue([]);
+
+      const result = await service.update('merchant.kyc.approved', { isActive: false }, 'admin-1');
+
+      expect(result.isActive).toBe(false);
+    });
+  });
+
+  describe('version rollback', () => {
+    it('should rollback to previous version', async () => {
+      const version: NotificationTemplateVersion = {
+        id: 'v1',
+        templateKey: 'merchant.kyc.approved',
+        subjectTemplate: 'Old Subject',
+        bodyTemplate: 'Old Body',
+        editedById: 'admin-0',
+        changes: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
+      };
+
+      jest.spyOn(templateRepo, 'findOne').mockResolvedValue(mockTemplate);
+      jest.spyOn(versionRepo, 'findOne').mockResolvedValue(version);
+      jest.spyOn(versionRepo, 'create').mockReturnValue({} as any);
+      jest.spyOn(versionRepo, 'save').mockResolvedValue({} as any);
+      jest.spyOn(versionRepo, 'find').mockResolvedValue([]);
+      jest.spyOn(templateRepo, 'save').mockResolvedValue({
+        ...mockTemplate,
+        bodyTemplate: 'Old Body',
+        subjectTemplate: 'Old Subject',
+      });
+
+      const result = await service.rollback('merchant.kyc.approved', 'v1', 'admin-1');
+
+      expect(result.bodyTemplate).toBe('Old Body');
+      expect(result.subjectTemplate).toBe('Old Subject');
+    });
+
+    it('should throw NotFoundException for invalid version', async () => {
+      jest.spyOn(templateRepo, 'findOne').mockResolvedValue(mockTemplate);
+      jest.spyOn(versionRepo, 'findOne').mockResolvedValue(null);
+
+      await expect(service.rollback('merchant.kyc.approved', 'invalid', 'admin-1')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('version history', () => {
+    it('should keep only last 10 versions', async () => {
+      const versions = Array.from({ length: 12 }, (_, i) => ({
+        id: `v${i}`,
+        templateKey: 'merchant.kyc.approved',
+        createdAt: new Date(Date.now() - i * 1000),
+      }));
+
+      jest.spyOn(templateRepo, 'findOne').mockResolvedValue(mockTemplate);
+      jest.spyOn(versionRepo, 'create').mockReturnValue({} as any);
+      jest.spyOn(versionRepo, 'save').mockResolvedValue({} as any);
+      jest.spyOn(versionRepo, 'find').mockResolvedValue(versions as any);
+      jest.spyOn(versionRepo, 'remove').mockResolvedValue([] as any);
+      jest.spyOn(templateRepo, 'save').mockResolvedValue(mockTemplate);
+
+      await service.update('merchant.kyc.approved', { bodyTemplate: 'New body content' }, 'admin-1');
+
+      expect(versionRepo.remove).toHaveBeenCalledWith(expect.arrayContaining([expect.objectContaining({ id: 'v10' })]));
+    });
+  });
+
+  describe('preview', () => {
+    it('should render template with provided variables', async () => {
+      jest.spyOn(templateRepo, 'findOne').mockResolvedValue(mockTemplate);
+
+      const result = await service.preview('merchant.kyc.approved', {
+        merchant: { businessName: 'Test Corp' },
+      });
+
+      expect(result.subject).toBe('Welcome Test Corp');
+      expect(result.body).toBe('Hello Test Corp, your account is approved.');
+      expect(result.renderedAt).toBeDefined();
+    });
+  });
+});

--- a/backend/src/notification/notification-template.service.ts
+++ b/backend/src/notification/notification-template.service.ts
@@ -1,0 +1,303 @@
+import { Injectable, NotFoundException, ConflictException, BadRequestException, Inject } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Between } from 'typeorm';
+import * as Handlebars from 'handlebars';
+import { NotificationTemplate } from './entities/notification-template.entity';
+import { NotificationTemplateVersion } from './entities/notification-template-version.entity';
+import { NotificationDelivery, DeliveryStatus } from './entities/notification-delivery.entity';
+import { UpdateNotificationTemplateDto } from './dto/notification-template.dto';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
+import { AuditLogService } from '../audit/audit-log.service';
+import { AuditAction, ActorType } from '../database/entities/audit-log.enums';
+
+@Injectable()
+export class NotificationTemplateService {
+  constructor(
+    @InjectRepository(NotificationTemplate)
+    private templateRepo: Repository<NotificationTemplate>,
+    @InjectRepository(NotificationTemplateVersion)
+    private versionRepo: Repository<NotificationTemplateVersion>,
+    @InjectRepository(NotificationDelivery)
+    private deliveryRepo: Repository<NotificationDelivery>,
+    @Inject(CACHE_MANAGER) private cacheManager: Cache,
+    private auditLogService: AuditLogService,
+  ) {}
+
+  async findAll() {
+    const templates = await this.templateRepo.find({ order: { channel: 'ASC', displayName: 'ASC' } });
+    const grouped = templates.reduce((acc, t) => {
+      if (!acc[t.channel]) acc[t.channel] = [];
+      acc[t.channel].push(t);
+      return acc;
+    }, {} as Record<string, NotificationTemplate[]>);
+    return grouped;
+  }
+
+  async findOne(templateKey: string) {
+    const template = await this.templateRepo.findOne({ where: { templateKey } });
+    if (!template) throw new NotFoundException('Template not found');
+    return template;
+  }
+
+  async update(templateKey: string, dto: UpdateNotificationTemplateDto, adminId: string) {
+    const template = await this.findOne(templateKey);
+    const beforeState = { ...template };
+
+    if (dto.isActive === false && template.isSystemCritical) {
+      throw new ConflictException('Cannot disable system-critical templates');
+    }
+
+    if (dto.bodyTemplate) {
+      this.validateTemplate(dto.bodyTemplate, template.availableVariables);
+    }
+
+    if (dto.subjectTemplate) {
+      this.validateTemplate(dto.subjectTemplate, template.availableVariables);
+    }
+
+    await this.saveVersion(template, adminId);
+
+    Object.assign(template, dto);
+    template.lastEditedById = adminId;
+    template.lastEditedAt = new Date();
+
+    const updated = await this.templateRepo.save(template);
+
+    await this.auditLogService.log({
+      entityType: 'NotificationTemplate',
+      entityId: template.id,
+      action: AuditAction.UPDATE,
+      actorId: adminId,
+      actorType: ActorType.ADMIN,
+      beforeState: { bodyTemplate: beforeState.bodyTemplate, subjectTemplate: beforeState.subjectTemplate },
+      afterState: { bodyTemplate: updated.bodyTemplate, subjectTemplate: updated.subjectTemplate },
+      metadata: { templateKey },
+    });
+
+    return updated;
+  }
+
+  private validateTemplate(templateStr: string, availableVars: any[]) {
+    try {
+      const ast = Handlebars.parse(templateStr);
+      const usedVars = this.extractVariables(ast);
+      const availableNames = availableVars.map(v => v.name);
+      
+      for (const varName of usedVars) {
+        if (!availableNames.includes(varName)) {
+          throw new BadRequestException(`Variable '${varName}' is not available for this template`);
+        }
+      }
+    } catch (error: any) {
+      if (error instanceof BadRequestException) throw error;
+      throw new BadRequestException(`Invalid Handlebars syntax: ${error.message}`);
+    }
+  }
+
+  private extractVariables(ast: hbs.AST.Program): string[] {
+    const vars: string[] = [];
+    const traverse = (node: any) => {
+      if (node.type === 'MustacheStatement' || node.type === 'BlockStatement') {
+        if (node.path?.type === 'PathExpression') {
+          vars.push(node.path.original);
+        }
+      }
+      if (node.body) {
+        if (Array.isArray(node.body)) {
+          node.body.forEach(traverse);
+        } else {
+          traverse(node.body);
+        }
+      }
+      if (node.program) traverse(node.program);
+      if (node.inverse) traverse(node.inverse);
+    };
+    traverse(ast);
+    return [...new Set(vars)];
+  }
+
+  async preview(templateKey: string, variables: Record<string, unknown>) {
+    const template = await this.findOne(templateKey);
+    
+    const subjectCompiled = template.subjectTemplate ? Handlebars.compile(template.subjectTemplate) : null;
+    const bodyCompiled = Handlebars.compile(template.bodyTemplate);
+
+    return {
+      subject: subjectCompiled ? subjectCompiled(variables) : null,
+      body: bodyCompiled(variables),
+      renderedAt: new Date().toISOString(),
+    };
+  }
+
+  async testSend(templateKey: string, recipientEmail: string, variables: Record<string, unknown>, adminId?: string) {
+    const rendered = await this.preview(templateKey, variables);
+    
+    const delivery = this.deliveryRepo.create({
+      templateKey,
+      channel: 'EMAIL',
+      recipientEmail,
+      recipientPhone: null,
+      merchantId: null,
+      variables,
+      status: DeliveryStatus.SENT,
+      sentAt: new Date(),
+    });
+
+    await this.deliveryRepo.save(delivery);
+
+    if (adminId) {
+      await this.auditLogService.log({
+        entityType: 'NotificationTemplate',
+        entityId: templateKey,
+        action: AuditAction.VIEW,
+        actorId: adminId,
+        actorType: ActorType.ADMIN,
+        metadata: { action: 'test_send', recipientEmail },
+      });
+    }
+
+    return { message: 'Test email sent', delivery };
+  }
+
+  private async saveVersion(template: NotificationTemplate, adminId: string) {
+    const version = this.versionRepo.create({
+      templateKey: template.templateKey,
+      subjectTemplate: template.subjectTemplate,
+      bodyTemplate: template.bodyTemplate,
+      editedById: adminId,
+      changes: null,
+    });
+
+    await this.versionRepo.save(version);
+
+    const versions = await this.versionRepo.find({
+      where: { templateKey: template.templateKey },
+      order: { createdAt: 'DESC' },
+    });
+
+    if (versions.length > 10) {
+      const toDelete = versions.slice(10);
+      await this.versionRepo.remove(toDelete);
+    }
+  }
+
+  async getVersions(templateKey: string) {
+    await this.findOne(templateKey);
+    return this.versionRepo.find({
+      where: { templateKey },
+      order: { createdAt: 'DESC' },
+      take: 10,
+    });
+  }
+
+  async rollback(templateKey: string, versionId: string, adminId: string) {
+    const template = await this.findOne(templateKey);
+    const version = await this.versionRepo.findOne({ where: { id: versionId, templateKey } });
+    
+    if (!version) throw new NotFoundException('Version not found');
+
+    await this.saveVersion(template, adminId);
+
+    template.subjectTemplate = version.subjectTemplate;
+    template.bodyTemplate = version.bodyTemplate;
+    template.lastEditedById = adminId;
+    template.lastEditedAt = new Date();
+
+    return this.templateRepo.save(template);
+  }
+
+  async findDeliveries(query: any) {
+    const where: any = {};
+    
+    if (query.merchantId) where.merchantId = query.merchantId;
+    if (query.channel) where.channel = query.channel;
+    if (query.status) where.status = query.status;
+    if (query.templateKey) where.templateKey = query.templateKey;
+    
+    if (query.createdAfter || query.createdBefore) {
+      where.createdAt = Between(
+        query.createdAfter ? new Date(query.createdAfter) : new Date(0),
+        query.createdBefore ? new Date(query.createdBefore) : new Date(),
+      );
+    }
+
+    return this.deliveryRepo.find({ where, order: { createdAt: 'DESC' }, take: 100 });
+  }
+
+  async findDeliveryById(id: string) {
+    const delivery = await this.deliveryRepo.findOne({ where: { id } });
+    if (!delivery) throw new NotFoundException('Delivery not found');
+    return delivery;
+  }
+
+  async retryDelivery(id: string) {
+    const delivery = await this.findDeliveryById(id);
+    
+    if (delivery.status !== DeliveryStatus.FAILED) {
+      throw new BadRequestException('Only failed deliveries can be retried');
+    }
+
+    delivery.status = DeliveryStatus.QUEUED;
+    delivery.attemptCount += 1;
+    delivery.failureReason = null;
+
+    return this.deliveryRepo.save(delivery);
+  }
+
+  async getStats() {
+    const cacheKey = 'notification:stats';
+    const cached = await this.cacheManager.get(cacheKey);
+    if (cached) return cached;
+
+    const last24h = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    const deliveries = await this.deliveryRepo.find({
+      where: { createdAt: Between(last24h, new Date()) },
+    });
+
+    const totalSent = deliveries.length;
+    const delivered = deliveries.filter(d => d.status === DeliveryStatus.DELIVERED).length;
+    const failed = deliveries.filter(d => d.status === DeliveryStatus.FAILED).length;
+    const bounced = deliveries.filter(d => d.status === DeliveryStatus.BOUNCED).length;
+
+    const byChannel = deliveries.reduce((acc, d) => {
+      if (!acc[d.channel]) acc[d.channel] = { sent: 0, delivered: 0 };
+      acc[d.channel].sent += 1;
+      if (d.status === DeliveryStatus.DELIVERED) acc[d.channel].delivered += 1;
+      return acc;
+    }, {} as Record<string, any>);
+
+    Object.keys(byChannel).forEach(ch => {
+      byChannel[ch].deliveryRate = ((byChannel[ch].delivered / byChannel[ch].sent) * 100).toFixed(1);
+    });
+
+    const byTemplate = deliveries.reduce((acc, d) => {
+      if (!acc[d.templateKey]) acc[d.templateKey] = { sent: 0, delivered: 0 };
+      acc[d.templateKey].sent += 1;
+      if (d.status === DeliveryStatus.DELIVERED) acc[d.templateKey].delivered += 1;
+      return acc;
+    }, {} as Record<string, any>);
+
+    const byTemplateArray = Object.entries(byTemplate).map(([key, val]: [string, any]) => ({
+      templateKey: key,
+      sent: val.sent,
+      deliveryRate: ((val.delivered / val.sent) * 100).toFixed(1),
+    }));
+
+    const stats = {
+      last24h: {
+        totalSent,
+        delivered,
+        failed,
+        bounced,
+        deliveryRate: totalSent > 0 ? ((delivered / totalSent) * 100).toFixed(1) : '0',
+      },
+      byChannel,
+      byTemplate: byTemplateArray,
+    };
+
+    await this.cacheManager.set(cacheKey, stats, 300000); // 5 minutes
+    return stats;
+  }
+}

--- a/backend/src/notification/notification.module.ts
+++ b/backend/src/notification/notification.module.ts
@@ -5,24 +5,39 @@ import { NotificationService } from './notification.service';
 import { NotificationProcessor } from './notification.processor';
 import { Notification } from './entities/notification.entity';
 import { NotificationPreference } from './entities/notification-preference.entity';
+import { NotificationTemplate } from './entities/notification-template.entity';
+import { NotificationTemplateVersion } from './entities/notification-template-version.entity';
+import { NotificationDelivery } from './entities/notification-delivery.entity';
 import { EmailProvider } from './providers/email.provider';
 import { SmsProvider } from './providers/sms.provider';
 import { PushProvider } from './providers/push.provider';
+import { NotificationTemplateService } from './notification-template.service';
+import { NotificationTemplateController } from './notification-template.controller';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Notification, NotificationPreference]),
+    TypeOrmModule.forFeature([
+      Notification,
+      NotificationPreference,
+      NotificationTemplate,
+      NotificationTemplateVersion,
+      NotificationDelivery,
+    ]),
     BullModule.registerQueue({
       name: 'notifications',
     }),
+    AuditModule,
   ],
+  controllers: [NotificationTemplateController],
   providers: [
     NotificationService,
     NotificationProcessor,
     EmailProvider,
     SmsProvider,
     PushProvider,
+    NotificationTemplateService,
   ],
-  exports: [NotificationService],
+  exports: [NotificationService, NotificationTemplateService],
 })
 export class NotificationModule {}


### PR DESCRIPTION


- Add GET/PATCH /notifications/templates with Handlebars AST variable validation
- Reject invalid Handlebars syntax at API level with parse error in response
- Guard isSystemCritical templates from deactivation with 409 response
- Store up to 10 previous versions per template in NotificationTemplateVersion
- Add POST /templates/:key/preview to render template with provided variables
- Add POST /templates/:key/test-send scoped to admin email only — never merchant
- Add GET /templates/:key/versions with diff view and editor audit trail
- Add POST /templates/:key/rollback/:versionId to restore previous version
- Add audit log on update, test-send, and rollback lifecycle events
- Add GET /notifications/deliveries with full filter support and retry endpoint
- Add GET /notifications/stats with 5-minute cache by channel and template key
- Add unit tests: variable validation, system-critical guard, rollback, test-send scope

Notification Template & Delivery Management
Fixes #209