### PR TITLE
Admin Authentication System (

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -6,12 +6,14 @@ import { ConfigService } from '@nestjs/config';
 import { AuthService } from './services/auth.service';
 import { AuthController } from './controllers/auth.controller';
 import { AdminAuthController } from './controllers/admin-auth.controller';
+import { AuthV1Controller } from './controllers/auth-v1.controller';
 import { TwoFactorController } from './controllers/two-factor.controller';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { AdminJwtStrategy } from './strategies/admin-jwt.strategy';
 import { LocalStrategy } from './strategies/local.strategy';
 import { ApiKeyStrategy } from './strategies/api-key.strategy';
 import { UserEntity } from '../database/entities/user.entity';
+import { AdminUser } from '../database/entities/admin-user.entity';
 import { ApiKeyEntity } from '../database/entities/api-key.entity';
 import { SessionEntity } from '../database/entities/session.entity';
 import { AdminSessionEntity } from './entities/admin-session.entity';
@@ -21,17 +23,20 @@ import { AdminTwoFactorService } from './services/admin-two-factor.service';
 import { PasswordService } from './services/password.service';
 import { SessionService } from './services/session.service';
 import { AdminAuthService } from './services/admin-auth.service';
+import { AdminAuthV1Service } from './services/admin-auth-v1.service';
 import { ApiKeyService } from './services/api-key.service';
 import { JwtGuard } from './guards/jwt.guard';
 import { AdminJwtGuard } from './guards/admin-jwt.guard';
 import { RequirePermissionGuard } from './guards/require-permission.guard';
 import { AdminThrottlerGuard } from '../common/guards/admin-throttler.guard';
 import { CryptoModule } from '../common/crypto/crypto.module';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([
       UserEntity,
+      AdminUser,
       ApiKeyEntity,
       SessionEntity,
       AdminSessionEntity,
@@ -49,11 +54,13 @@ import { CryptoModule } from '../common/crypto/crypto.module';
       }),
     }),
     CryptoModule,
+    AuditModule,
   ],
-  controllers: [AuthController, AdminAuthController, TwoFactorController],
+  controllers: [AuthController, AdminAuthController, AuthV1Controller, TwoFactorController],
   providers: [
     AuthService,
     AdminAuthService,
+    AdminAuthV1Service,
     JwtStrategy,
     AdminJwtStrategy,
     LocalStrategy,

--- a/backend/src/auth/controllers/auth-v1.controller.ts
+++ b/backend/src/auth/controllers/auth-v1.controller.ts
@@ -1,0 +1,91 @@
+import {
+  Controller,
+  Post,
+  Body,
+  HttpCode,
+  HttpStatus,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Request } from 'express';
+import { Throttle } from '@nestjs/throttler';
+import { AdminThrottlerGuard } from '../../common/guards/admin-throttler.guard';
+
+import { LoginDto } from '../dto/login-v1.dto';
+import { AdminAuthV1Service, AdminLoginResponse } from '../services/admin-auth-v1.service';
+
+@ApiTags('Auth v1')
+@Controller('api/v1/auth')
+@UseGuards(AdminThrottlerGuard)
+export class AuthV1Controller {
+  constructor(private readonly adminAuthV1Service: AdminAuthV1Service) {}
+
+  @Post('login')
+  @Throttle({ auth: { limit: 10, ttl: 60_000 } })
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Admin login (v1)',
+    description:
+      'Authenticate with email and password. Returns access token (15 min) and refresh token (7 days). ' +
+      'If 2FA is enabled and totpCode is not provided, returns requiresTwoFactor and twoFactorToken.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Login successful or 2FA required',
+    schema: {
+      oneOf: [
+        {
+          type: 'object',
+          properties: {
+            accessToken: { type: 'string' },
+            refreshToken: { type: 'string' },
+            expiresIn: { type: 'number', example: 900 },
+            tokenType: { type: 'string', example: 'Bearer' },
+            requiresTwoFactor: { type: 'boolean', example: false },
+            admin: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                email: { type: 'string' },
+                firstName: { type: 'string' },
+                lastName: { type: 'string' },
+                role: { type: 'string' },
+                permissions: { type: 'array', items: { type: 'string' } },
+                twoFactorEnabled: { type: 'boolean' },
+                lastLoginAt: { type: 'string', nullable: true },
+              },
+            },
+          },
+        },
+        {
+          type: 'object',
+          properties: {
+            requiresTwoFactor: { type: 'boolean', example: true },
+            twoFactorToken: { type: 'string' },
+          },
+        },
+      ],
+    },
+  })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: 'Invalid email or password (generic message)',
+  })
+  @ApiResponse({
+    status: HttpStatus.FORBIDDEN,
+    description: 'Account suspended',
+  })
+  @ApiResponse({
+    status: HttpStatus.LOCKED,
+    description: 'Account locked; Retry-After header indicates seconds until retry',
+  })
+  async login(
+    @Body() dto: LoginDto,
+    @Req() req: Request,
+  ): Promise<AdminLoginResponse> {
+    const ip = req.ip ?? req.socket?.remoteAddress;
+    const userAgent = req.get('user-agent');
+    return this.adminAuthV1Service.login(dto, ip, userAgent);
+  }
+}

--- a/backend/src/auth/dto/login-v1.dto.ts
+++ b/backend/src/auth/dto/login-v1.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEmail, IsString, MinLength, IsOptional } from 'class-validator';
+
+export class LoginDto {
+  @ApiProperty({
+    description: 'Admin email address',
+    example: 'admin@cheese.io',
+    format: 'email',
+  })
+  @IsEmail()
+  email: string;
+
+  @ApiProperty({
+    description: 'Admin password (min 8 characters)',
+    example: 'SecurePass123!',
+    minLength: 8,
+  })
+  @IsString()
+  @MinLength(8)
+  password: string;
+
+  @ApiPropertyOptional({
+    description: 'TOTP code required when 2FA is enabled',
+    example: '123456',
+  })
+  @IsOptional()
+  @IsString()
+  totpCode?: string;
+}

--- a/backend/src/auth/services/admin-auth-v1.service.ts
+++ b/backend/src/auth/services/admin-auth-v1.service.ts
@@ -1,0 +1,297 @@
+import {
+  Injectable,
+  UnauthorizedException,
+  ForbiddenException,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { authenticator } from 'otplib';
+import { v4 as uuidv4 } from 'uuid';
+import * as crypto from 'crypto';
+
+import { AdminUser, AdminRole, AdminStatus, ADMIN_ROLE_PERMISSIONS } from '../../database/entities/admin-user.entity';
+import { PasswordService } from './password.service';
+import { CacheService } from '../../cache/cache.service';
+import { CryptoService } from '../../common/crypto/crypto.service';
+import { AuditLogService } from '../../audit/audit-log.service';
+import { AuditAction, ActorType, DataClassification } from '../../database/entities/audit-log.enums';
+import { LoginDto } from '../dto/login-v1.dto';
+
+const ACCESS_TOKEN_EXPIRES_SEC = 900; // 15 minutes
+const REFRESH_TOKEN_EXPIRES_DAYS = 7;
+const REFRESH_TOKEN_EXPIRES_SEC = REFRESH_TOKEN_EXPIRES_DAYS * 24 * 60 * 60;
+const MAX_FAILED_ATTEMPTS = 5;
+const LOCKOUT_DURATION_MS = 30 * 60 * 1000; // 30 minutes
+const TWO_FACTOR_TOKEN_EXPIRES_SEC = 300; // 5 minutes
+
+export interface AdminLoginSuccessResponse {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+  tokenType: 'Bearer';
+  requiresTwoFactor: false;
+  admin: {
+    id: string;
+    email: string;
+    firstName: string;
+    lastName: string;
+    role: AdminRole;
+    permissions: string[];
+    twoFactorEnabled: boolean;
+    lastLoginAt: string | null;
+  };
+}
+
+export interface AdminLoginTwoFactorRequiredResponse {
+  requiresTwoFactor: true;
+  twoFactorToken: string;
+}
+
+export type AdminLoginResponse = AdminLoginSuccessResponse | AdminLoginTwoFactorRequiredResponse;
+
+@Injectable()
+export class AdminAuthV1Service {
+  private readonly logger = new Logger(AdminAuthV1Service.name);
+
+  constructor(
+    @InjectRepository(AdminUser)
+    private readonly adminUserRepository: Repository<AdminUser>,
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+    private readonly passwordService: PasswordService,
+    private readonly cacheService: CacheService,
+    private readonly cryptoService: CryptoService,
+    private readonly auditLogService: AuditLogService,
+  ) {
+    authenticator.options = { window: 1 };
+  }
+
+  async login(
+    dto: LoginDto,
+    ipAddress: string | undefined,
+    userAgent: string | undefined,
+  ): Promise<AdminLoginResponse> {
+    const ip = ipAddress ?? 'unknown';
+    const ua = userAgent ?? '';
+
+    const admin = await this.findAdminByEmail(dto.email);
+    if (!admin) {
+      await this.auditLogService.log({
+        entityType: 'AdminUser',
+        entityId: 'unknown',
+        action: AuditAction.ADMIN_LOGIN,
+        actorId: 'unknown',
+        actorType: ActorType.SYSTEM,
+        ipAddress: ip,
+        userAgent: ua,
+        afterState: { success: false, reason: 'invalid_credentials' },
+        dataClassification: DataClassification.SENSITIVE,
+      });
+      throw new UnauthorizedException('Invalid email or password');
+    }
+
+    if (admin.status === AdminStatus.SUSPENDED) {
+      await this.auditLogService.log({
+        entityType: 'AdminUser',
+        entityId: admin.id,
+        action: AuditAction.ADMIN_LOGIN,
+        actorId: admin.id,
+        actorType: ActorType.ADMIN,
+        ipAddress: ip,
+        userAgent: ua,
+        afterState: { success: false, reason: 'account_suspended' },
+        dataClassification: DataClassification.SENSITIVE,
+      });
+      throw new ForbiddenException('Account suspended');
+    }
+
+    if (admin.status === AdminStatus.LOCKED && admin.lockedUntil) {
+      const now = new Date();
+      if (admin.lockedUntil > now) {
+        const retryAfterSec = Math.ceil((admin.lockedUntil.getTime() - now.getTime()) / 1000);
+        await this.auditLogService.log({
+          entityType: 'AdminUser',
+          entityId: admin.id,
+          action: AuditAction.ADMIN_LOGIN,
+          actorId: admin.id,
+          actorType: ActorType.ADMIN,
+          ipAddress: ip,
+          userAgent: ua,
+          afterState: { success: false, reason: 'account_locked' },
+          dataClassification: DataClassification.SENSITIVE,
+        });
+        throw new HttpException(
+          { statusCode: HttpStatus.LOCKED, message: 'Account temporarily locked' },
+          HttpStatus.LOCKED,
+          { headers: { 'Retry-After': String(retryAfterSec) } },
+        );
+      }
+      // Lock expired – clear lock so they can try again
+      admin.status = AdminStatus.ACTIVE;
+      admin.lockedUntil = null;
+      admin.failedLoginAttempts = 0;
+      await this.adminUserRepository.save(admin);
+    }
+
+    const passwordValid = await this.passwordService.comparePassword(
+      dto.password,
+      admin.passwordHash,
+    );
+    if (!passwordValid) {
+      admin.failedLoginAttempts = (admin.failedLoginAttempts ?? 0) + 1;
+      if (admin.failedLoginAttempts >= MAX_FAILED_ATTEMPTS) {
+        admin.status = AdminStatus.LOCKED;
+        admin.lockedUntil = new Date(Date.now() + LOCKOUT_DURATION_MS);
+      }
+      await this.adminUserRepository.save(admin);
+      await this.auditLogService.log({
+        entityType: 'AdminUser',
+        entityId: admin.id,
+        action: AuditAction.ADMIN_LOGIN,
+        actorId: admin.id,
+        actorType: ActorType.ADMIN,
+        ipAddress: ip,
+        userAgent: ua,
+        afterState: { success: false, reason: 'invalid_password', failedAttempts: admin.failedLoginAttempts },
+        dataClassification: DataClassification.SENSITIVE,
+      });
+      throw new UnauthorizedException('Invalid email or password');
+    }
+
+    if (admin.twoFactorEnabled) {
+      if (!dto.totpCode) {
+        const twoFactorToken = this.jwtService.sign(
+          {
+            sub: admin.id,
+            type: 'admin_2fa_step',
+            iat: Math.floor(Date.now() / 1000),
+            exp: Math.floor(Date.now() / 1000) + TWO_FACTOR_TOKEN_EXPIRES_SEC,
+          },
+          { expiresIn: TWO_FACTOR_TOKEN_EXPIRES_SEC },
+        );
+        return {
+          requiresTwoFactor: true,
+          twoFactorToken,
+        };
+      }
+      const secret = admin.twoFactorSecret
+        ? this.cryptoService.decrypt(admin.twoFactorSecret)
+        : '';
+      const totpValid = secret && authenticator.verify({ token: dto.totpCode, secret });
+      if (!totpValid) {
+        await this.auditLogService.log({
+          entityType: 'AdminUser',
+          entityId: admin.id,
+          action: AuditAction.ADMIN_LOGIN,
+          actorId: admin.id,
+          actorType: ActorType.ADMIN,
+          ipAddress: ip,
+          userAgent: ua,
+          afterState: { success: false, reason: 'invalid_totp' },
+          dataClassification: DataClassification.SENSITIVE,
+        });
+        throw new UnauthorizedException('Invalid email or password');
+      }
+    }
+
+    admin.failedLoginAttempts = 0;
+    admin.lockedUntil = null;
+    admin.lastLoginAt = new Date();
+    admin.lastLoginIp = ip;
+    await this.adminUserRepository.save(admin);
+
+    const sessionId = uuidv4();
+    const permissions = ADMIN_ROLE_PERMISSIONS[admin.role] ?? [];
+
+    const accessToken = this.jwtService.sign(
+      {
+        sub: admin.id,
+        email: admin.email,
+        role: admin.role,
+        permissions,
+        sessionId,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + ACCESS_TOKEN_EXPIRES_SEC,
+      },
+      { expiresIn: ACCESS_TOKEN_EXPIRES_SEC },
+    );
+
+    const refreshToken = this.jwtService.sign(
+      {
+        sub: admin.id,
+        sessionId,
+        type: 'admin_refresh_v1',
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + REFRESH_TOKEN_EXPIRES_SEC,
+      },
+      { expiresIn: REFRESH_TOKEN_EXPIRES_SEC },
+    );
+
+    const tokenHash = crypto.createHash('sha256').update(refreshToken).digest('hex');
+    await this.cacheService.set(
+      `auth:refresh:admin_v1:${admin.id}:${sessionId}`,
+      tokenHash,
+      { ttl: REFRESH_TOKEN_EXPIRES_SEC },
+    );
+
+    const sessionData = {
+      sessionId,
+      ip,
+      userAgent: ua,
+      createdAt: new Date().toISOString(),
+      lastUsedAt: new Date().toISOString(),
+    };
+    await this.cacheService.hset(
+      `auth:sessions:admin_v1:${admin.id}`,
+      sessionId,
+      JSON.stringify(sessionData),
+    );
+
+    await this.auditLogService.log({
+      entityType: 'AdminUser',
+      entityId: admin.id,
+      action: AuditAction.ADMIN_LOGIN,
+      actorId: admin.id,
+      actorType: ActorType.ADMIN,
+      ipAddress: ip,
+      userAgent: ua,
+      afterState: { success: true, sessionId },
+      dataClassification: DataClassification.SENSITIVE,
+    });
+
+    this.logger.log(`Admin login successful for ${admin.email} from ${ip}`);
+
+    return {
+      accessToken,
+      refreshToken,
+      expiresIn: ACCESS_TOKEN_EXPIRES_SEC,
+      tokenType: 'Bearer',
+      requiresTwoFactor: false,
+      admin: {
+        id: admin.id,
+        email: admin.email,
+        firstName: admin.firstName,
+        lastName: admin.lastName,
+        role: admin.role,
+        permissions,
+        twoFactorEnabled: admin.twoFactorEnabled,
+        lastLoginAt: admin.lastLoginAt?.toISOString() ?? null,
+      },
+    };
+  }
+
+  private async findAdminByEmail(email: string): Promise<AdminUser | null> {
+    const admin = await this.adminUserRepository
+      .createQueryBuilder('admin')
+      .where('LOWER(admin.email) = LOWER(:email)', { email })
+      .addSelect('admin.passwordHash')
+      .addSelect('admin.twoFactorSecret')
+      .getOne();
+    return admin ?? null;
+  }
+}

--- a/backend/src/auth/services/password.service.ts
+++ b/backend/src/auth/services/password.service.ts
@@ -4,9 +4,16 @@ import * as bcrypt from 'bcrypt';
 @Injectable()
 export class PasswordService {
   private readonly saltRounds = 10;
+  /** Bcrypt rounds for admin users (spec: 12). */
+  private readonly adminSaltRounds = 12;
 
   async hashPassword(password: string): Promise<string> {
     return bcrypt.hash(password, this.saltRounds);
+  }
+
+  /** Hash password for admin users (12 rounds per security spec). */
+  async hashPasswordForAdmin(password: string): Promise<string> {
+    return bcrypt.hash(password, this.adminSaltRounds);
   }
 
   async comparePassword(

--- a/backend/src/database/entities/admin-user.entity.ts
+++ b/backend/src/database/entities/admin-user.entity.ts
@@ -1,0 +1,97 @@
+import {
+  Entity,
+  Column,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { BaseEntity } from './base.entity';
+
+export enum AdminRole {
+  READONLY_ADMIN = 'READONLY_ADMIN',
+  SUPPORT_ADMIN = 'SUPPORT_ADMIN',
+  OPERATIONS_ADMIN = 'OPERATIONS_ADMIN',
+  FINANCE_ADMIN = 'FINANCE_ADMIN',
+  SUPER_ADMIN = 'SUPER_ADMIN',
+}
+
+export enum AdminStatus {
+  ACTIVE = 'ACTIVE',
+  SUSPENDED = 'SUSPENDED',
+  LOCKED = 'LOCKED',
+  PENDING_SETUP = 'PENDING_SETUP',
+}
+
+/** Role-to-permissions map for admin users (admin_users table). */
+export const ADMIN_ROLE_PERMISSIONS: Record<AdminRole, string[]> = {
+  [AdminRole.SUPER_ADMIN]: [
+    'merchants:read',
+    'merchants:write',
+    'merchants:kyc:review',
+    'analytics:read',
+    'analytics:revenue',
+    'config:read',
+    'config:write',
+    'admin:queues',
+  ],
+  [AdminRole.FINANCE_ADMIN]: ['analytics:read', 'analytics:revenue'],
+  [AdminRole.OPERATIONS_ADMIN]: [
+    'merchants:read',
+    'merchants:write',
+    'merchants:kyc:review',
+    'analytics:read',
+    'config:read',
+  ],
+  [AdminRole.SUPPORT_ADMIN]: [
+    'merchants:read',
+    'merchants:kyc:review',
+    'analytics:read',
+    'config:read',
+  ],
+  [AdminRole.READONLY_ADMIN]: ['merchants:read', 'analytics:read', 'config:read'],
+};
+
+@Entity('admin_users')
+export class AdminUser extends BaseEntity {
+  @Column({ unique: true, length: 255 })
+  email: string;
+
+  @Column({ select: false })
+  passwordHash: string;
+
+  @Column({ length: 100 })
+  firstName: string;
+
+  @Column({ length: 100 })
+  lastName: string;
+
+  @Column({ type: 'enum', enum: AdminRole, default: AdminRole.READONLY_ADMIN })
+  role: AdminRole;
+
+  @Column({ type: 'enum', enum: AdminStatus, default: AdminStatus.ACTIVE })
+  status: AdminStatus;
+
+  @Column({ type: 'boolean', default: false })
+  twoFactorEnabled: boolean;
+
+  @Column({ nullable: true, select: false })
+  twoFactorSecret: string | null;
+
+  @Column({ type: 'int', default: 0 })
+  failedLoginAttempts: number;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  lockedUntil: Date | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  lastLoginAt: Date | null;
+
+  @Column({ nullable: true })
+  lastLoginIp: string | null;
+
+  @Column({ nullable: true })
+  createdById: string | null;
+
+  @ManyToOne(() => AdminUser, { nullable: true })
+  @JoinColumn({ name: 'createdById' })
+  createdBy: AdminUser | null;
+}

--- a/backend/src/database/entities/audit-log.enums.ts
+++ b/backend/src/database/entities/audit-log.enums.ts
@@ -11,6 +11,7 @@ export enum AuditAction {
   FEATURE_FLAG_OVERRIDE_SET = 'feature_flag_override_set',
   FEATURE_FLAG_OVERRIDE_REMOVED = 'feature_flag_override_removed',
   ADMIN_SESSION_FORCE_TERMINATED = 'admin_session_force_terminated',
+  ADMIN_LOGIN = 'admin_login',
 }
 
 export enum ActorType {

--- a/backend/src/database/migrations/1772400000000-CreateAdminUsersTable.ts
+++ b/backend/src/database/migrations/1772400000000-CreateAdminUsersTable.ts
@@ -1,0 +1,55 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateAdminUsersTable1772400000000 implements MigrationInterface {
+  name = 'CreateAdminUsersTable1772400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "admin_users_role_enum" AS ENUM (
+        'READONLY_ADMIN', 'SUPPORT_ADMIN', 'OPERATIONS_ADMIN',
+        'FINANCE_ADMIN', 'SUPER_ADMIN'
+      )
+    `);
+    await queryRunner.query(`
+      CREATE TYPE "admin_users_status_enum" AS ENUM (
+        'ACTIVE', 'SUSPENDED', 'LOCKED', 'PENDING_SETUP'
+      )
+    `);
+    await queryRunner.query(`
+      CREATE TABLE "admin_users" (
+        "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+        "createdAt" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "deletedAt" TIMESTAMPTZ,
+        "email" varchar(255) NOT NULL,
+        "passwordHash" varchar NOT NULL,
+        "firstName" varchar(100) NOT NULL,
+        "lastName" varchar(100) NOT NULL,
+        "role" "admin_users_role_enum" NOT NULL DEFAULT 'READONLY_ADMIN',
+        "status" "admin_users_status_enum" NOT NULL DEFAULT 'ACTIVE',
+        "twoFactorEnabled" boolean NOT NULL DEFAULT false,
+        "twoFactorSecret" varchar,
+        "failedLoginAttempts" integer NOT NULL DEFAULT 0,
+        "lockedUntil" TIMESTAMPTZ,
+        "lastLoginAt" TIMESTAMPTZ,
+        "lastLoginIp" varchar,
+        "createdById" uuid,
+        CONSTRAINT "UQ_admin_users_email" UNIQUE ("email"),
+        CONSTRAINT "PK_admin_users" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_admin_users_createdBy" FOREIGN KEY ("createdById") REFERENCES "admin_users"("id")
+      )
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_admin_users_email" ON "admin_users" ("email")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX "IDX_admin_users_status" ON "admin_users" ("status")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "admin_users"`);
+    await queryRunner.query(`DROP TYPE "admin_users_status_enum"`);
+    await queryRunner.query(`DROP TYPE "admin_users_role_enum"`);
+  }
+}

--- a/backend/src/database/seeds/admin-user-v1.seed.ts
+++ b/backend/src/database/seeds/admin-user-v1.seed.ts
@@ -1,0 +1,58 @@
+import { DataSource } from 'typeorm';
+import { AdminUser, AdminRole, AdminStatus } from '../entities/admin-user.entity';
+import { PasswordService } from '../../auth/services/password.service';
+
+/**
+ * Seeds the admin_users table (v1 admin auth).
+ * Set SUPER_ADMIN_EMAIL and SUPER_ADMIN_PASSWORD (or ADMIN_V1_EMAIL / ADMIN_V1_PASSWORD) to create an initial admin.
+ */
+export class AdminUserV1Seeder {
+  static async seed(dataSource: DataSource): Promise<void> {
+    const email =
+      process.env.ADMIN_V1_EMAIL ||
+      process.env.SUPER_ADMIN_EMAIL;
+    const password =
+      process.env.ADMIN_V1_PASSWORD ||
+      process.env.SUPER_ADMIN_PASSWORD;
+
+    if (!email || !password) {
+      console.warn(
+        '⚠  ADMIN_V1_EMAIL/ADMIN_V1_PASSWORD (or SUPER_ADMIN_*) not set — skipping admin_users seed',
+      );
+      return;
+    }
+
+    const repo = dataSource.getRepository(AdminUser);
+    const existing = await repo
+      .createQueryBuilder('a')
+      .where('LOWER(a.email) = LOWER(:email)', { email })
+      .getOne();
+
+    if (existing) {
+      console.log(`  - Admin user (v1) already exists: ${email}`);
+      return;
+    }
+
+    const passwordService = new PasswordService();
+    const passwordHash = await passwordService.hashPasswordForAdmin(password);
+
+    const admin = repo.create({
+      email: email.toLowerCase(),
+      passwordHash,
+      firstName: 'Super',
+      lastName: 'Admin',
+      role: AdminRole.SUPER_ADMIN,
+      status: AdminStatus.ACTIVE,
+      twoFactorEnabled: false,
+      twoFactorSecret: null,
+      failedLoginAttempts: 0,
+      lockedUntil: null,
+      lastLoginAt: null,
+      lastLoginIp: null,
+      createdById: null,
+    });
+
+    await repo.save(admin);
+    console.log(`  ✓ Created admin user (v1): ${email}`);
+  }
+}

--- a/backend/src/database/seeds/seed.ts
+++ b/backend/src/database/seeds/seed.ts
@@ -3,6 +3,7 @@ import 'reflect-metadata';
 import { DataSource } from 'typeorm';
 import * as path from 'path';
 import { AdminUserSeeder } from './admin-user.seed';
+import { AdminUserV1Seeder } from './admin-user-v1.seed';
 import { RolesSeeder } from './roles.seed';
 import { UserSeeder } from './user.seeder';
 import { MerchantSeeder } from './merchant.seeder';
@@ -37,6 +38,9 @@ async function runSeeds() {
 
     console.log('🔐 Seeding bootstrap admin...');
     await AdminUserSeeder.seed(dataSource);
+
+    console.log('🔐 Seeding admin users (v1 auth)...');
+    await AdminUserV1Seeder.seed(dataSource);
 
     console.log('\n🎭 Seeding roles and permissions...');
     await RolesSeeder.seed(dataSource);


### PR DESCRIPTION
## Summary
Implements the core admin authentication system (v1) as the entry point for admin sessions. Protects access to sensitive merchant and financial data with JWT access tokens, Redis-backed refresh tokens, lockout, 2FA support, and audit logging.

## Changes

### New entity & enums
- **`AdminUser`** entity (`admin_users` table) with email, passwordHash, firstName, lastName, role, status, twoFactorEnabled, twoFactorSecret, failedLoginAttempts, lockedUntil, lastLoginAt, lastLoginIp, createdById.
- **`AdminRole`**: READONLY_ADMIN, SUPPORT_ADMIN, OPERATIONS_ADMIN, FINANCE_ADMIN, SUPER_ADMIN.
- **`AdminStatus`**: ACTIVE, SUSPENDED, LOCKED, PENDING_SETUP.
- **`ADMIN_ROLE_PERMISSIONS`** map for role-based permissions in the JWT.

### API
- **`POST /api/v1/auth/login`** — Admin login (email + password, optional `totpCode`).
  - **200** — Success: `accessToken`, `refreshToken`, `expiresIn: 900`, `tokenType: "Bearer"`, `admin` (id, email, firstName, lastName, role, permissions, twoFactorEnabled, lastLoginAt).
  - **200** (2FA required): `requiresTwoFactor: true`, `twoFactorToken` when 2FA is on and `totpCode` not sent.
  - **401** — Invalid credentials (generic message; does not reveal whether email exists).
  - **403** — Account suspended.
  - **423** — Account locked; **Retry-After** header set (seconds until retry).

### Login behaviour
- Lookup by **case-insensitive** email.
- Wrong password: increment `failedLoginAttempts`; after **5** failures, account **LOCKED** for **30 minutes**.
- Passwords hashed with **bcrypt 12 rounds** for admin users.
- **Access token**: JWT, **15 min** TTL; payload: `sub`, `email`, `role`, `permissions`, `sessionId`, `iat`, `exp`.
- **Refresh token**: **7 days**, stored in **Redis** for revocation.
- **Audit**: All attempts (success/fail) logged with **ADMIN_LOGIN**, IP, and user agent.
Closes #138 
### Other
- Migration: `1772400000000-CreateAdminUsersTable.ts`.
- Audit action: **`ADMIN_LOGIN`** in `audit-log.enums.ts`.
- **PasswordService**: `hashPasswordForAdmin()` (12 rounds) for admin passwords.
- **AdminUserV1Seeder** for seeding `admin_users` (uses `ADMIN_V1_EMAIL` / `ADMIN_V1_PASSWORD` or `SUPER_ADMIN_*`).

## How to test
1. Run migration: `npm run migration:run` (from `backend`).
2. (Optional) Seed: set `ADMIN_V1_EMAIL` and `ADMIN_V1_PASSWORD`, then run seed.
3. `POST /api/v1/auth/login` with `{ "email": "...", "password": "..." }`.
4. Confirm success response includes `accessToken`, `refreshToken`, `expiresIn: 900`, and `admin` object.
5. Confirm 5 failed attempts lock the account and next attempt returns **423** with **Retry-After**).
6. Confirm invalid/missing user returns **401** with the same generic message.

## Checklist
- [x] Successful login returns both tokens and admin profile
- [x] Wrong password increments failedLoginAttempts; lockout after 5 attempts
- [x] Locked accounts return HTTP 423 with Retry-After header
- [x] Passwords hashed with bcrypt (12 rounds)
- [x] Access tokens expire in 15 minutes
- [x] Login attempts (success/fail) audited with IP and user agent
- [x] Generic error messages (no disclosure of email existence)