### PR TITLE
setup auth module

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -30,3 +30,5 @@ coverage/
 # OS
 .DS_Store
 Thumbs.db
+
+issue.md

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,6 +28,8 @@
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.3",
     "@nestjs/core": "^11.0.1",
+    "@nestjs/jwt": "^11.0.2",
+    "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.2.6",
     "@nestjs/terminus": "^11.1.1",
@@ -40,10 +42,13 @@
     "dotenv": "^17.3.1",
     "ioredis": "^5.10.1",
     "joi": "^18.1.1",
+    "passport": "^0.7.0",
+    "passport-jwt": "^4.0.1",
     "pg": "^8.20.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
-    "typeorm": "^0.3.28"
+    "typeorm": "^0.3.28",
+    "uuid": "^13.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -56,7 +61,9 @@
     "@types/express": "^5.0.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.10.7",
+    "@types/passport-jwt": "^4.0.1",
     "@types/supertest": "^6.0.2",
+    "@types/uuid": "^11.0.0",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.2",
@@ -95,5 +102,6 @@
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"
-  }
+  },
+  "packageManager": "pnpm@10.30.2+sha512.36cdc707e7b7940a988c9c1ecf88d084f8514b5c3f085f53a2e244c2921d3b2545bc20dd4ebe1fc245feec463bb298aecea7a63ed1f7680b877dc6379d8d0cb4"
 }

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       '@nestjs/core':
         specifier: ^11.0.1
         version: 11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/jwt':
+        specifier: ^11.0.2
+        version: 11.0.2(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))
+      '@nestjs/passport':
+        specifier: ^11.0.5
+        version: 11.0.5(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(passport@0.7.0)
       '@nestjs/platform-express':
         specifier: ^11.0.1
         version: 11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)
@@ -56,6 +62,12 @@ importers:
       joi:
         specifier: ^18.1.1
         version: 18.1.1
+      passport:
+        specifier: ^0.7.0
+        version: 0.7.0
+      passport-jwt:
+        specifier: ^4.0.1
+        version: 4.0.1
       pg:
         specifier: ^8.20.0
         version: 8.20.0
@@ -68,6 +80,9 @@ importers:
       typeorm:
         specifier: ^0.3.28
         version: 0.3.28(ioredis@5.10.1)(pg@8.20.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      uuid:
+        specifier: ^13.0.0
+        version: 13.0.0
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.2.0
@@ -99,9 +114,15 @@ importers:
       '@types/node':
         specifier: ^22.10.7
         version: 22.19.15
+      '@types/passport-jwt':
+        specifier: ^4.0.1
+        version: 4.0.1
       '@types/supertest':
         specifier: ^6.0.2
         version: 6.0.3
+      '@types/uuid':
+        specifier: ^11.0.0
+        version: 11.0.0
       eslint:
         specifier: ^9.18.0
         version: 9.39.4
@@ -802,6 +823,11 @@ packages:
       '@nestjs/websockets':
         optional: true
 
+  '@nestjs/jwt@11.0.2':
+    resolution: {integrity: sha512-rK8aE/3/Ma45gAWfCksAXUNbOoSOUudU0Kn3rT39htPF7wsYXtKfjALKeKKJbFrIWbLjsbqfXX5bIJNvgBugGA==}
+    peerDependencies:
+      '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+
   '@nestjs/mapped-types@2.1.0':
     resolution: {integrity: sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==}
     peerDependencies:
@@ -814,6 +840,12 @@ packages:
         optional: true
       class-validator:
         optional: true
+
+  '@nestjs/passport@11.0.5':
+    resolution: {integrity: sha512-ulQX6mbjlws92PIM15Naes4F4p2JoxGnIJuUsdXQPT+Oo2sqQmENEZXM7eYuimocfHnKlcfZOuyzbA33LwUlOQ==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      passport: ^0.5.0 || ^0.6.0 || ^0.7.0
 
   '@nestjs/platform-express@11.1.17':
     resolution: {integrity: sha512-mAf4eOsSBsTOn/VbrUO1gsjW6dVh91qqXPMXun4dN8SnNjf7PTQagM9o8d6ab8ZBpNe6UdZftdrZoDetU+n4Qg==}
@@ -1041,11 +1073,26 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/jsonwebtoken@9.0.10':
+    resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
+
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
 
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
+
+  '@types/passport-jwt@4.0.1':
+    resolution: {integrity: sha512-Y0Ykz6nWP4jpxgEUYq8NoVZeCQPo1ZndJLfapI249g1jHChvRfZRO/LS3tqu26YgAS/laI1qx98sYGz0IalRXQ==}
+
+  '@types/passport-strategy@0.2.38':
+    resolution: {integrity: sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==}
+
+  '@types/passport@1.0.17':
+    resolution: {integrity: sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==}
 
   '@types/qs@6.15.0':
     resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
@@ -1067,6 +1114,10 @@ packages:
 
   '@types/supertest@6.0.3':
     resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
+
+  '@types/uuid@11.0.0':
+    resolution: {integrity: sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==}
+    deprecated: This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.
 
   '@types/validator@13.15.10':
     resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
@@ -1501,6 +1552,9 @@ packages:
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
 
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -1792,6 +1846,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -2465,6 +2522,16 @@ packages:
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -2501,14 +2568,35 @@ packages:
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
 
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
   lodash.isarguments@3.1.0:
     resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
 
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
@@ -2745,6 +2833,17 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  passport-jwt@4.0.1:
+    resolution: {integrity: sha512-UCKMDYhNuGOBE9/9Ycuoyh7vP6jpeTp/+sfMJl7nLff/t6dps+iaeE0hhNkKN8/HZHcJ7lCdOyDxHdDoxoSvdQ==}
+
+  passport-strategy@1.0.0:
+    resolution: {integrity: sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==}
+    engines: {node: '>= 0.4.0'}
+
+  passport@0.7.0:
+    resolution: {integrity: sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==}
+    engines: {node: '>= 0.4.0'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2771,6 +2870,9 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pause@0.0.1:
+    resolution: {integrity: sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==}
 
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
@@ -3399,8 +3501,16 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
+  uuid@13.0.0:
+    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
     hasBin: true
 
   uuid@8.3.2:
@@ -4336,6 +4446,12 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-express': 11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)
 
+  '@nestjs/jwt@11.0.2(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))':
+    dependencies:
+      '@nestjs/common': 11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@types/jsonwebtoken': 9.0.10
+      jsonwebtoken: 9.0.3
+
   '@nestjs/mapped-types@2.1.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)':
     dependencies:
       '@nestjs/common': 11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -4343,6 +4459,11 @@ snapshots:
     optionalDependencies:
       class-transformer: 0.5.1
       class-validator: 0.15.1
+
+  '@nestjs/passport@11.0.5(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(passport@0.7.0)':
+    dependencies:
+      '@nestjs/common': 11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      passport: 0.7.0
 
   '@nestjs/platform-express@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17)':
     dependencies:
@@ -4555,11 +4676,32 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/jsonwebtoken@9.0.10':
+    dependencies:
+      '@types/ms': 2.1.0
+      '@types/node': 22.19.15
+
   '@types/methods@1.1.4': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/passport-jwt@4.0.1':
+    dependencies:
+      '@types/jsonwebtoken': 9.0.10
+      '@types/passport-strategy': 0.2.38
+
+  '@types/passport-strategy@0.2.38':
+    dependencies:
+      '@types/express': 5.0.6
+      '@types/passport': 1.0.17
+
+  '@types/passport@1.0.17':
+    dependencies:
+      '@types/express': 5.0.6
 
   '@types/qs@6.15.0': {}
 
@@ -4587,6 +4729,10 @@ snapshots:
     dependencies:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
+
+  '@types/uuid@11.0.0':
+    dependencies:
+      uuid: 13.0.0
 
   '@types/validator@13.15.10': {}
 
@@ -5065,6 +5211,8 @@ snapshots:
     dependencies:
       node-int64: 0.4.0
 
+  buffer-equal-constant-time@1.0.1: {}
+
   buffer-from@1.1.2: {}
 
   buffer@5.7.1:
@@ -5309,6 +5457,10 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -6210,6 +6362,30 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.4
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -6239,11 +6415,25 @@ snapshots:
 
   lodash.defaults@4.2.0: {}
 
+  lodash.includes@4.3.0: {}
+
   lodash.isarguments@3.1.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
 
   lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
+
+  lodash.once@4.1.1: {}
 
   lodash@4.17.23: {}
 
@@ -6459,6 +6649,19 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  passport-jwt@4.0.1:
+    dependencies:
+      jsonwebtoken: 9.0.3
+      passport-strategy: 1.0.0
+
+  passport-strategy@1.0.0: {}
+
+  passport@0.7.0:
+    dependencies:
+      passport-strategy: 1.0.0
+      pause: 0.0.1
+      utils-merge: 1.0.1
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -6478,6 +6681,8 @@ snapshots:
   path-to-regexp@8.3.0: {}
 
   path-type@4.0.0: {}
+
+  pause@0.0.1: {}
 
   pg-cloudflare@1.3.0:
     optional: true
@@ -7082,7 +7287,11 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  utils-merge@1.0.1: {}
+
   uuid@11.1.0: {}
+
+  uuid@13.0.0: {}
 
   uuid@8.3.2: {}
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
 import { ConfigType } from '@nestjs/config';
 import { BullModule } from '@nestjs/bull';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { AppConfigModule, appConfig, redisConfig } from './config';
 import { DatabaseModule } from './database/database.module';
 import { HealthModule } from './health/health.module';
+import { AuthModule } from './auth/auth.module';
+import { JwtAuthGuard } from './auth/guards/jwt-auth.guard';
 
 @Module({
   imports: [
@@ -40,6 +43,17 @@ import { HealthModule } from './health/health.module';
     }),
 
     HealthModule,
+
+    // 5. Auth — register/login/refresh/logout + global JWT guard.
+    AuthModule,
+  ],
+  providers: [
+    // Global guard: every route requires a valid JWT unless decorated @Public().
+    {
+      provide: APP_GUARD,
+      useClass: JwtAuthGuard,
+    },
   ],
 })
 export class AppModule {}
+

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,0 +1,77 @@
+import {
+  Controller,
+  Post,
+  Body,
+  Req,
+  Headers,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { JwtService } from '@nestjs/jwt';
+import { AuthService } from './auth.service';
+import { RegisterDto } from './dto/register.dto';
+import { LoginDto } from './dto/login.dto';
+import { RefreshDto } from './dto/refresh.dto';
+import { TokenResponseDto } from './dto/token-response.dto';
+import { Public } from './decorators/public.decorator';
+
+interface RequestWithUser {
+  ip: string;
+  headers: { authorization?: string };
+  user?: { id: string };
+}
+
+@ApiTags('auth')
+@Controller('auth')
+export class AuthController {
+  constructor(
+    private readonly authService: AuthService,
+    private readonly jwtService: JwtService,
+  ) {}
+
+  @Public()
+  @Post('register')
+  @ApiOperation({ summary: 'Register a new user and receive a token pair' })
+  register(
+    @Body() dto: RegisterDto,
+    @Req() req: RequestWithUser,
+    @Headers('user-agent') ua?: string,
+  ): Promise<TokenResponseDto> {
+    return this.authService.register(dto, req.ip, ua ? { userAgent: ua } : undefined);
+  }
+
+  @Public()
+  @Post('login')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Login and receive a token pair' })
+  login(
+    @Body() dto: LoginDto,
+    @Req() req: RequestWithUser,
+    @Headers('user-agent') ua?: string,
+  ): Promise<TokenResponseDto> {
+    return this.authService.login(dto, req.ip, ua ? { userAgent: ua } : undefined);
+  }
+
+  @Public()
+  @Post('refresh')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Rotate a refresh token and receive a new pair' })
+  refresh(@Body() dto: RefreshDto): Promise<TokenResponseDto> {
+    return this.authService.refresh(dto.refreshToken);
+  }
+
+  @Post('logout')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Revoke the current session refresh token' })
+  async logout(@Req() req: RequestWithUser): Promise<void> {
+    const raw = req.headers.authorization?.replace('Bearer ', '');
+    if (!raw) return;
+
+    const payload = this.jwtService.decode<{ sessionId?: string }>(raw);
+    if (payload?.sessionId) {
+      await this.authService.logout(payload.sessionId);
+    }
+  }
+}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,0 +1,31 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import type { ConfigType } from '@nestjs/config';
+import { jwtConfig } from '../config/jwt.config';
+import { User } from '../users/entities/user.entity';
+import { RefreshToken } from './entities/refresh-token.entity';
+import { Session } from './entities/session.entity';
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+import { JwtStrategy } from './strategies/jwt.strategy';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([User, RefreshToken, Session]),
+    PassportModule,
+    JwtModule.registerAsync({
+      inject: [jwtConfig.KEY],
+      useFactory: (jwt: ConfigType<typeof jwtConfig>) => ({
+        secret: jwt.accessSecret,
+        signOptions: { expiresIn: jwt.accessExpiry as unknown as number },
+      }),
+    }),
+  ],
+  controllers: [AuthController],
+  providers: [AuthService, JwtStrategy, JwtAuthGuard],
+  exports: [JwtAuthGuard, AuthService],
+})
+export class AuthModule {}

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,0 +1,278 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { JwtService } from '@nestjs/jwt';
+import { ConflictException, UnauthorizedException } from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
+import { AuthService } from './auth.service';
+import { User } from '../users/entities/user.entity';
+import { RefreshToken } from './entities/refresh-token.entity';
+import { Session } from './entities/session.entity';
+import { jwtConfig } from '../config/jwt.config';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockUserRepo = {
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+};
+
+const mockTokenRepo = {
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+};
+
+const mockSessionRepo = {
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+};
+
+const mockJwtService = {
+  sign: jest.fn(),
+  verify: jest.fn(),
+  decode: jest.fn(),
+};
+
+const mockJwtConfig = {
+  accessSecret: 'access-secret-32-chars-minimum!!',
+  refreshSecret: 'refresh-secret-32-chars-minimum!!',
+  accessExpiry: '15m',
+  refreshExpiry: '30d',
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const makeUser = (overrides: Partial<User> = {}): User =>
+  ({
+    id: 'user-uuid-1',
+    email: 'alice@example.com',
+    username: 'alice',
+    passwordHash: '$2b$12$hashedpassword',
+    isAdmin: false,
+    isActive: true,
+    isTreasury: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as User);
+
+const makeRefreshToken = (overrides: Partial<RefreshToken> = {}): RefreshToken =>
+  ({
+    id: 'rt-uuid-1',
+    userId: 'user-uuid-1',
+    tokenHash: 'a'.repeat(64),
+    sessionId: 'session-uuid-1',
+    deviceInfo: null,
+    ipAddress: null,
+    expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    revokedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as RefreshToken);
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: getRepositoryToken(User), useValue: mockUserRepo },
+        { provide: getRepositoryToken(RefreshToken), useValue: mockTokenRepo },
+        { provide: getRepositoryToken(Session), useValue: mockSessionRepo },
+        { provide: JwtService, useValue: mockJwtService },
+        { provide: jwtConfig.KEY, useValue: mockJwtConfig },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+  });
+
+  // ── register ───────────────────────────────────────────────────────────────
+
+  describe('register', () => {
+    it('creates a user and returns a token pair', async () => {
+      mockUserRepo.findOne.mockResolvedValue(null); // no existing email/username
+      const user = makeUser();
+      mockUserRepo.create.mockReturnValue(user);
+      mockUserRepo.save.mockResolvedValue(user);
+
+      const savedToken = makeRefreshToken();
+      mockTokenRepo.create.mockReturnValue(savedToken);
+      mockTokenRepo.save.mockResolvedValue(savedToken);
+      mockSessionRepo.create.mockReturnValue({});
+      mockSessionRepo.save.mockResolvedValue({});
+
+      mockJwtService.sign
+        .mockReturnValueOnce('access-token')
+        .mockReturnValueOnce('refresh-token');
+
+      const result = await service.register({
+        email: 'alice@example.com',
+        username: 'alice',
+        password: 'password123',
+      });
+
+      expect(result.accessToken).toBe('access-token');
+      expect(result.refreshToken).toBe('refresh-token');
+      expect(result.expiresIn).toBe(900); // 15m in seconds
+    });
+
+    it('throws ConflictException when email already exists', async () => {
+      mockUserRepo.findOne
+        .mockResolvedValueOnce(makeUser()) // email exists
+        .mockResolvedValueOnce(null);
+
+      await expect(
+        service.register({ email: 'alice@example.com', username: 'alice', password: 'pass1234' }),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('throws ConflictException when username already exists', async () => {
+      mockUserRepo.findOne
+        .mockResolvedValueOnce(null)       // email ok
+        .mockResolvedValueOnce(makeUser()); // username taken
+
+      await expect(
+        service.register({ email: 'new@example.com', username: 'alice', password: 'pass1234' }),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  // ── login ──────────────────────────────────────────────────────────────────
+
+  describe('login', () => {
+    it('returns a token pair for valid credentials', async () => {
+      const hash = await bcrypt.hash('password123', 4); // low cost for tests
+      const user = makeUser({ passwordHash: hash });
+      mockUserRepo.findOne.mockResolvedValue(user);
+
+      const savedToken = makeRefreshToken();
+      mockTokenRepo.create.mockReturnValue(savedToken);
+      mockTokenRepo.save.mockResolvedValue(savedToken);
+      mockSessionRepo.create.mockReturnValue({});
+      mockSessionRepo.save.mockResolvedValue({});
+
+      mockJwtService.sign
+        .mockReturnValueOnce('access-token')
+        .mockReturnValueOnce('refresh-token');
+
+      const result = await service.login({ email: 'alice@example.com', password: 'password123' });
+      expect(result.accessToken).toBe('access-token');
+    });
+
+    it('throws UnauthorizedException for wrong password', async () => {
+      const hash = await bcrypt.hash('realpassword', 4);
+      mockUserRepo.findOne.mockResolvedValue(makeUser({ passwordHash: hash }));
+
+      await expect(
+        service.login({ email: 'alice@example.com', password: 'wrongpassword' }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('throws UnauthorizedException when user not found', async () => {
+      mockUserRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.login({ email: 'ghost@example.com', password: 'pass' }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('throws UnauthorizedException for inactive account', async () => {
+      const hash = await bcrypt.hash('password123', 4);
+      mockUserRepo.findOne.mockResolvedValue(makeUser({ passwordHash: hash, isActive: false }));
+
+      await expect(
+        service.login({ email: 'alice@example.com', password: 'password123' }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  // ── refresh ────────────────────────────────────────────────────────────────
+
+  describe('refresh', () => {
+    it('rotates the refresh token and returns a new pair', async () => {
+      const payload = { sub: 'user-uuid-1', username: 'alice', role: 'user', sessionId: 'session-1' };
+      mockJwtService.verify.mockReturnValue(payload);
+
+      const stored = makeRefreshToken({ sessionId: 'session-1' });
+      mockTokenRepo.findOne.mockResolvedValue(stored);
+      mockTokenRepo.save.mockResolvedValue({ ...stored, revokedAt: new Date() });
+
+      const user = makeUser();
+      mockUserRepo.findOne.mockResolvedValue(user);
+
+      const newToken = makeRefreshToken({ id: 'rt-uuid-2' });
+      mockTokenRepo.create.mockReturnValue(newToken);
+      mockTokenRepo.save.mockResolvedValue(newToken);
+      mockSessionRepo.create.mockReturnValue({});
+      mockSessionRepo.save.mockResolvedValue({});
+
+      mockJwtService.sign
+        .mockReturnValueOnce('new-access-token')
+        .mockReturnValueOnce('new-refresh-token');
+
+      const result = await service.refresh('old-refresh-token');
+      expect(result.accessToken).toBe('new-access-token');
+      // Old token should have been revoked
+      expect(mockTokenRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ revokedAt: expect.any(Date) }),
+      );
+    });
+
+    it('throws 401 when refresh token is revoked', async () => {
+      const payload = { sub: 'u1', username: 'alice', role: 'user', sessionId: 's1' };
+      mockJwtService.verify.mockReturnValue(payload);
+
+      const revokedToken = makeRefreshToken({ revokedAt: new Date() });
+      mockTokenRepo.findOne.mockResolvedValue(revokedToken);
+
+      await expect(service.refresh('revoked-token')).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('throws 401 when reusing a revoked refresh token (rotation guard)', async () => {
+      mockJwtService.verify.mockReturnValue({
+        sub: 'u1', username: 'alice', role: 'user', sessionId: 's1',
+      });
+      // Token not found in DB (was previously rotated away)
+      mockTokenRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.refresh('old-revoked-token')).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('throws 401 when verify fails (tampered / expired token)', async () => {
+      mockJwtService.verify.mockImplementation(() => { throw new Error('jwt expired'); });
+
+      await expect(service.refresh('bad-token')).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  // ── logout ─────────────────────────────────────────────────────────────────
+
+  describe('logout', () => {
+    it('revokes the refresh token for the given sessionId', async () => {
+      const token = makeRefreshToken();
+      mockTokenRepo.findOne.mockResolvedValue(token);
+      mockTokenRepo.save.mockResolvedValue({ ...token, revokedAt: new Date() });
+
+      await service.logout('session-uuid-1');
+
+      expect(mockTokenRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ revokedAt: expect.any(Date) }),
+      );
+    });
+
+    it('is a no-op when token not found', async () => {
+      mockTokenRepo.findOne.mockResolvedValue(null);
+      await service.logout('nonexistent-session');
+      expect(mockTokenRepo.save).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,0 +1,223 @@
+import {
+  Injectable,
+  UnauthorizedException,
+  ConflictException,
+  Inject,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { JwtService } from '@nestjs/jwt';
+import type { ConfigType } from '@nestjs/config';
+import * as bcrypt from 'bcrypt';
+import * as crypto from 'crypto';
+import { jwtConfig } from '../config/jwt.config';
+import { User } from '../users/entities/user.entity';
+import { RefreshToken } from './entities/refresh-token.entity';
+import { Session } from './entities/session.entity';
+import type { RegisterDto } from './dto/register.dto';
+import type { LoginDto } from './dto/login.dto';
+import type { TokenResponseDto } from './dto/token-response.dto';
+
+export interface JwtPayload {
+  sub: string;
+  username: string;
+  role: 'admin' | 'user';
+  sessionId: string;
+}
+
+@Injectable()
+export class AuthService {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+
+    @InjectRepository(RefreshToken)
+    private readonly tokenRepo: Repository<RefreshToken>,
+
+    @InjectRepository(Session)
+    private readonly sessionRepo: Repository<Session>,
+
+    private readonly jwtService: JwtService,
+
+    @Inject(jwtConfig.KEY)
+    private readonly jwt: ConfigType<typeof jwtConfig>,
+  ) {}
+
+  // ── Register ────────────────────────────────────────────────────
+
+  async register(
+    dto: RegisterDto,
+    ipAddress?: string,
+    deviceInfo?: Record<string, unknown>,
+  ): Promise<TokenResponseDto> {
+    const [existingEmail, existingUsername] = await Promise.all([
+      this.userRepo.findOne({ where: { email: dto.email } }),
+      this.userRepo.findOne({ where: { username: dto.username } }),
+    ]);
+
+    if (existingEmail) {
+      throw new ConflictException('Email already in use');
+    }
+    if (existingUsername) {
+      throw new ConflictException('Username already taken');
+    }
+
+    const passwordHash = await bcrypt.hash(dto.password, 12);
+    const user = this.userRepo.create({
+      email: dto.email,
+      username: dto.username,
+      passwordHash,
+    });
+    await this.userRepo.save(user);
+
+    const sessionId = crypto.randomUUID();
+    return this.issueTokens(user, sessionId, ipAddress, deviceInfo);
+  }
+
+  // ── Login ───────────────────────────────────────────────────────
+
+  async login(
+    dto: LoginDto,
+    ipAddress?: string,
+    deviceInfo?: Record<string, unknown>,
+  ): Promise<TokenResponseDto> {
+    const user = await this.userRepo.findOne({ where: { email: dto.email } });
+    if (!user) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    const match = await bcrypt.compare(dto.password, user.passwordHash);
+    if (!match) {
+      throw new UnauthorizedException('Invalid credentials');
+    }
+
+    if (!user.isActive) {
+      throw new UnauthorizedException('Account is disabled');
+    }
+
+    const sessionId = crypto.randomUUID();
+    return this.issueTokens(user, sessionId, ipAddress, deviceInfo);
+  }
+
+  // ── Refresh ─────────────────────────────────────────────────────
+
+  async refresh(rawRefreshToken: string): Promise<TokenResponseDto> {
+    let payload: JwtPayload;
+    try {
+      payload = this.jwtService.verify<JwtPayload>(rawRefreshToken, {
+        secret: this.jwt.refreshSecret,
+      });
+    } catch {
+      throw new UnauthorizedException('Invalid or expired refresh token');
+    }
+
+    const tokenHash = this.hashToken(rawRefreshToken);
+    const stored = await this.tokenRepo.findOne({
+      where: { tokenHash, sessionId: payload.sessionId },
+    });
+
+    if (!stored || stored.revokedAt || stored.expiresAt < new Date()) {
+      throw new UnauthorizedException('Refresh token is invalid or revoked');
+    }
+
+    // Revoke old token
+    stored.revokedAt = new Date();
+    await this.tokenRepo.save(stored);
+
+    const user = await this.userRepo.findOne({ where: { id: payload.sub } });
+    if (!user || !user.isActive) {
+      throw new UnauthorizedException('User not found or disabled');
+    }
+
+    return this.issueTokens(user, payload.sessionId);
+  }
+
+  // ── Logout ──────────────────────────────────────────────────────
+
+  async logout(sessionId: string): Promise<void> {
+    const token = await this.tokenRepo.findOne({ where: { sessionId } });
+    if (token && !token.revokedAt) {
+      token.revokedAt = new Date();
+      await this.tokenRepo.save(token);
+    }
+  }
+
+  // ── Issue tokens ────────────────────────────────────────────────
+
+  async issueTokens(
+    user: User,
+    sessionId: string,
+    ipAddress?: string,
+    deviceInfo?: Record<string, unknown>,
+  ): Promise<TokenResponseDto> {
+    const role: 'admin' | 'user' = user.isAdmin ? 'admin' : 'user';
+    const payload: JwtPayload = {
+      sub: user.id,
+      username: user.username,
+      role,
+      sessionId,
+    };
+
+    // @nestjs/jwt v11 signs expect expiresIn as a StringValue; cast to satisfy TS.
+    const accessToken = this.jwtService.sign(payload, {
+      secret: this.jwt.accessSecret,
+      expiresIn: this.jwt.accessExpiry as unknown as number,
+    });
+
+    const rawRefreshToken = this.jwtService.sign(payload, {
+      secret: this.jwt.refreshSecret,
+      expiresIn: this.jwt.refreshExpiry as unknown as number,
+    });
+
+    const refreshExpMs = this.parseExpiry(this.jwt.refreshExpiry);
+    const expiresAt = new Date(Date.now() + refreshExpMs);
+
+    const tokenHash = this.hashToken(rawRefreshToken);
+    const refreshToken = this.tokenRepo.create({
+      userId: user.id,
+      tokenHash,
+      sessionId,
+      deviceInfo: deviceInfo ?? null,
+      ipAddress: ipAddress ?? null,
+      expiresAt,
+    });
+    const savedToken = await this.tokenRepo.save(refreshToken);
+
+    await this.sessionRepo.save(
+      this.sessionRepo.create({
+        userId: user.id,
+        refreshTokenId: savedToken.id,
+        deviceInfo: deviceInfo ?? null,
+        ipAddress: ipAddress ?? null,
+        lastSeenAt: new Date(),
+      }),
+    );
+
+    const accessExpMs = this.parseExpiry(this.jwt.accessExpiry);
+
+    return {
+      accessToken,
+      refreshToken: rawRefreshToken,
+      expiresIn: Math.floor(accessExpMs / 1000),
+    };
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────
+
+  private hashToken(token: string): string {
+    return crypto.createHash('sha256').update(token).digest('hex');
+  }
+
+  /** Converts strings like "15m", "30d", "1h" to milliseconds. */
+  private parseExpiry(expiry: string): number {
+    const units: Record<string, number> = {
+      s: 1000,
+      m: 60 * 1000,
+      h: 60 * 60 * 1000,
+      d: 24 * 60 * 60 * 1000,
+    };
+    const match = /^(\d+)([smhd])$/.exec(expiry);
+    if (!match) return 15 * 60 * 1000;
+    return parseInt(match[1], 10) * (units[match[2]] ?? 1000);
+  }
+}

--- a/backend/src/auth/decorators/public.decorator.ts
+++ b/backend/src/auth/decorators/public.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+
+/** Marks a route as publicly accessible — skips the global JwtAuthGuard. */
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,0 +1,12 @@
+import { IsEmail, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class LoginDto {
+  @ApiProperty({ example: 'alice@example.com' })
+  @IsEmail()
+  email!: string;
+
+  @ApiProperty({ example: 'supersecret123' })
+  @IsString()
+  password!: string;
+}

--- a/backend/src/auth/dto/refresh.dto.ts
+++ b/backend/src/auth/dto/refresh.dto.ts
@@ -1,0 +1,8 @@
+import { IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RefreshDto {
+  @ApiProperty()
+  @IsString()
+  refreshToken!: string;
+}

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -1,0 +1,19 @@
+import { IsEmail, IsString, MinLength, MaxLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RegisterDto {
+  @ApiProperty({ example: 'alice@example.com' })
+  @IsEmail()
+  email!: string;
+
+  @ApiProperty({ example: 'alice99', minLength: 3, maxLength: 50 })
+  @IsString()
+  @MinLength(3)
+  @MaxLength(50)
+  username!: string;
+
+  @ApiProperty({ example: 'supersecret123', minLength: 8 })
+  @IsString()
+  @MinLength(8)
+  password!: string;
+}

--- a/backend/src/auth/dto/token-response.dto.ts
+++ b/backend/src/auth/dto/token-response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class TokenResponseDto {
+  @ApiProperty()
+  accessToken!: string;
+
+  @ApiProperty()
+  refreshToken!: string;
+
+  @ApiProperty({ description: 'Access token lifetime in seconds' })
+  expiresIn!: number;
+}

--- a/backend/src/auth/entities/refresh-token.entity.ts
+++ b/backend/src/auth/entities/refresh-token.entity.ts
@@ -1,0 +1,30 @@
+import { Entity, Column, Index } from 'typeorm';
+import { BaseEntity } from '../../common/entities/base.entity';
+
+@Entity('refresh_tokens')
+@Index(['sessionId'])
+@Index(['userId'])
+export class RefreshToken extends BaseEntity {
+  @Column({ name: 'user_id' })
+  userId!: string;
+
+  /** SHA-256 hash of the raw refresh token value stored in the JWT. */
+  @Column({ name: 'token_hash', length: 64 })
+  tokenHash!: string;
+
+  /** Groups access + refresh pair for a single device session. */
+  @Column({ name: 'session_id' })
+  sessionId!: string;
+
+  @Column({ name: 'device_info', type: 'jsonb', nullable: true })
+  deviceInfo!: Record<string, unknown> | null;
+
+  @Column({ name: 'ip_address', length: 45, nullable: true })
+  ipAddress!: string | null;
+
+  @Column({ name: 'expires_at', type: 'timestamptz' })
+  expiresAt!: Date;
+
+  @Column({ name: 'revoked_at', type: 'timestamptz', nullable: true, default: null })
+  revokedAt!: Date | null;
+}

--- a/backend/src/auth/entities/session.entity.ts
+++ b/backend/src/auth/entities/session.entity.ts
@@ -1,0 +1,21 @@
+import { Entity, Column, Index } from 'typeorm';
+import { BaseEntity } from '../../common/entities/base.entity';
+
+@Entity('sessions')
+@Index(['userId'])
+export class Session extends BaseEntity {
+  @Column({ name: 'user_id' })
+  userId!: string;
+
+  @Column({ name: 'refresh_token_id' })
+  refreshTokenId!: string;
+
+  @Column({ name: 'device_info', type: 'jsonb', nullable: true })
+  deviceInfo!: Record<string, unknown> | null;
+
+  @Column({ name: 'ip_address', length: 45, nullable: true })
+  ipAddress!: string | null;
+
+  @Column({ name: 'last_seen_at', type: 'timestamptz', default: () => 'NOW()' })
+  lastSeenAt!: Date;
+}

--- a/backend/src/auth/guards/jwt-auth.guard.ts
+++ b/backend/src/auth/guards/jwt-auth.guard.ts
@@ -1,0 +1,24 @@
+import { Injectable, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { AuthGuard } from '@nestjs/passport';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor(private readonly reflector: Reflector) {
+    super();
+  }
+
+  canActivate(context: ExecutionContext) {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (isPublic) {
+      return true;
+    }
+
+    return super.canActivate(context);
+  }
+}

--- a/backend/src/auth/strategies/jwt.strategy.ts
+++ b/backend/src/auth/strategies/jwt.strategy.ts
@@ -1,0 +1,34 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import type { ConfigType } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { jwtConfig } from '../../config/jwt.config';
+import { User } from '../../users/entities/user.entity';
+import type { JwtPayload } from '../auth.service';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(
+    @Inject(jwtConfig.KEY)
+    jwt: ConfigType<typeof jwtConfig>,
+
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+  ) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: jwt.accessSecret,
+    });
+  }
+
+  async validate(payload: JwtPayload): Promise<User> {
+    const user = await this.userRepo.findOne({ where: { id: payload.sub } });
+    if (!user || !user.isActive) {
+      throw new Error('Unauthorized');
+    }
+    return user;
+  }
+}

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -6,6 +6,9 @@ export class User extends BaseEntity {
   @Column({ unique: true, length: 255 })
   email!: string;
 
+  @Column({ unique: true, length: 50 })
+  username!: string;
+
   @Column({ name: 'password_hash', length: 255 })
   passwordHash!: string;
 


### PR DESCRIPTION
Implement full JWT auth lifecycle with refresh token rotation
- Add `username` column to `User` entity (unique, length 50)
- Add `RefreshToken` entity: tokenHash (sha256), sessionId, deviceInfo,
  ipAddress, expiresAt, revokedAt
- Add `Session` entity: userId, refreshTokenId, deviceInfo, ipAddress,
  lastSeenAt
- Add RegisterDto, LoginDto, RefreshDto, TokenResponseDto
- Implement AuthService: register (bcrypt cost 12), login, refresh
  (token rotation + revocation check), logout
- JWT payload embeds: userId, username, role, sessionId; access tokens
  expire per JWT_ACCESS_EXPIRY, refresh tokens per JWT_REFRESH_EXPIRY
- Add JwtStrategy: validates access token, loads user from DB
- Add JwtAuthGuard (global via APP_GUARD) + @Public() decorator opt-out
- Add AuthController: POST /auth/register|login|refresh (public),
  POST /auth/logout (guarded)
- Wire AuthModule into AppModule
- Add 13 unit tests covering: register, login, refresh rotation,
  revoked token reuse → 401, logout
closes: #306