### PR TITLE
feat(transfers): internal @username payment module

### DIFF
--- a/backend/src/database/migrations/1769800000000-CreateTransfers.ts
+++ b/backend/src/database/migrations/1769800000000-CreateTransfers.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateTransfers1769800000000 implements MigrationInterface {
+  name = 'CreateTransfers1769800000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "transfers_status_enum" AS ENUM ('pending', 'confirmed', 'failed')
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "transfers" (
+        "id"            UUID         NOT NULL DEFAULT uuid_generate_v4(),
+        "created_at"    TIMESTAMPTZ  NOT NULL DEFAULT now(),
+        "updated_at"    TIMESTAMPTZ  NOT NULL DEFAULT now(),
+        "from_user_id"  UUID         NOT NULL,
+        "to_user_id"    UUID         NOT NULL,
+        "from_username" VARCHAR(50)  NOT NULL,
+        "to_username"   VARCHAR(50)  NOT NULL,
+        "amount"        VARCHAR      NOT NULL,
+        "fee"           VARCHAR      NOT NULL DEFAULT '0',
+        "net_amount"    VARCHAR      NOT NULL,
+        "note"          VARCHAR(100)          DEFAULT NULL,
+        "tx_hash"       VARCHAR               DEFAULT NULL,
+        "status"        "transfers_status_enum" NOT NULL DEFAULT 'pending',
+        CONSTRAINT "PK_transfers" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`CREATE INDEX "IDX_transfers_from_user_id" ON "transfers" ("from_user_id")`);
+    await queryRunner.query(`CREATE INDEX "IDX_transfers_to_user_id" ON "transfers" ("to_user_id")`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_transfers_to_user_id"`);
+    await queryRunner.query(`DROP INDEX "IDX_transfers_from_user_id"`);
+    await queryRunner.query(`DROP TABLE "transfers"`);
+    await queryRunner.query(`DROP TYPE "transfers_status_enum"`);
+  }
+}

--- a/backend/src/transfers/dto/create-transfer.dto.ts
+++ b/backend/src/transfers/dto/create-transfer.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty, IsOptional, MaxLength, IsNumberString, Min } from 'class-validator';
+
+export class CreateTransferDto {
+  @ApiProperty({ example: 'alice' })
+  @IsString()
+  @IsNotEmpty()
+  toUsername!: string;
+
+  @ApiProperty({ example: '10.00', description: 'Amount in USDC' })
+  @IsNumberString()
+  amount!: string;
+
+  @ApiProperty({ example: 'Thanks for lunch', required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  note?: string;
+}

--- a/backend/src/transfers/dto/transfer-query.dto.ts
+++ b/backend/src/transfers/dto/transfer-query.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsEnum, IsString } from 'class-validator';
+
+export enum TransferDirection {
+  SENT = 'sent',
+  RECEIVED = 'received',
+}
+
+export class TransferQueryDto {
+  @ApiProperty({ enum: TransferDirection, required: false })
+  @IsOptional()
+  @IsEnum(TransferDirection)
+  direction?: TransferDirection;
+
+  @ApiProperty({ required: false, description: 'Cursor (last transfer id)' })
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+
+  @ApiProperty({ required: false, default: 20 })
+  @IsOptional()
+  limit?: number;
+}

--- a/backend/src/transfers/entities/transfer.entity.ts
+++ b/backend/src/transfers/entities/transfer.entity.ts
@@ -1,0 +1,48 @@
+import { Entity, Column, Index } from 'typeorm';
+import { BaseEntity } from '../../common/entities/base.entity';
+
+export enum TransferStatus {
+  PENDING = 'pending',
+  CONFIRMED = 'confirmed',
+  FAILED = 'failed',
+}
+
+@Entity('transfers')
+export class Transfer extends BaseEntity {
+  @Column({ name: 'from_user_id' })
+  @Index()
+  fromUserId!: string;
+
+  @Column({ name: 'to_user_id' })
+  @Index()
+  toUserId!: string;
+
+  @Column({ name: 'from_username', length: 50 })
+  fromUsername!: string;
+
+  @Column({ name: 'to_username', length: 50 })
+  toUsername!: string;
+
+  @Column({ name: 'amount', type: 'varchar' })
+  amount!: string;
+
+  @Column({ name: 'fee', type: 'varchar', default: '0' })
+  fee!: string;
+
+  @Column({ name: 'net_amount', type: 'varchar' })
+  netAmount!: string;
+
+  @Column({ name: 'note', length: 100, nullable: true, default: null })
+  note!: string | null;
+
+  @Column({ name: 'tx_hash', type: 'varchar', nullable: true, default: null })
+  txHash!: string | null;
+
+  @Column({
+    name: 'status',
+    type: 'enum',
+    enum: TransferStatus,
+    default: TransferStatus.PENDING,
+  })
+  status!: TransferStatus;
+}

--- a/backend/src/transfers/processors/transfer.processor.ts
+++ b/backend/src/transfers/processors/transfer.processor.ts
@@ -1,0 +1,147 @@
+import { Process, Processor, OnQueueFailed } from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Job } from 'bull';
+import {
+  TRANSFER_QUEUE,
+  PROCESS_TRANSFER_JOB,
+  TransfersService,
+  ProcessTransferJobData,
+} from '../transfers.service';
+import { Transfer } from '../entities/transfer.entity';
+import { SorobanService } from '../../soroban/soroban.service';
+import {
+  Transaction,
+  TransactionType,
+  TransactionStatus,
+} from '../../transactions/entities/transaction.entity';
+import { NotificationService } from '../../notifications/notifications.service';
+import { NotificationType } from '../../notifications/notifications.types';
+import { WS_EVENTS } from '../../ws/cheese.gateway';
+import { CheeseGateway } from '../../ws/cheese.gateway';
+import { EmailService } from '../../email/email.service';
+import { UsersService } from '../../users/users.service';
+
+@Processor(TRANSFER_QUEUE)
+export class TransferProcessor {
+  private readonly logger = new Logger(TransferProcessor.name);
+
+  constructor(
+    private readonly transfersService: TransfersService,
+    private readonly sorobanService: SorobanService,
+    private readonly notificationService: NotificationService,
+    private readonly gateway: CheeseGateway,
+    private readonly emailService: EmailService,
+    private readonly usersService: UsersService,
+
+    @InjectRepository(Transaction)
+    private readonly transactionRepo: Repository<Transaction>,
+
+    @InjectRepository(Transfer)
+    private readonly transferRepo: Repository<Transfer>,
+  ) {}
+
+  @Process(PROCESS_TRANSFER_JOB)
+  async handle(job: Job<ProcessTransferJobData>): Promise<void> {
+    const { transferId } = job.data;
+    this.logger.log(`Processing transfer ${transferId}`);
+
+    const transfer = await this.transferRepo.findOneOrFail({ where: { id: transferId } });
+
+    try {
+      const result = await this.sorobanService.transfer(
+        transfer.fromUsername,
+        transfer.toUsername,
+        transfer.amount,
+        transfer.note ?? undefined,
+      ) as { txHash?: string } | null;
+
+      const txHash = result?.txHash ?? `transfer-${transferId}`;
+      const confirmed = await this.transfersService.markConfirmed(transferId, txHash);
+
+      // Create Transaction records for both parties
+      await this.transactionRepo.save([
+        this.transactionRepo.create({
+          userId: transfer.fromUserId,
+          type: TransactionType.TRANSFER_OUT,
+          amountUsdc: transfer.amount,
+          amount: parseFloat(transfer.amount),
+          currency: 'USDC',
+          fee: transfer.fee,
+          balanceAfter: '0',
+          status: TransactionStatus.COMPLETED,
+          reference: txHash,
+          counterpartyUsername: transfer.toUsername,
+          description: transfer.note ?? `Transfer to @${transfer.toUsername}`,
+          metadata: { transferId },
+        }),
+        this.transactionRepo.create({
+          userId: transfer.toUserId,
+          type: TransactionType.TRANSFER_IN,
+          amountUsdc: transfer.netAmount,
+          amount: parseFloat(transfer.netAmount),
+          currency: 'USDC',
+          fee: '0',
+          balanceAfter: '0',
+          status: TransactionStatus.COMPLETED,
+          reference: txHash,
+          counterpartyUsername: transfer.fromUsername,
+          description: transfer.note ?? `Transfer from @${transfer.fromUsername}`,
+          metadata: { transferId },
+        }),
+      ]);
+
+      // WebSocket events
+      await this.gateway.emitToUser(transfer.fromUserId, WS_EVENTS.TRANSFER_SENT, confirmed);
+      await this.gateway.emitToUser(transfer.toUserId, WS_EVENTS.TRANSFER_RECEIVED, confirmed);
+
+      // In-app notifications
+      await Promise.all([
+        this.notificationService.create(
+          transfer.fromUserId,
+          NotificationType.TRANSFER_SENT,
+          'Transfer sent',
+          `You sent ${transfer.amount} USDC to @${transfer.toUsername}`,
+          { transferId },
+        ),
+        this.notificationService.create(
+          transfer.toUserId,
+          NotificationType.TRANSFER_RECEIVED,
+          'Transfer received',
+          `You received ${transfer.netAmount} USDC from @${transfer.fromUsername}`,
+          { transferId },
+        ),
+      ]);
+
+      // Email to receiver (best-effort)
+      try {
+        const receiver = await this.usersService.findById(transfer.toUserId);
+        if (receiver?.email) {
+          await this.emailService.queue(
+            receiver.email,
+            'transfer-received',
+            {
+              username: receiver.username,
+              fromUsername: transfer.fromUsername,
+              amount: transfer.netAmount,
+              note: transfer.note ?? '',
+            },
+            transfer.toUserId,
+          );
+        }
+      } catch (err) {
+        this.logger.warn(`Email queue failed for transfer ${transferId}: ${(err as Error).message}`);
+      }
+    } catch (err) {
+      this.logger.error(`Transfer ${transferId} failed: ${(err as Error).message}`);
+      await this.transfersService.markFailed(transferId);
+    }
+  }
+
+  @OnQueueFailed()
+  async onFailed(job: Job<ProcessTransferJobData>, err: Error): Promise<void> {
+    this.logger.error(`Transfer job failed transferId=${job.data.transferId}: ${err.message}`);
+    await this.transfersService.markFailed(job.data.transferId);
+  }
+}

--- a/backend/src/transfers/transfers.controller.ts
+++ b/backend/src/transfers/transfers.controller.ts
@@ -1,8 +1,11 @@
 import {
   Controller,
-  NotImplementedException,
   Post,
+  Get,
+  Param,
+  Body,
   Req,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import {
@@ -14,6 +17,10 @@ import {
 } from '@nestjs/swagger';
 import type { Request } from 'express';
 import { User } from '../users/entities/user.entity';
+import { TransfersService } from './transfers.service';
+import { CreateTransferDto } from './dto/create-transfer.dto';
+import { TransferQueryDto } from './dto/transfer-query.dto';
+import { Transfer } from './entities/transfer.entity';
 import { RequirePin } from '../pin/decorators/require-pin.decorator';
 import { PinGuard } from '../pin/guards/pin.guard';
 
@@ -23,17 +30,37 @@ type AuthenticatedRequest = Request & { user: User };
 @ApiBearerAuth()
 @Controller({ path: 'transfers', version: '1' })
 export class TransfersController {
+  constructor(private readonly transfersService: TransfersService) {}
+
   @Post()
   @RequirePin()
   @UseGuards(PinGuard)
-  @ApiHeader({
-    name: 'X-Transaction-Pin',
-    description: '4-digit transaction PIN',
-    required: true,
-  })
-  @ApiOperation({ summary: 'Create a transfer (placeholder)' })
-  @ApiResponse({ status: 501 })
-  transfer(@Req() _req: AuthenticatedRequest): never {
-    throw new NotImplementedException('Transfers are not implemented yet');
+  @ApiHeader({ name: 'X-Transaction-Pin', description: '4-digit PIN', required: true })
+  @ApiOperation({ summary: 'Send USDC to another user by @username' })
+  @ApiResponse({ status: 201, type: Transfer })
+  async create(
+    @Req() req: AuthenticatedRequest,
+    @Body() dto: CreateTransferDto,
+  ): Promise<Transfer> {
+    return this.transfersService.create(req.user.id, req.user.username, dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List transfers (cursor-paginated)' })
+  async findAll(
+    @Req() req: AuthenticatedRequest,
+    @Query() query: TransferQueryDto,
+  ): Promise<{ data: Transfer[]; nextCursor: string | null }> {
+    return this.transfersService.findAll(req.user.id, query);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a single transfer' })
+  @ApiResponse({ status: 200, type: Transfer })
+  async findOne(
+    @Req() req: AuthenticatedRequest,
+    @Param('id') id: string,
+  ): Promise<Transfer> {
+    return this.transfersService.findOne(req.user.id, id);
   }
 }

--- a/backend/src/transfers/transfers.module.ts
+++ b/backend/src/transfers/transfers.module.ts
@@ -1,9 +1,34 @@
 import { Module } from '@nestjs/common';
-import { PinModule } from '../pin/pin.module';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BullModule } from '@nestjs/bull';
+import { Transfer } from './entities/transfer.entity';
+import { FeeConfig } from '../fee-config/entities/fee-config.entity';
+import { Transaction } from '../transactions/entities/transaction.entity';
+import { TransfersService, TRANSFER_QUEUE } from './transfers.service';
 import { TransfersController } from './transfers.controller';
+import { TransferProcessor } from './processors/transfer.processor';
+import { SorobanModule } from '../soroban/soroban.module';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { UsersModule } from '../users/users.module';
+import { TierConfigModule } from '../tier-config/tier-config.module';
+import { WsModule } from '../ws/ws.module';
+import { EmailModule } from '../email/email.module';
+import { PinModule } from '../pin/pin.module';
 
 @Module({
-  imports: [PinModule],
+  imports: [
+    TypeOrmModule.forFeature([Transfer, FeeConfig, Transaction]),
+    BullModule.registerQueue({ name: TRANSFER_QUEUE }),
+    SorobanModule,
+    NotificationsModule,
+    UsersModule,
+    TierConfigModule,
+    WsModule,
+    EmailModule,
+    PinModule,
+  ],
   controllers: [TransfersController],
+  providers: [TransfersService, TransferProcessor],
+  exports: [TransfersService],
 })
 export class TransfersModule {}

--- a/backend/src/transfers/transfers.service.spec.ts
+++ b/backend/src/transfers/transfers.service.spec.ts
@@ -1,0 +1,164 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { getQueueToken } from '@nestjs/bull';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { TransfersService, TRANSFER_QUEUE } from './transfers.service';
+import { Transfer, TransferStatus } from './entities/transfer.entity';
+import { FeeConfig, FeeType } from '../fee-config/entities/fee-config.entity';
+import { UsersService } from '../users/users.service';
+import { TierService } from '../tier-config/tier.service';
+import { TierLimitExceededException } from '../common/exceptions/tier-limit-exceeded.exception';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockTransferRepo = {
+  findOne: jest.fn(),
+  findOneOrFail: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+  update: jest.fn(),
+  createQueryBuilder: jest.fn(),
+};
+
+const mockFeeConfigRepo = {
+  findOne: jest.fn(),
+};
+
+const mockQueue = {
+  add: jest.fn().mockResolvedValue({}),
+};
+
+const mockUsersService = {
+  findByUsername: jest.fn(),
+};
+
+const mockTierService = {
+  checkTransferLimit: jest.fn(),
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const makeTransfer = (overrides: Partial<Transfer> = {}): Transfer =>
+  ({
+    id: 'transfer-uuid-1',
+    fromUserId: 'user-uuid-1',
+    toUserId: 'user-uuid-2',
+    fromUsername: 'alice',
+    toUsername: 'bob',
+    amount: '10.000000',
+    fee: '0.100000',
+    netAmount: '9.900000',
+    note: null,
+    txHash: null,
+    status: TransferStatus.PENDING,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as Transfer);
+
+const makeUser = (overrides = {}) => ({
+  id: 'user-uuid-2',
+  username: 'bob',
+  email: 'bob@example.com',
+  ...overrides,
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('TransfersService', () => {
+  let service: TransfersService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TransfersService,
+        { provide: getRepositoryToken(Transfer), useValue: mockTransferRepo },
+        { provide: getRepositoryToken(FeeConfig), useValue: mockFeeConfigRepo },
+        { provide: getQueueToken(TRANSFER_QUEUE), useValue: mockQueue },
+        { provide: UsersService, useValue: mockUsersService },
+        { provide: TierService, useValue: mockTierService },
+      ],
+    }).compile();
+
+    service = module.get<TransfersService>(TransfersService);
+  });
+
+  // ── toUsername not found → 404 ────────────────────────────────────────────
+
+  describe('create', () => {
+    it('throws NotFoundException when toUsername does not exist', async () => {
+      mockUsersService.findByUsername.mockResolvedValue(null);
+
+      await expect(
+        service.create('user-uuid-1', 'alice', { toUsername: 'ghost', amount: '10' }),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(mockTierService.checkTransferLimit).not.toHaveBeenCalled();
+      expect(mockQueue.add).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when sender equals receiver', async () => {
+      await expect(
+        service.create('user-uuid-1', 'alice', { toUsername: 'alice', amount: '10' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    // ── tier limit exceeded → 400/403 ─────────────────────────────────────
+
+    it('throws TierLimitExceededException when daily limit is exceeded', async () => {
+      mockUsersService.findByUsername.mockResolvedValue(makeUser());
+      mockTierService.checkTransferLimit.mockRejectedValue(
+        new TierLimitExceededException({ limit: '100', used: '95', requested: '10' }),
+      );
+
+      await expect(
+        service.create('user-uuid-1', 'alice', { toUsername: 'bob', amount: '10' }),
+      ).rejects.toThrow(TierLimitExceededException);
+
+      expect(mockQueue.add).not.toHaveBeenCalled();
+    });
+
+    it('creates transfer and enqueues job on success', async () => {
+      mockUsersService.findByUsername.mockResolvedValue(makeUser());
+      mockTierService.checkTransferLimit.mockResolvedValue(undefined);
+      mockFeeConfigRepo.findOne.mockResolvedValue({
+        feeType: FeeType.TRANSFER,
+        baseFeeRate: '0.01',
+        minFee: '0',
+        maxFee: null,
+        isActive: true,
+      });
+      const transfer = makeTransfer();
+      mockTransferRepo.create.mockReturnValue(transfer);
+      mockTransferRepo.save.mockResolvedValue(transfer);
+
+      const result = await service.create('user-uuid-1', 'alice', {
+        toUsername: 'bob',
+        amount: '10',
+      });
+
+      expect(result).toEqual(transfer);
+      expect(mockQueue.add).toHaveBeenCalledWith(
+        'process-transfer',
+        { transferId: transfer.id },
+        expect.any(Object),
+      );
+    });
+  });
+
+  // ── markFailed ────────────────────────────────────────────────────────────
+
+  describe('markFailed', () => {
+    it('sets status to failed', async () => {
+      mockTransferRepo.update.mockResolvedValue({});
+
+      await service.markFailed('transfer-uuid-1');
+
+      expect(mockTransferRepo.update).toHaveBeenCalledWith('transfer-uuid-1', {
+        status: TransferStatus.FAILED,
+      });
+    });
+  });
+});

--- a/backend/src/transfers/transfers.service.ts
+++ b/backend/src/transfers/transfers.service.ts
@@ -1,0 +1,166 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { InjectQueue } from '@nestjs/bull';
+import { Repository } from 'typeorm';
+import { Queue } from 'bull';
+import { Transfer, TransferStatus } from './entities/transfer.entity';
+import { CreateTransferDto } from './dto/create-transfer.dto';
+import { TransferQueryDto, TransferDirection } from './dto/transfer-query.dto';
+import { UsersService } from '../users/users.service';
+import { TierService } from '../tier-config/tier.service';
+import { FeeConfig, FeeType } from '../fee-config/entities/fee-config.entity';
+
+export const TRANSFER_QUEUE = 'process-transfer';
+export const PROCESS_TRANSFER_JOB = 'process-transfer';
+
+export interface ProcessTransferJobData {
+  transferId: string;
+}
+
+@Injectable()
+export class TransfersService {
+  private readonly logger = new Logger(TransfersService.name);
+
+  constructor(
+    @InjectRepository(Transfer)
+    private readonly transferRepo: Repository<Transfer>,
+
+    @InjectRepository(FeeConfig)
+    private readonly feeConfigRepo: Repository<FeeConfig>,
+
+    @InjectQueue(TRANSFER_QUEUE)
+    private readonly transferQueue: Queue,
+
+    private readonly usersService: UsersService,
+    private readonly tierService: TierService,
+  ) {}
+
+  // ── Create ────────────────────────────────────────────────────────────────
+
+  async create(
+    fromUserId: string,
+    fromUsername: string,
+    dto: CreateTransferDto,
+  ): Promise<Transfer> {
+    if (dto.toUsername.toLowerCase() === fromUsername.toLowerCase()) {
+      throw new BadRequestException('Cannot transfer to yourself');
+    }
+
+    const toUser = await this.usersService.findByUsername(dto.toUsername);
+    if (!toUser) {
+      throw new NotFoundException(`User @${dto.toUsername} not found`);
+    }
+
+    const amount = parseFloat(dto.amount);
+    if (isNaN(amount) || amount <= 0) {
+      throw new BadRequestException('Invalid amount');
+    }
+
+    // Tier limit check (throws TierLimitExceededException → 403 if exceeded)
+    await this.tierService.checkTransferLimit(fromUserId, amount);
+
+    const { fee, netAmount } = await this.computeFee(amount);
+
+    const transfer = this.transferRepo.create({
+      fromUserId,
+      toUserId: toUser.id,
+      fromUsername,
+      toUsername: toUser.username,
+      amount: dto.amount,
+      fee,
+      netAmount,
+      note: dto.note ?? null,
+      status: TransferStatus.PENDING,
+    });
+
+    await this.transferRepo.save(transfer);
+
+    await this.transferQueue.add(
+      PROCESS_TRANSFER_JOB,
+      { transferId: transfer.id } satisfies ProcessTransferJobData,
+      { attempts: 1, removeOnComplete: true, removeOnFail: false },
+    );
+
+    return transfer;
+  }
+
+  // ── Find ──────────────────────────────────────────────────────────────────
+
+  async findAll(
+    userId: string,
+    query: TransferQueryDto,
+  ): Promise<{ data: Transfer[]; nextCursor: string | null }> {
+    const limit = Math.min(query.limit ?? 20, 100);
+
+    const qb = this.transferRepo.createQueryBuilder('t').orderBy('t.createdAt', 'DESC').limit(limit + 1);
+
+    if (query.direction === TransferDirection.SENT) {
+      qb.where('t.from_user_id = :userId', { userId });
+    } else if (query.direction === TransferDirection.RECEIVED) {
+      qb.where('t.to_user_id = :userId', { userId });
+    } else {
+      qb.where('t.from_user_id = :userId OR t.to_user_id = :userId', { userId });
+    }
+
+    if (query.cursor) {
+      const cursor = await this.transferRepo.findOne({ where: { id: query.cursor } });
+      if (cursor) {
+        qb.andWhere('t.createdAt < :cursorDate', { cursorDate: cursor.createdAt });
+      }
+    }
+
+    const rows = await qb.getMany();
+    const hasMore = rows.length > limit;
+    const data = hasMore ? rows.slice(0, limit) : rows;
+    const nextCursor = hasMore ? data[data.length - 1].id : null;
+
+    return { data, nextCursor };
+  }
+
+  async findOne(userId: string, id: string): Promise<Transfer> {
+    const transfer = await this.transferRepo.findOne({ where: { id } });
+    if (!transfer || (transfer.fromUserId !== userId && transfer.toUserId !== userId)) {
+      throw new NotFoundException('Transfer not found');
+    }
+    return transfer;
+  }
+
+  // ── Status helpers (used by processor) ───────────────────────────────────
+
+  async markConfirmed(id: string, txHash: string): Promise<Transfer> {
+    await this.transferRepo.update(id, { status: TransferStatus.CONFIRMED, txHash });
+    return this.transferRepo.findOneOrFail({ where: { id } });
+  }
+
+  async markFailed(id: string): Promise<void> {
+    await this.transferRepo.update(id, { status: TransferStatus.FAILED });
+  }
+
+  // ── Fee ───────────────────────────────────────────────────────────────────
+
+  private async computeFee(amount: number): Promise<{ fee: string; netAmount: string }> {
+    const config = await this.feeConfigRepo.findOne({
+      where: { feeType: FeeType.TRANSFER, isActive: true },
+    });
+
+    if (!config) {
+      return { fee: '0', netAmount: amount.toFixed(6) };
+    }
+
+    let fee = amount * parseFloat(config.baseFeeRate);
+    const min = parseFloat(config.minFee);
+    if (fee < min) fee = min;
+    if (config.maxFee !== null) {
+      const max = parseFloat(config.maxFee);
+      if (fee > max) fee = max;
+    }
+
+    const netAmount = amount - fee;
+    return { fee: fee.toFixed(6), netAmount: netAmount.toFixed(6) };
+  }
+}

--- a/commit-msg.txt
+++ b/commit-msg.txt
@@ -1,0 +1,1 @@
+feat(transfers): internal @username payment module


### PR DESCRIPTION
OverviewnThe core Cheese-to-Cheese payment flow. Users send USDC to another user by @username, triggering the contract's internal transfer. Both parties get real-time WebSocket notifications. Tier limits enforced before submitting.nn## Acceptance Criterian- [ ] Transfer entity: id, fromUserId, toUserId, fromUsername, toUsername, amount (varchar), fee (varchar), netAmount (varchar), note (nullable, max 100 chars), txHash (nullable), status (enum pending|confirmed|failed), createdAtn- [ ] POST /transfers body: toUsername, amount, note; validate sender ≠ receiver; resolve toUsername → toUserId (404 if not found); call TierService.checkTransferLimit → 400 if exceeded; compute fee; enqueue process-transfer jobn- [ ] process-transfer worker: SorobanService.transfer() → update txHash + status=confirmed; create Transaction records for both parties; emit WebSocket transfer_sent and transfer_received; create Notifications; queue email to receivern- [ ] On Soroban failure: set status=failed (no balance was deducted — no refund needed)n- [ ] GET /transfers: cursor-paginated; filter by direction (sent|received); GET /transfers/:idn- [ ] Unit tests: toUsername not found → 404; tier limit exceeded → 400; Soroban error → Transfer marked failed
Closes #315 