### PR TITLE
feat: define typed contract Error enum + ERROR_CODES.md (closes #281)

### DIFF
--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -1,0 +1,23 @@
+# ERROR_CODES.md
+
+| Code | Variant | Description | HTTP Status |
+|------|---------|-------------|-------------|
+| 1  | AlreadyInitialized       | initialize() already called                        | 409 Conflict             |
+| 2  | NotInitialized           | Called before initialize()                         | 503 Service Unavailable  |
+| 3  | ContractPaused           | Contract is administratively paused                | 503 Service Unavailable  |
+| 4  | Unauthorized             | Caller lacks required role/ownership               | 403 Forbidden            |
+| 5  | InsufficientBalance      | Sender balance below transfer amount               | 402 Payment Required     |
+| 6  | InvalidAmount            | Amount is zero or out of bounds                    | 400 Bad Request          |
+| 7  | SelfTransfer             | Sender and recipient are the same address          | 400 Bad Request          |
+| 8  | PayLinkNotFound          | No PayLink for supplied identifier                 | 404 Not Found            |
+| 9  | PayLinkAlreadyPaid       | PayLink already settled                            | 409 Conflict             |
+| 10 | PayLinkCancelled         | PayLink was cancelled                              | 410 Gone                 |
+| 11 | PayLinkAlreadyExists     | PayLink with that ID already exists                | 409 Conflict             |
+| 12 | PayLinkExpired           | PayLink expiration timestamp passed                | 410 Gone                 |
+| 13 | NotPayLinkCreator        | Caller is not the PayLink creator                  | 403 Forbidden            |
+| 14 | FeeTooHigh               | Proposed fee exceeds protocol maximum              | 400 Bad Request          |
+| 15 | UsernameAlreadyRegistered| Username already taken                             | 409 Conflict             |
+| 16 | UserAlreadyRegistered    | Address already registered                         | 409 Conflict             |
+| 17 | UserNotFound             | No user record for address/identifier              | 404 Not Found            |
+
+> Never renumber or remove variants after deployment — codes are stored on-chain.

--- a/contracts/cheese_pay/src/errors.rs
+++ b/contracts/cheese_pay/src/errors.rs
@@ -1,0 +1,60 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Clone, Debug, PartialEq)]
+pub enum Error {
+    // Lifecycle
+    AlreadyInitialized      = 1,
+    NotInitialized          = 2,
+    ContractPaused          = 3,
+    Unauthorized            = 4,
+    // Token / Balance
+    InsufficientBalance     = 5,
+    InvalidAmount           = 6,
+    SelfTransfer            = 7,
+    // PayLink
+    PayLinkNotFound         = 8,
+    PayLinkAlreadyPaid      = 9,
+    PayLinkCancelled        = 10,
+    PayLinkAlreadyExists    = 11,
+    PayLinkExpired          = 12,
+    NotPayLinkCreator       = 13,
+    // Fees / Users
+    FeeTooHigh              = 14,
+    UsernameAlreadyRegistered = 15,
+    UserAlreadyRegistered   = 16,
+    UserNotFound            = 17,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+
+    #[test]
+    fn discriminants_are_stable() {
+        assert_eq!(Error::AlreadyInitialized as u32, 1);
+        assert_eq!(Error::NotInitialized as u32, 2);
+        assert_eq!(Error::ContractPaused as u32, 3);
+        assert_eq!(Error::Unauthorized as u32, 4);
+        assert_eq!(Error::InsufficientBalance as u32, 5);
+        assert_eq!(Error::InvalidAmount as u32, 6);
+        assert_eq!(Error::SelfTransfer as u32, 7);
+        assert_eq!(Error::PayLinkNotFound as u32, 8);
+        assert_eq!(Error::PayLinkAlreadyPaid as u32, 9);
+        assert_eq!(Error::PayLinkCancelled as u32, 10);
+        assert_eq!(Error::PayLinkAlreadyExists as u32, 11);
+        assert_eq!(Error::PayLinkExpired as u32, 12);
+        assert_eq!(Error::NotPayLinkCreator as u32, 13);
+        assert_eq!(Error::FeeTooHigh as u32, 14);
+        assert_eq!(Error::UsernameAlreadyRegistered as u32, 15);
+        assert_eq!(Error::UserAlreadyRegistered as u32, 16);
+        assert_eq!(Error::UserNotFound as u32, 17);
+    }
+
+    #[test]
+    fn clone_and_partial_eq() {
+        let a = Error::Unauthorized;
+        assert_eq!(a.clone(), a);
+        assert_ne!(a, Error::ContractPaused);
+    }
+}

--- a/contracts/cheese_pay/src/lib.rs
+++ b/contracts/cheese_pay/src/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 use soroban_sdk::{contract, contractimpl};
 
+pub mod errors;
+pub use errors::Error;
+
 #[contract]
 pub struct CheesePay;
 


### PR DESCRIPTION
Closes #281

Added shared typed error enum to cheese_pay contract so all contract functions return deterministic errors instead of panicking.

- contracts/cheese_pay/src/errors.rs — 17 variants with stable u32 discriminants
- contracts/cheese_pay/src/lib.rs — registered pub mod errors
- ERROR_CODES.md — maps each code to description and HTTP status for NestJS

All acceptance criteria met.