### PR TITLE
feat(stellar): add StellarAssetService for USDC trust line management

### DIFF
--- a/backend/src/blockchain-wallet/blockchain-wallet.module.ts
+++ b/backend/src/blockchain-wallet/blockchain-wallet.module.ts
@@ -10,12 +10,14 @@ import { InternalWalletController } from './internal-wallet.controller';
 import { WalletProvisionedListener } from './listeners/wallet-provisioned.listener';
 import { NotificationModule } from '../notification/notification.module';
 import { UserEntity } from '../database/entities/user.entity';
+import { StellarModule } from '../stellar/stellar.module';
 
 @Module({
   imports: [
     ConfigModule,
     TypeOrmModule.forFeature([BlockchainWallet, UserEntity]),
     NotificationModule,
+    StellarModule,
   ],
   providers: [BlockchainWalletService, SorobanService, WalletProvisionedListener],
   controllers: [WalletController, InternalWalletController],

--- a/backend/src/blockchain-wallet/blockchain-wallet.service.spec.ts
+++ b/backend/src/blockchain-wallet/blockchain-wallet.service.spec.ts
@@ -5,6 +5,7 @@ import { ConfigService } from '@nestjs/config';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { BlockchainWalletService, WALLET_PROVISIONED_EVENT } from './blockchain-wallet.service';
 import { SorobanService } from './soroban.service';
+import { StellarAssetService } from '../stellar/stellar-asset.service';
 import { BlockchainWallet } from './entities/blockchain-wallet.entity';
 
 const MOCK_ENC_KEY = 'test-encryption-key-32-chars-long!!';
@@ -26,6 +27,7 @@ describe('BlockchainWalletService', () => {
   let service: BlockchainWalletService;
   let walletRepo: any;
   let sorobanService: jest.Mocked<SorobanService>;
+  let stellarAssetService: jest.Mocked<StellarAssetService>;
   let eventEmitter: jest.Mocked<EventEmitter2>;
   let configService: jest.Mocked<ConfigService>;
 
@@ -50,6 +52,12 @@ describe('BlockchainWalletService', () => {
           },
         },
         {
+          provide: StellarAssetService,
+          useValue: {
+            ensureTrustLine: jest.fn(),
+          },
+        },
+        {
           provide: ConfigService,
           useValue: {
             get: jest.fn((key: string, def?: any) => {
@@ -70,6 +78,7 @@ describe('BlockchainWalletService', () => {
     service = module.get(BlockchainWalletService);
     walletRepo = module.get(getRepositoryToken(BlockchainWallet));
     sorobanService = module.get(SorobanService);
+    stellarAssetService = module.get(StellarAssetService);
     eventEmitter = module.get(EventEmitter2);
     configService = module.get(ConfigService);
   });
@@ -121,6 +130,29 @@ describe('BlockchainWalletService', () => {
       const result = await service.provision('user-uuid', 'alice');
       expect(result).toBeDefined();
       expect(walletRepo.save).toHaveBeenCalled();
+    });
+
+    it('calls ensureTrustLine before registerUser during provisioning', async () => {
+      walletRepo.findOne.mockResolvedValue(null);
+      const wallet = mockWallet();
+      walletRepo.create.mockReturnValue(wallet);
+      walletRepo.save.mockResolvedValue(wallet);
+
+      const callOrder: string[] = [];
+      stellarAssetService.ensureTrustLine.mockImplementation(async () => {
+        callOrder.push('ensureTrustLine');
+      });
+      sorobanService.registerUser.mockImplementation(async () => {
+        callOrder.push('registerUser');
+      });
+
+      const StellarSdk = require('@stellar/stellar-sdk');
+      const mockFriendbot = { call: jest.fn().mockResolvedValue({}) };
+      jest.spyOn(StellarSdk.Horizon.Server.prototype, 'friendbot').mockReturnValue(mockFriendbot);
+
+      await service.provision('user-uuid', 'alice');
+
+      expect(callOrder).toEqual(['ensureTrustLine', 'registerUser']);
     });
   });
 

--- a/backend/src/blockchain-wallet/blockchain-wallet.service.ts
+++ b/backend/src/blockchain-wallet/blockchain-wallet.service.ts
@@ -17,6 +17,7 @@ import {
 import * as StellarSdk from '@stellar/stellar-sdk';
 import { BlockchainWallet } from './entities/blockchain-wallet.entity';
 import { SorobanService } from './soroban.service';
+import { StellarAssetService } from '../stellar/stellar-asset.service';
 
 export const WALLET_PROVISIONED_EVENT = 'wallet.provisioned';
 
@@ -30,6 +31,7 @@ export class BlockchainWalletService {
     @InjectRepository(BlockchainWallet)
     private readonly walletRepo: Repository<BlockchainWallet>,
     private readonly sorobanService: SorobanService,
+    private readonly stellarAssetService: StellarAssetService,
     private readonly configService: ConfigService,
     private readonly eventEmitter: EventEmitter2,
   ) {
@@ -66,6 +68,7 @@ export class BlockchainWalletService {
 
     // 4. Register on Soroban contract
     try {
+      await this.stellarAssetService.ensureTrustLine(publicKey, secretKey);
       await this.sorobanService.registerUser(username, publicKey);
     } catch (err: any) {
       this.logger.warn(`Soroban registerUser failed for ${userId}: ${err.message}`);

--- a/backend/src/soroban/controllers/soroban-admin.controller.ts
+++ b/backend/src/soroban/controllers/soroban-admin.controller.ts
@@ -7,6 +7,7 @@ import { Role } from '../../rbac/enums/role.enum';
 import { ContractEventListenerService } from '../services/contract-event-listener.service';
 import { ContractEventType } from '../entities/contract-event-log.entity';
 import { PaginatedContractEventsDto, PaginatedReconciliationAlertsDto } from '../dto/soroban.dto';
+import { StellarAssetService } from '../../stellar/stellar-asset.service';
 
 /**
  * SorobanAdminController
@@ -20,7 +21,10 @@ import { PaginatedContractEventsDto, PaginatedReconciliationAlertsDto } from '..
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Roles(Role.ADMIN, Role.SUPER_ADMIN)
 export class SorobanAdminController {
-  constructor(private readonly contractEventListenerService: ContractEventListenerService) {}
+  constructor(
+    private readonly contractEventListenerService: ContractEventListenerService,
+    private readonly stellarAssetService: StellarAssetService,
+  ) {}
 
   /**
    * GET /admin/blockchain/events
@@ -141,5 +145,11 @@ export class SorobanAdminController {
   ): Promise<{ message: string }> {
     await this.contractEventListenerService.resolveAlert(alertId, resolvedNote);
     return { message: `Alert ${alertId} marked as resolved` };
+  }
+
+  @Get('account/:address')
+  @ApiOperation({ summary: 'Get full Stellar account details including trust lines and balances' })
+  async getAccountDetails(@Param('address') address: string) {
+    return this.stellarAssetService.getAccountDetails(address);
   }
 }

--- a/backend/src/soroban/soroban.module.ts
+++ b/backend/src/soroban/soroban.module.ts
@@ -9,12 +9,14 @@ import { CacheModule } from '../cache/cache.module';
 import { User } from '../users/entities/user.entity';
 import { Transaction } from '../transactions/entities/transaction.entity';
 import { PayLink } from '../paylink/entities/paylink.entity';
+import { StellarModule } from '../stellar/stellar.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([ContractEventLog, ReconciliationAlert, User, Transaction, PayLink]),
     BullModule.registerQueue({ name: 'blockchain-sync' }),
     CacheModule,
+    StellarModule,
   ],
   providers: [SorobanService, ContractEventListenerService],
   controllers: [SorobanAdminController],

--- a/backend/src/stellar/stellar-asset.service.spec.ts
+++ b/backend/src/stellar/stellar-asset.service.spec.ts
@@ -1,0 +1,149 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StellarAssetService } from './stellar-asset.service';
+import { StellarService } from './stellar.service';
+import { stellarConfig } from '../config/stellar.config';
+import { AccountNotFundedException } from './stellar.exceptions';
+
+const USDC_ISSUER = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+
+const mockConfig = {
+  usdcIssuer: USDC_ISSUER,
+  network: 'testnet' as const,
+  rpcUrl: 'https://horizon-testnet.stellar.org',
+  networkPassphrase: 'Test SDF Network ; September 2015',
+  contractId: 'CONTRACT_ID',
+  adminSecretKey: 'SECRET',
+  receiveAddress: 'RECEIVE_ADDRESS',
+};
+
+const mockStellarService = {
+  loadAccount: jest.fn(),
+  buildTransaction: jest.fn(),
+  signTransaction: jest.fn(),
+  submitTransaction: jest.fn(),
+};
+
+describe('StellarAssetService', () => {
+  let service: StellarAssetService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StellarAssetService,
+        { provide: StellarService, useValue: mockStellarService },
+        { provide: stellarConfig.KEY, useValue: mockConfig },
+      ],
+    }).compile();
+
+    service = module.get(StellarAssetService);
+    jest.clearAllMocks();
+  });
+
+  describe('hasTrustLine', () => {
+    it('returns false when USDC not in balances', async () => {
+      mockStellarService.loadAccount.mockResolvedValue({
+        balances: [{ asset_type: 'native', balance: '10.0000000' }],
+        sequence: '1',
+        signers: [],
+      });
+
+      expect(await service.hasTrustLine('GPUBKEY')).toBe(false);
+    });
+
+    it('returns true when USDC trust line exists with correct issuer', async () => {
+      mockStellarService.loadAccount.mockResolvedValue({
+        balances: [
+          { asset_type: 'native', balance: '10.0000000' },
+          { asset_type: 'credit_alphanum4', asset_code: 'USDC', asset_issuer: USDC_ISSUER, balance: '5.0000000' },
+        ],
+        sequence: '1',
+        signers: [],
+      });
+
+      expect(await service.hasTrustLine('GPUBKEY')).toBe(true);
+    });
+
+    it('returns false when USDC exists but with wrong issuer', async () => {
+      mockStellarService.loadAccount.mockResolvedValue({
+        balances: [
+          { asset_type: 'credit_alphanum4', asset_code: 'USDC', asset_issuer: 'WRONGISSUER', balance: '5.0000000' },
+        ],
+        sequence: '1',
+        signers: [],
+      });
+
+      expect(await service.hasTrustLine('GPUBKEY')).toBe(false);
+    });
+  });
+
+  describe('getUsdcBalance', () => {
+    it("returns '0' for account with no trust line", async () => {
+      mockStellarService.loadAccount.mockResolvedValue({
+        balances: [{ asset_type: 'native', balance: '10.0000000' }],
+        sequence: '1',
+        signers: [],
+      });
+
+      expect(await service.getUsdcBalance('GPUBKEY')).toBe('0');
+    });
+
+    it('returns balance string when trust line exists', async () => {
+      mockStellarService.loadAccount.mockResolvedValue({
+        balances: [
+          { asset_type: 'credit_alphanum4', asset_code: 'USDC', asset_issuer: USDC_ISSUER, balance: '42.5000000' },
+        ],
+        sequence: '1',
+        signers: [],
+      });
+
+      expect(await service.getUsdcBalance('GPUBKEY')).toBe('42.5000000');
+    });
+  });
+
+  describe('ensureTrustLine', () => {
+    it('skips creation if trust line already exists', async () => {
+      mockStellarService.loadAccount.mockResolvedValue({
+        balances: [
+          { asset_type: 'credit_alphanum4', asset_code: 'USDC', asset_issuer: USDC_ISSUER, balance: '0.0000000' },
+        ],
+        sequence: '1',
+        signers: [],
+      });
+
+      await service.ensureTrustLine('GPUBKEY', 'SECRET');
+
+      expect(mockStellarService.buildTransaction).not.toHaveBeenCalled();
+      expect(mockStellarService.submitTransaction).not.toHaveBeenCalled();
+    });
+
+    it('creates trust line when missing', async () => {
+      mockStellarService.loadAccount.mockResolvedValue({
+        balances: [{ asset_type: 'native', balance: '10.0000000' }],
+        sequence: '1',
+        signers: [],
+      });
+      mockStellarService.buildTransaction.mockResolvedValue({} as any);
+      mockStellarService.signTransaction.mockReturnValue('signed-xdr');
+      mockStellarService.submitTransaction.mockResolvedValue({});
+
+      await service.ensureTrustLine('GPUBKEY', 'SECRET');
+
+      expect(mockStellarService.buildTransaction).toHaveBeenCalledTimes(1);
+      expect(mockStellarService.submitTransaction).toHaveBeenCalledWith('signed-xdr');
+    });
+  });
+
+  describe('createTrustLine', () => {
+    it('throws AccountNotFundedException when XLM balance is too low', async () => {
+      mockStellarService.loadAccount.mockResolvedValue({
+        balances: [{ asset_type: 'native', balance: '0.5000000' }],
+        sequence: '1',
+        signers: [],
+      });
+
+      await expect(service.createTrustLine('GPUBKEY', 'SECRET')).rejects.toThrow(
+        AccountNotFundedException,
+      );
+    });
+  });
+});

--- a/backend/src/stellar/stellar-asset.service.ts
+++ b/backend/src/stellar/stellar-asset.service.ts
@@ -1,0 +1,83 @@
+import { Injectable, Inject } from '@nestjs/common';
+import * as StellarSdk from 'stellar-sdk';
+import { stellarConfig, StellarConfig } from '../config/stellar.config';
+import { StellarService } from './stellar.service';
+import { AccountNotFundedException } from './stellar.exceptions';
+
+@Injectable()
+export class StellarAssetService {
+  constructor(
+    @Inject(stellarConfig.KEY)
+    private readonly config: StellarConfig,
+    private readonly stellarService: StellarService,
+  ) {}
+
+  getUsdcAsset(): StellarSdk.Asset {
+    return new StellarSdk.Asset('USDC', this.config.usdcIssuer);
+  }
+
+  async hasTrustLine(publicKey: string): Promise<boolean> {
+    const account = await this.stellarService.loadAccount(publicKey);
+    return account.balances.some(
+      (b) =>
+        b.asset_type === 'credit_alphanum4' &&
+        (b as StellarSdk.Horizon.HorizonApi.BalanceLine<'credit_alphanum4'>).asset_code === 'USDC' &&
+        (b as StellarSdk.Horizon.HorizonApi.BalanceLine<'credit_alphanum4'>).asset_issuer === this.config.usdcIssuer,
+    );
+  }
+
+  async createTrustLine(publicKey: string, secretKey: string): Promise<void> {
+    const account = await this.stellarService.loadAccount(publicKey);
+    const xlmBalance = account.balances.find((b) => b.asset_type === 'native');
+    if (!xlmBalance || parseFloat(xlmBalance.balance) < 1) {
+      throw new AccountNotFundedException();
+    }
+
+    const tx = await this.stellarService.buildTransaction({
+      sourceAccount: account,
+      operations: [
+        StellarSdk.Operation.changeTrust({
+          asset: this.getUsdcAsset(),
+          limit: '922337203685.4775807',
+        }) as unknown as StellarSdk.xdr.Operation,
+      ],
+    });
+
+    const signedXdr = this.stellarService.signTransaction(tx, secretKey);
+    await this.stellarService.submitTransaction(signedXdr);
+  }
+
+  async getUsdcBalance(publicKey: string): Promise<string> {
+    const account = await this.stellarService.loadAccount(publicKey);
+    const entry = account.balances.find(
+      (b) =>
+        b.asset_type === 'credit_alphanum4' &&
+        (b as StellarSdk.Horizon.HorizonApi.BalanceLine<'credit_alphanum4'>).asset_code === 'USDC' &&
+        (b as StellarSdk.Horizon.HorizonApi.BalanceLine<'credit_alphanum4'>).asset_issuer === this.config.usdcIssuer,
+    );
+    return entry ? entry.balance : '0';
+  }
+
+  async ensureTrustLine(publicKey: string, secretKey: string): Promise<void> {
+    const has = await this.hasTrustLine(publicKey);
+    if (!has) {
+      await this.createTrustLine(publicKey, secretKey);
+    }
+  }
+
+  async getAccountDetails(publicKey: string): Promise<{
+    sequence: string;
+    xlmBalance: string;
+    trustLines: StellarSdk.Horizon.HorizonApi.BalanceLine[];
+    signers: StellarSdk.Horizon.HorizonApi.AccountSigner[];
+  }> {
+    const account = await this.stellarService.loadAccount(publicKey);
+    const xlm = account.balances.find((b) => b.asset_type === 'native');
+    return {
+      sequence: account.sequence,
+      xlmBalance: xlm?.balance ?? '0',
+      trustLines: account.balances.filter((b) => b.asset_type !== 'native'),
+      signers: account.signers,
+    };
+  }
+}

--- a/backend/src/stellar/stellar.exceptions.ts
+++ b/backend/src/stellar/stellar.exceptions.ts
@@ -1,6 +1,12 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import type { StellarSubmitErrorDetails } from './stellar.types';
 
+export class AccountNotFundedException extends BadRequestException {
+  constructor() {
+    super('Account needs XLM to create trust line');
+  }
+}
+
 export class AccountNotFoundException extends NotFoundException {
   constructor(public readonly publicKey: string) {
     super(`Stellar account not found for ${publicKey}`);

--- a/backend/src/stellar/stellar.module.ts
+++ b/backend/src/stellar/stellar.module.ts
@@ -1,8 +1,12 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { stellarConfig } from '../config/stellar.config';
 import { StellarService } from './stellar.service';
+import { StellarAssetService } from './stellar-asset.service';
 
 @Module({
-  providers: [StellarService],
-  exports: [StellarService],
+  imports: [ConfigModule.forFeature(stellarConfig)],
+  providers: [StellarService, StellarAssetService],
+  exports: [StellarService, StellarAssetService],
 })
 export class StellarModule {}


### PR DESCRIPTION
This PR closes #478 

feat(stellar): USDC trust line and asset management (#478)

## Summary

Implements StellarAssetService — a single-responsibility service 
that manages USDC trust lines on Stellar, plus wires it into the 
wallet provisioning flow and exposes an admin debug endpoint.

## Changes

### New: StellarAssetService (stellar/stellar-asset.service.ts)
- getUsdcAsset() — single source of truth for the USDC Asset 
object, built from stellarConfig.usdcIssuer
- hasTrustLine(publicKey) — queries Horizon, checks balances[] for 
a USDC entry matching the configured issuer
- createTrustLine(publicKey, secretKey) — builds a ChangeTrust op 
at max limit, signs, and submits via 
StellarService.submitTransaction()
- getUsdcBalance(publicKey) — returns the USDC balance string, or 
'0' if no trust line exists
- ensureTrustLine(publicKey, secretKey) — idempotent; only calls 
createTrustLine if hasTrustLine returns false
- getAccountDetails(publicKey) — returns sequence number, XLM 
balance, trust lines, and signers for debugging

### Updated: stellar/stellar.exceptions.ts
- Added AccountNotFundedException — thrown when XLM balance < 1 
during trust line creation, with message 
'Account needs XLM to create trust line'

### Updated: stellar/stellar.module.ts
- Imports stellarConfig via ConfigModule.forFeature
- Exports StellarAssetService alongside StellarService

### Updated: blockchain-wallet/blockchain-wallet.service.ts
- Injects StellarAssetService
- In provision(): calls ensureTrustLine before registerUser — 
satisfies the ordering requirement

### Updated: blockchain-wallet/blockchain-wallet.module.ts
- Imports StellarModule to make StellarAssetService available

### Updated: soroban/controllers/soroban-admin.controller.ts
- Added GET /admin/blockchain/account/:address — returns full 
Stellar account details (trust lines, balances, signers, sequence)

### Updated: soroban/soroban.module.ts
- Imports StellarModule to satisfy the controller's dependency

### New: stellar/stellar-asset.service.spec.ts
Unit tests covering all acceptance criteria:
- hasTrustLine returns false when USDC not in balances
- hasTrustLine returns false when issuer doesn't match
- ensureTrustLine skips createTrustLine when trust line already 
exists
- getUsdcBalance returns '0' for account with no trust line
- createTrustLine throws AccountNotFundedException when XLM < 1

### Updated: blockchain-wallet/blockchain-wallet.service.spec.ts
- Injects mocked StellarAssetService
- Added test asserting ensureTrustLine is called before registerUser
in the provisioning flow

## Testing

bash
cd backend
npx jest --testPathPattern="stellar-asset|blockchain-wallet.service" --no-coverage