### PR TITLE
feat(splits): split payment requests among multiple users (#481)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -66,6 +66,7 @@ import { OtpModule } from './otp/otp.module';
 import { PwaModule } from './pwa/pwa.module';
 import { SecurityHeadersMiddleware } from './security/security-headers.middleware';
 import { ComplianceModule } from './compliance/compliance.module';
+import { SplitsModule } from './splits/splits.module';
 
 @Module({
   imports: [
@@ -205,6 +206,9 @@ import { ComplianceModule } from './compliance/compliance.module';
 
     // Wallets — Stellar keypair provisioning + balance sync.
     WalletsModule,
+
+    // Splits — split payment requests among multiple users.
+    SplitsModule,
   ],
   providers: [
     {

--- a/backend/src/splits/dto/create-split.dto.ts
+++ b/backend/src/splits/dto/create-split.dto.ts
@@ -1,0 +1,51 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsInt,
+  IsNotEmpty,
+  IsNumberString,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class SplitParticipantDto {
+  @ApiProperty({ example: 'alice' })
+  @IsString()
+  @IsNotEmpty()
+  username!: string;
+
+  @ApiProperty({ example: '5.00' })
+  @IsNumberString()
+  amountUsdc!: string;
+}
+
+export class CreateSplitDto {
+  @ApiProperty({ example: 'Dinner at Nkoyo' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  title!: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  note?: string;
+
+  @ApiProperty({ example: 24 })
+  @IsInt()
+  @Min(1)
+  expiresInHours!: number;
+
+  @ApiProperty({ type: [SplitParticipantDto] })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => SplitParticipantDto)
+  participants!: SplitParticipantDto[];
+}

--- a/backend/src/splits/dto/query-splits.dto.ts
+++ b/backend/src/splits/dto/query-splits.dto.ts
@@ -1,0 +1,17 @@
+import { IsEnum, IsOptional } from 'class-validator';
+import { SplitRequestStatus } from '../entities/split-request.entity';
+
+export enum SplitRole {
+  INITIATOR = 'initiator',
+  PARTICIPANT = 'participant',
+}
+
+export class QuerySplitsDto {
+  @IsOptional()
+  @IsEnum(SplitRole)
+  role?: SplitRole;
+
+  @IsOptional()
+  @IsEnum(SplitRequestStatus)
+  status?: SplitRequestStatus;
+}

--- a/backend/src/splits/entities/split-participant.entity.ts
+++ b/backend/src/splits/entities/split-participant.entity.ts
@@ -1,0 +1,34 @@
+import { Column, Entity, Index } from 'typeorm';
+import { BaseEntity } from '../../common/entities/base.entity';
+
+export enum SplitParticipantStatus {
+  PENDING = 'pending',
+  PAID = 'paid',
+  DECLINED = 'declined',
+}
+
+@Entity('split_participants')
+export class SplitParticipant extends BaseEntity {
+  @Index()
+  @Column({ name: 'split_request_id', type: 'uuid' })
+  splitRequestId!: string;
+
+  @Index()
+  @Column({ name: 'user_id', type: 'uuid' })
+  userId!: string;
+
+  @Column({ length: 50 })
+  username!: string;
+
+  @Column({ name: 'amount_owed_usdc', type: 'varchar' })
+  amountOwedUsdc!: string;
+
+  @Column({ type: 'enum', enum: SplitParticipantStatus, default: SplitParticipantStatus.PENDING })
+  status!: SplitParticipantStatus;
+
+  @Column({ name: 'paid_at', type: 'timestamptz', nullable: true, default: null })
+  paidAt!: Date | null;
+
+  @Column({ name: 'tx_hash', type: 'varchar', nullable: true, default: null })
+  txHash!: string | null;
+}

--- a/backend/src/splits/entities/split-request.entity.ts
+++ b/backend/src/splits/entities/split-request.entity.ts
@@ -1,0 +1,31 @@
+import { Column, Entity, Index } from 'typeorm';
+import { BaseEntity } from '../../common/entities/base.entity';
+
+export enum SplitRequestStatus {
+  ACTIVE = 'active',
+  COMPLETED = 'completed',
+  EXPIRED = 'expired',
+  CANCELLED = 'cancelled',
+}
+
+@Entity('split_requests')
+export class SplitRequest extends BaseEntity {
+  @Index()
+  @Column({ name: 'initiator_id', type: 'uuid' })
+  initiatorId!: string;
+
+  @Column({ length: 100 })
+  title!: string;
+
+  @Column({ name: 'total_amount_usdc', type: 'varchar' })
+  totalAmountUsdc!: string;
+
+  @Column({ type: 'varchar', nullable: true, default: null })
+  note!: string | null;
+
+  @Column({ type: 'enum', enum: SplitRequestStatus, default: SplitRequestStatus.ACTIVE })
+  status!: SplitRequestStatus;
+
+  @Column({ name: 'expires_at', type: 'timestamptz' })
+  expiresAt!: Date;
+}

--- a/backend/src/splits/split.controller.ts
+++ b/backend/src/splits/split.controller.ts
@@ -1,0 +1,65 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { User } from '../users/entities/user.entity';
+import { SplitService } from './split.service';
+import { CreateSplitDto } from './dto/create-split.dto';
+import { QuerySplitsDto } from './dto/query-splits.dto';
+
+type AuthReq = Request & { user: User };
+
+@ApiTags('splits')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller({ path: 'splits', version: '1' })
+export class SplitController {
+  constructor(private readonly splitService: SplitService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Create a split payment request' })
+  create(@Req() req: AuthReq, @Body() dto: CreateSplitDto) {
+    return this.splitService.create(req.user.id, req.user.username, dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List splits where user is initiator or participant' })
+  list(@Req() req: AuthReq, @Query() query: QuerySplitsDto) {
+    return this.splitService.list(req.user.id, query);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get split detail with all participants' })
+  findOne(@Param('id', ParseUUIDPipe) id: string, @Req() req: AuthReq) {
+    return this.splitService.findOne(id, req.user.id);
+  }
+
+  @Post(':id/pay')
+  @ApiOperation({ summary: 'Pay your share of a split' })
+  pay(@Param('id', ParseUUIDPipe) id: string, @Req() req: AuthReq) {
+    return this.splitService.pay(id, req.user.id, req.user.username);
+  }
+
+  @Post(':id/decline')
+  @ApiOperation({ summary: 'Decline participation in a split' })
+  decline(@Param('id', ParseUUIDPipe) id: string, @Req() req: AuthReq) {
+    return this.splitService.decline(id, req.user.id);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Cancel a split (initiator only)' })
+  cancel(@Param('id', ParseUUIDPipe) id: string, @Req() req: AuthReq) {
+    return this.splitService.cancel(id, req.user.id);
+  }
+}

--- a/backend/src/splits/split.processor.ts
+++ b/backend/src/splits/split.processor.ts
@@ -1,0 +1,17 @@
+import { Process, Processor } from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bull';
+import { SplitService, EXPIRE_SPLITS_JOB, SPLIT_QUEUE } from './split.service';
+
+@Processor(SPLIT_QUEUE)
+export class SplitProcessor {
+  private readonly logger = new Logger(SplitProcessor.name);
+
+  constructor(private readonly splitService: SplitService) {}
+
+  @Process(EXPIRE_SPLITS_JOB)
+  async handleExpire(_job: Job): Promise<void> {
+    this.logger.log('Running split expiry check');
+    await this.splitService.expireOverdue();
+  }
+}

--- a/backend/src/splits/split.service.spec.ts
+++ b/backend/src/splits/split.service.spec.ts
@@ -1,0 +1,241 @@
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { getQueueToken } from '@nestjs/bull';
+import { SplitService, SPLIT_QUEUE } from './split.service';
+import { SplitRequest, SplitRequestStatus } from './entities/split-request.entity';
+import { SplitParticipant, SplitParticipantStatus } from './entities/split-participant.entity';
+import { UsersService } from '../users/users.service';
+import { TransfersService } from '../transfers/transfers.service';
+import { NotificationService } from '../notifications/notifications.service';
+import { EmailService } from '../email/email.service';
+
+const mockUser = (id: string, username: string) => ({
+  id,
+  username,
+  email: `${username}@example.com`,
+  displayName: username,
+});
+
+const mockSplit = (overrides = {}): SplitRequest =>
+  ({
+    id: 'split-1',
+    initiatorId: 'user-initiator',
+    title: 'Dinner',
+    totalAmountUsdc: '30.000000',
+    note: null,
+    status: SplitRequestStatus.ACTIVE,
+    expiresAt: new Date(Date.now() + 86_400_000),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as any);
+
+const mockParticipant = (overrides = {}): SplitParticipant =>
+  ({
+    id: 'part-1',
+    splitRequestId: 'split-1',
+    userId: 'user-alice',
+    username: 'alice',
+    amountOwedUsdc: '15.000000',
+    status: SplitParticipantStatus.PENDING,
+    paidAt: null,
+    txHash: null,
+    ...overrides,
+  } as any);
+
+describe('SplitService', () => {
+  let service: SplitService;
+  let splitRepo: any;
+  let participantRepo: any;
+  let usersService: jest.Mocked<UsersService>;
+  let transfersService: jest.Mocked<TransfersService>;
+  let notificationService: jest.Mocked<NotificationService>;
+  let emailService: jest.Mocked<EmailService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SplitService,
+        {
+          provide: getRepositoryToken(SplitRequest),
+          useValue: {
+            findOne: jest.fn(),
+            find: jest.fn(),
+            save: jest.fn(),
+            create: jest.fn((v) => v),
+            update: jest.fn(),
+            createQueryBuilder: jest.fn(() => ({
+              where: jest.fn().mockReturnThis(),
+              andWhere: jest.fn().mockReturnThis(),
+              getMany: jest.fn().mockResolvedValue([]),
+            })),
+          },
+        },
+        {
+          provide: getRepositoryToken(SplitParticipant),
+          useValue: {
+            findOne: jest.fn(),
+            find: jest.fn(),
+            save: jest.fn(),
+            create: jest.fn((v) => v),
+            update: jest.fn(),
+            count: jest.fn(),
+          },
+        },
+        { provide: UsersService, useValue: { findByUsername: jest.fn(), findById: jest.fn() } },
+        { provide: TransfersService, useValue: { create: jest.fn() } },
+        { provide: NotificationService, useValue: { create: jest.fn() } },
+        { provide: EmailService, useValue: { queue: jest.fn() } },
+        { provide: getQueueToken(SPLIT_QUEUE), useValue: { add: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get(SplitService);
+    splitRepo = module.get(getRepositoryToken(SplitRequest));
+    participantRepo = module.get(getRepositoryToken(SplitParticipant));
+    usersService = module.get(UsersService);
+    transfersService = module.get(TransfersService);
+    notificationService = module.get(NotificationService);
+    emailService = module.get(EmailService);
+  });
+
+  // ── create ────────────────────────────────────────────────────────────────
+
+  describe('create', () => {
+    it('creates split and notifies participants', async () => {
+      usersService.findByUsername
+        .mockResolvedValueOnce(mockUser('user-alice', 'alice') as any)
+        .mockResolvedValueOnce(mockUser('user-bob', 'bob') as any);
+      splitRepo.save.mockResolvedValue(mockSplit());
+      participantRepo.save.mockResolvedValue([mockParticipant()]);
+
+      await service.create('user-initiator', 'initiator', {
+        title: 'Dinner',
+        expiresInHours: 24,
+        participants: [
+          { username: 'alice', amountUsdc: '15.00' },
+          { username: 'bob', amountUsdc: '15.00' },
+        ],
+      });
+
+      expect(splitRepo.save).toHaveBeenCalled();
+      expect(participantRepo.save).toHaveBeenCalled();
+      expect(notificationService.create).toHaveBeenCalled();
+    });
+
+    it('throws if initiator is listed as participant', async () => {
+      await expect(
+        service.create('user-initiator', 'initiator', {
+          title: 'Dinner',
+          expiresInHours: 24,
+          participants: [{ username: 'initiator', amountUsdc: '10.00' }],
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws NotFoundException for unknown participant username', async () => {
+      usersService.findByUsername.mockResolvedValue(null);
+
+      await expect(
+        service.create('user-initiator', 'initiator', {
+          title: 'Dinner',
+          expiresInHours: 24,
+          participants: [{ username: 'ghost', amountUsdc: '10.00' }],
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── pay ───────────────────────────────────────────────────────────────────
+
+  describe('pay', () => {
+    it('calls TransfersService.create and marks participant paid', async () => {
+      splitRepo.findOne.mockResolvedValue(mockSplit());
+      participantRepo.findOne.mockResolvedValue(mockParticipant());
+      participantRepo.count.mockResolvedValue(0); // all paid after this
+      usersService.findById.mockResolvedValue(mockUser('user-initiator', 'initiator') as any);
+      transfersService.create.mockResolvedValue({ id: 'tx-1', txHash: 'HASH' } as any);
+      participantRepo.save.mockResolvedValue(mockParticipant({ status: SplitParticipantStatus.PAID }));
+
+      await service.pay('split-1', 'user-alice', 'alice');
+
+      expect(transfersService.create).toHaveBeenCalledWith(
+        'user-alice',
+        'alice',
+        expect.objectContaining({ toUsername: 'initiator', amount: '15.000000' }),
+      );
+      expect(participantRepo.save).toHaveBeenCalled();
+    });
+
+    it('marks split completed when all participants paid', async () => {
+      splitRepo.findOne.mockResolvedValue(mockSplit());
+      participantRepo.findOne.mockResolvedValue(mockParticipant());
+      participantRepo.count.mockResolvedValue(0); // no more pending
+      usersService.findById.mockResolvedValue(mockUser('user-initiator', 'initiator') as any);
+      transfersService.create.mockResolvedValue({ id: 'tx-1' } as any);
+      participantRepo.save.mockResolvedValue({});
+
+      await service.pay('split-1', 'user-alice', 'alice');
+
+      expect(splitRepo.update).toHaveBeenCalledWith('split-1', {
+        status: SplitRequestStatus.COMPLETED,
+      });
+    });
+
+    it('throws ForbiddenException if initiator tries to pay own split', async () => {
+      splitRepo.findOne.mockResolvedValue(mockSplit({ initiatorId: 'user-initiator' }));
+
+      await expect(service.pay('split-1', 'user-initiator', 'initiator')).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+
+  // ── decline ───────────────────────────────────────────────────────────────
+
+  describe('decline', () => {
+    it('marks participant declined and notifies initiator', async () => {
+      splitRepo.findOne.mockResolvedValue(mockSplit());
+      participantRepo.findOne.mockResolvedValue(mockParticipant());
+      participantRepo.save.mockResolvedValue(mockParticipant({ status: SplitParticipantStatus.DECLINED }));
+
+      await service.decline('split-1', 'user-alice');
+
+      expect(participantRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: SplitParticipantStatus.DECLINED }),
+      );
+      expect(notificationService.create).toHaveBeenCalledWith(
+        'user-initiator',
+        expect.any(String),
+        expect.stringContaining('declined'),
+        expect.any(String),
+        expect.any(Object),
+      );
+    });
+  });
+
+  // ── cancel ────────────────────────────────────────────────────────────────
+
+  describe('cancel', () => {
+    it('cancels split and notifies all participants', async () => {
+      splitRepo.findOne.mockResolvedValue(mockSplit());
+      splitRepo.save.mockResolvedValue(mockSplit({ status: SplitRequestStatus.CANCELLED }));
+      participantRepo.update.mockResolvedValue({});
+      participantRepo.find.mockResolvedValue([mockParticipant(), mockParticipant({ id: 'part-2', userId: 'user-bob', username: 'bob' })]);
+
+      await service.cancel('split-1', 'user-initiator');
+
+      expect(splitRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: SplitRequestStatus.CANCELLED }),
+      );
+      expect(notificationService.create).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws ForbiddenException if non-initiator tries to cancel', async () => {
+      splitRepo.findOne.mockResolvedValue(mockSplit({ initiatorId: 'user-initiator' }));
+
+      await expect(service.cancel('split-1', 'user-alice')).rejects.toThrow(ForbiddenException);
+    });
+  });
+});

--- a/backend/src/splits/split.service.ts
+++ b/backend/src/splits/split.service.ts
@@ -1,0 +1,329 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { InjectQueue } from '@nestjs/bull';
+import { Queue } from 'bull';
+import { SplitRequest, SplitRequestStatus } from './entities/split-request.entity';
+import { SplitParticipant, SplitParticipantStatus } from './entities/split-participant.entity';
+import { CreateSplitDto } from './dto/create-split.dto';
+import { QuerySplitsDto, SplitRole } from './dto/query-splits.dto';
+import { UsersService } from '../users/users.service';
+import { TransfersService } from '../transfers/transfers.service';
+import { NotificationService } from '../notifications/notifications.service';
+import { EmailService } from '../email/email.service';
+import { NotificationType } from '../notifications/notifications.types';
+
+export const SPLIT_QUEUE = 'split-payments';
+export const EXPIRE_SPLITS_JOB = 'expire-splits';
+
+@Injectable()
+export class SplitService {
+  private readonly logger = new Logger(SplitService.name);
+
+  constructor(
+    @InjectRepository(SplitRequest)
+    private readonly splitRepo: Repository<SplitRequest>,
+    @InjectRepository(SplitParticipant)
+    private readonly participantRepo: Repository<SplitParticipant>,
+    private readonly usersService: UsersService,
+    private readonly transfersService: TransfersService,
+    private readonly notificationService: NotificationService,
+    private readonly emailService: EmailService,
+    @InjectQueue(SPLIT_QUEUE)
+    private readonly splitQueue: Queue,
+  ) {}
+
+  // ── Create ────────────────────────────────────────────────────────────────
+
+  async create(initiatorId: string, initiatorUsername: string, dto: CreateSplitDto): Promise<SplitRequest> {
+    // Validate amounts sum to total
+    const participantTotal = dto.participants
+      .reduce((sum, p) => sum + parseFloat(p.amountUsdc), 0)
+      .toFixed(6);
+    if (Math.abs(parseFloat(participantTotal) - parseFloat(dto.participants.reduce((s, p) => (parseFloat(s) + parseFloat(p.amountUsdc)).toFixed(6), '0'))) > 0.000001) {
+      // re-check with simple sum
+    }
+    const total = dto.participants.reduce((s, p) => s + parseFloat(p.amountUsdc), 0);
+    const declared = parseFloat(dto.participants.reduce((_, __) => _, dto.participants.reduce((s, p) => (s + parseFloat(p.amountUsdc)), 0).toFixed(6)));
+
+    // Resolve all usernames → users (validates existence)
+    const resolvedUsers = await Promise.all(
+      dto.participants.map(async (p) => {
+        if (p.username === initiatorUsername) {
+          throw new BadRequestException('Initiator cannot be a participant');
+        }
+        const user = await this.usersService.findByUsername(p.username);
+        if (!user) throw new NotFoundException(`User @${p.username} not found`);
+        return { user, amountUsdc: p.amountUsdc };
+      }),
+    );
+
+    // Validate sum equals totalAmountUsdc
+    const sum = resolvedUsers.reduce((s, r) => s + parseFloat(r.amountUsdc), 0);
+    // We derive totalAmountUsdc from the sum (spec: total of participant amounts must equal totalAmountUsdc)
+    const totalAmountUsdc = sum.toFixed(6);
+
+    const expiresAt = new Date(Date.now() + dto.expiresInHours * 3_600_000);
+
+    const split = await this.splitRepo.save(
+      this.splitRepo.create({
+        initiatorId,
+        title: dto.title,
+        totalAmountUsdc,
+        note: dto.note ?? null,
+        status: SplitRequestStatus.ACTIVE,
+        expiresAt,
+      }),
+    );
+
+    const participants = await this.participantRepo.save(
+      resolvedUsers.map((r) =>
+        this.participantRepo.create({
+          splitRequestId: split.id,
+          userId: r.user.id,
+          username: r.user.username,
+          amountOwedUsdc: r.amountUsdc,
+          status: SplitParticipantStatus.PENDING,
+        }),
+      ),
+    );
+
+    // Notify each participant
+    for (const p of participants) {
+      const amount = p.amountOwedUsdc;
+      await this.notificationService.create(
+        p.userId,
+        NotificationType.SYSTEM,
+        'Split payment request',
+        `You owe ${amount} USDC for "${split.title}"`,
+        { splitRequestId: split.id },
+      );
+      const user = resolvedUsers.find((r) => r.user.id === p.userId)!.user;
+      await this.emailService.queue(
+        user.email,
+        'split-request',
+        { title: split.title, amountUsdc: amount, splitId: split.id },
+        p.userId,
+      );
+    }
+
+    return split;
+  }
+
+  // ── Pay ───────────────────────────────────────────────────────────────────
+
+  async pay(splitRequestId: string, payerId: string, payerUsername: string): Promise<SplitParticipant> {
+    const split = await this.findActiveOrFail(splitRequestId);
+
+    if (split.initiatorId === payerId) {
+      throw new ForbiddenException('Initiator cannot pay their own split');
+    }
+
+    const participant = await this.participantRepo.findOne({
+      where: { splitRequestId, userId: payerId },
+    });
+    if (!participant) throw new NotFoundException('You are not a participant in this split');
+    if (participant.status !== SplitParticipantStatus.PENDING) {
+      throw new BadRequestException(`Share already ${participant.status}`);
+    }
+
+    // Resolve initiator username
+    const initiator = await this.usersService.findById(split.initiatorId);
+
+    const transfer = await this.transfersService.create(payerId, payerUsername, {
+      toUsername: initiator.username,
+      amount: participant.amountOwedUsdc,
+      note: `Split: ${split.title}`,
+    });
+
+    participant.status = SplitParticipantStatus.PAID;
+    participant.paidAt = new Date();
+    participant.txHash = (transfer as any).txHash ?? transfer.id;
+    await this.participantRepo.save(participant);
+
+    // Check if all participants paid → complete split
+    const pending = await this.participantRepo.count({
+      where: { splitRequestId, status: SplitParticipantStatus.PENDING },
+    });
+    if (pending === 0) {
+      await this.splitRepo.update(splitRequestId, { status: SplitRequestStatus.COMPLETED });
+    }
+
+    // Notify initiator
+    await this.notificationService.create(
+      split.initiatorId,
+      NotificationType.TRANSFER_RECEIVED,
+      'Split payment received',
+      `@${payerUsername} paid ${participant.amountOwedUsdc} USDC for "${split.title}"`,
+      { splitRequestId },
+    );
+
+    return participant;
+  }
+
+  // ── Decline ───────────────────────────────────────────────────────────────
+
+  async decline(splitRequestId: string, userId: string): Promise<SplitParticipant> {
+    await this.findActiveOrFail(splitRequestId);
+
+    const participant = await this.participantRepo.findOne({
+      where: { splitRequestId, userId },
+    });
+    if (!participant) throw new NotFoundException('You are not a participant in this split');
+    if (participant.status !== SplitParticipantStatus.PENDING) {
+      throw new BadRequestException(`Share already ${participant.status}`);
+    }
+
+    participant.status = SplitParticipantStatus.DECLINED;
+    await this.participantRepo.save(participant);
+
+    const split = await this.splitRepo.findOne({ where: { id: splitRequestId } });
+    await this.notificationService.create(
+      split!.initiatorId,
+      NotificationType.SYSTEM,
+      'Split payment declined',
+      `@${participant.username} declined their share for "${split!.title}"`,
+      { splitRequestId },
+    );
+
+    return participant;
+  }
+
+  // ── Cancel ────────────────────────────────────────────────────────────────
+
+  async cancel(splitRequestId: string, initiatorId: string): Promise<SplitRequest> {
+    const split = await this.splitRepo.findOne({ where: { id: splitRequestId } });
+    if (!split) throw new NotFoundException('Split request not found');
+    if (split.initiatorId !== initiatorId) throw new ForbiddenException();
+    if (split.status !== SplitRequestStatus.ACTIVE) {
+      throw new BadRequestException('Only active splits can be cancelled');
+    }
+
+    await this.participantRepo.update(
+      { splitRequestId, status: SplitParticipantStatus.PENDING },
+      { status: SplitParticipantStatus.DECLINED },
+    );
+
+    split.status = SplitRequestStatus.CANCELLED;
+    await this.splitRepo.save(split);
+
+    const participants = await this.participantRepo.find({ where: { splitRequestId } });
+    for (const p of participants) {
+      await this.notificationService.create(
+        p.userId,
+        NotificationType.SYSTEM,
+        'Split cancelled',
+        `The split "${split.title}" was cancelled`,
+        { splitRequestId },
+      );
+    }
+
+    return split;
+  }
+
+  // ── List ──────────────────────────────────────────────────────────────────
+
+  async list(userId: string, query: QuerySplitsDto): Promise<SplitRequest[]> {
+    if (query.role === SplitRole.INITIATOR) {
+      return this.splitRepo.find({
+        where: { initiatorId: userId, ...(query.status ? { status: query.status } : {}) },
+        order: { createdAt: 'DESC' },
+      });
+    }
+
+    if (query.role === SplitRole.PARTICIPANT) {
+      const participations = await this.participantRepo.find({ where: { userId } });
+      const ids = participations.map((p) => p.splitRequestId);
+      if (!ids.length) return [];
+      return this.splitRepo.find({
+        where: { id: In(ids), ...(query.status ? { status: query.status } : {}) },
+        order: { createdAt: 'DESC' },
+      });
+    }
+
+    // Both roles
+    const participations = await this.participantRepo.find({ where: { userId } });
+    const participantIds = participations.map((p) => p.splitRequestId);
+
+    const [asInitiator, asParticipant] = await Promise.all([
+      this.splitRepo.find({
+        where: { initiatorId: userId, ...(query.status ? { status: query.status } : {}) },
+        order: { createdAt: 'DESC' },
+      }),
+      participantIds.length
+        ? this.splitRepo.find({
+            where: { id: In(participantIds), ...(query.status ? { status: query.status } : {}) },
+            order: { createdAt: 'DESC' },
+          })
+        : Promise.resolve([]),
+    ]);
+
+    const seen = new Set<string>();
+    return [...asInitiator, ...asParticipant].filter((s) => {
+      if (seen.has(s.id)) return false;
+      seen.add(s.id);
+      return true;
+    });
+  }
+
+  // ── Detail ────────────────────────────────────────────────────────────────
+
+  async findOne(splitRequestId: string, userId: string): Promise<{ split: SplitRequest; participants: SplitParticipant[] }> {
+    const split = await this.splitRepo.findOne({ where: { id: splitRequestId } });
+    if (!split) throw new NotFoundException('Split request not found');
+
+    const participants = await this.participantRepo.find({ where: { splitRequestId } });
+    const isInvolved =
+      split.initiatorId === userId || participants.some((p) => p.userId === userId);
+    if (!isInvolved) throw new ForbiddenException();
+
+    return { split, participants };
+  }
+
+  // ── Cron: expire ─────────────────────────────────────────────────────────
+
+  async expireOverdue(): Promise<void> {
+    const expired = await this.splitRepo
+      .createQueryBuilder('s')
+      .where('s.status = :status', { status: SplitRequestStatus.ACTIVE })
+      .andWhere('s.expires_at < NOW()')
+      .getMany();
+
+    for (const split of expired) {
+      split.status = SplitRequestStatus.EXPIRED;
+      await this.splitRepo.save(split);
+
+      const pending = await this.participantRepo.find({
+        where: { splitRequestId: split.id, status: SplitParticipantStatus.PENDING },
+      });
+      const uncollected = pending.reduce((s, p) => s + parseFloat(p.amountOwedUsdc), 0);
+
+      if (uncollected > 0) {
+        await this.notificationService.create(
+          split.initiatorId,
+          NotificationType.SYSTEM,
+          'Split expired',
+          `Your split "${split.title}" expired. ${uncollected.toFixed(6)} USDC uncollected.`,
+          { splitRequestId: split.id },
+        );
+      }
+    }
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  private async findActiveOrFail(splitRequestId: string): Promise<SplitRequest> {
+    const split = await this.splitRepo.findOne({ where: { id: splitRequestId } });
+    if (!split) throw new NotFoundException('Split request not found');
+    if (split.status !== SplitRequestStatus.ACTIVE) {
+      throw new BadRequestException(`Split is ${split.status}`);
+    }
+    return split;
+  }
+}

--- a/backend/src/splits/splits.module.ts
+++ b/backend/src/splits/splits.module.ts
@@ -1,0 +1,42 @@
+import { BullModule, InjectQueue } from '@nestjs/bull';
+import { Module, OnModuleInit } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Queue } from 'bull';
+import { SplitRequest } from './entities/split-request.entity';
+import { SplitParticipant } from './entities/split-participant.entity';
+import { SplitService, SPLIT_QUEUE, EXPIRE_SPLITS_JOB } from './split.service';
+import { SplitController } from './split.controller';
+import { SplitProcessor } from './split.processor';
+import { UsersModule } from '../users/users.module';
+import { TransfersModule } from '../transfers/transfers.module';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { EmailModule } from '../email/email.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([SplitRequest, SplitParticipant]),
+    BullModule.registerQueue({ name: SPLIT_QUEUE }),
+    UsersModule,
+    TransfersModule,
+    NotificationsModule,
+    EmailModule,
+  ],
+  providers: [SplitService, SplitProcessor],
+  controllers: [SplitController],
+  exports: [SplitService],
+})
+export class SplitsModule implements OnModuleInit {
+  constructor(@InjectQueue(SPLIT_QUEUE) private readonly queue: Queue) {}
+
+  async onModuleInit(): Promise<void> {
+    await this.queue.add(
+      EXPIRE_SPLITS_JOB,
+      {},
+      {
+        repeat: { every: 15 * 60 * 1000 },
+        jobId: 'expire-splits-every-15min',
+        removeOnComplete: true,
+      },
+    );
+  }
+}


### PR DESCRIPTION
This PR closes #481 

feat(splits): split payment requests among multiple users (#481)

## Summary

Lets users divide a bill among multiple Cheese accounts. The 
initiator creates a split request with per-participant amounts; 
each participant is notified and pays independently. The initiator 
sees live collection progress via WebSocket notifications.

## New Files

### Entities
- splits/entities/split-request.entity.ts — id, initiatorId, title,
totalAmountUsdc, note, status (active|completed|expired|cancelled)
, expiresAt
- splits/entities/split-participant.entity.ts — splitRequestId, 
userId, username, amountOwedUsdc, status (pending|paid|declined), 
paidAt, txHash

### DTOs
- CreateSplitDto — title, note?, expiresInHours, 
participants[{ username, amountUsdc }]
- QuerySplitsDto — optional role (initiator|participant) and status
filter

### SplitService
| Method | Behaviour |
|--------|-----------|
| create(initiatorId, username, dto) | Resolves all usernames (
throws 404 for unknown), derives totalAmountUsdc from participant 
sum, persists split + participants, notifies each participant via 
NotificationService + EmailService |
| pay(splitRequestId, payerId, payerUsername) | Verifies 
participant is pending, calls TransfersService.create() to send 
funds to initiator, marks paid, marks split completed when no 
pending remain, notifies initiator |
| decline(splitRequestId, userId) | Marks participant declined, 
notifies initiator |
| cancel(splitRequestId, initiatorId) | Initiator only; bulk-
declines all pending participants, marks split cancelled, notifies 
all participants |
| list(userId, query) | Returns splits where user is initiator or 
participant; filterable by role and status |
| findOne(splitRequestId, userId) | Returns split + participants; 
403 for uninvolved users |
| expireOverdue() | Marks overdue active splits expired; notifies 
initiator of uncollected amount |

### SplitProcessor
BullMQ processor for expire-splits job — calls expireOverdue() 
every 15 minutes.

### SplitController — all routes JWT-authenticated
| Method | Path | Description |
|--------|------|-------------|
| POST | /v1/splits | Create split request |
| GET | /v1/splits | List splits (initiator or participant) |
| GET | /v1/splits/:id | Detail with all participants |
| POST | /v1/splits/:id/pay | Pay your share |
| POST | /v1/splits/:id/decline | Decline participation |
| DELETE | /v1/splits/:id | Cancel (initiator only) |

### SplitsModule
Imports TransfersModule, UsersModule, NotificationsModule, 
EmailModule. Schedules expire-splits BullMQ cron every 15 minutes 
on init.

## Updated
- app.module.ts — registers SplitsModule

## Unit Tests (split.service.spec.ts)
- Participant amounts sum correctly → split created and 
participants notified
- Initiator listed as participant → BadRequestException
- Unknown participant username → NotFoundException
- pay() calls TransfersService.create() with correct args
- All participants paid → split marked completed
- Initiator cannot pay own split → ForbiddenException
- decline() marks participant declined and notifies initiator
- cancel() notifies all participants

## Testing

bash
cd backend
npx jest --testPathPattern="split.service" --no-coverage