### PR TITLE
feat: add GDPR and account statement report types and endpoints

### DIFF
--- a/backend/src/database/migrations/1770100000000-AddDataExportReportTypes.ts
+++ b/backend/src/database/migrations/1770100000000-AddDataExportReportTypes.ts
@@ -1,0 +1,42 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddDataExportReportTypes1770100000000 implements MigrationInterface {
+  name = 'AddDataExportReportTypes1770100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query("SET lock_timeout = '5s'");
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1
+          FROM pg_enum e
+          JOIN pg_type t ON t.oid = e.enumtypid
+          WHERE t.typname = 'report_type_enum' AND e.enumlabel = 'gdpr_export'
+        ) THEN
+          ALTER TYPE "report_type_enum" ADD VALUE 'gdpr_export';
+        END IF;
+      END
+      $$;
+    `);
+
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1
+          FROM pg_enum e
+          JOIN pg_type t ON t.oid = e.enumtypid
+          WHERE t.typname = 'report_type_enum' AND e.enumlabel = 'account_statement'
+        ) THEN
+          ALTER TYPE "report_type_enum" ADD VALUE 'account_statement';
+        END IF;
+      END
+      $$;
+    `);
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    // Postgres enum value removal is non-trivial; intentionally no-op for safety.
+  }
+}

--- a/backend/src/reports/dto/account-statement-request.dto.ts
+++ b/backend/src/reports/dto/account-statement-request.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDateString } from 'class-validator';
+
+export class AccountStatementRequestDto {
+  @ApiProperty({ example: '2026-01-01' })
+  @IsDateString()
+  dateFrom!: string;
+
+  @ApiProperty({ example: '2026-03-31' })
+  @IsDateString()
+  dateTo!: string;
+}

--- a/backend/src/reports/entities/report-job.entity.ts
+++ b/backend/src/reports/entities/report-job.entity.ts
@@ -7,6 +7,8 @@ export enum ReportType {
   FEE_SUMMARY = 'fee_summary',
   KYC_SUBMISSIONS = 'kyc_submissions',
   WAITLIST_EXPORT = 'waitlist_export',
+  GDPR_EXPORT = 'gdpr_export',
+  ACCOUNT_STATEMENT = 'account_statement',
 }
 
 export enum ReportStatus {

--- a/backend/src/reports/gdpr-export.util.spec.ts
+++ b/backend/src/reports/gdpr-export.util.spec.ts
@@ -1,0 +1,40 @@
+import { buildGdprExportPayload } from './gdpr-export.util';
+
+describe('buildGdprExportPayload', () => {
+  it('includes all required GDPR entity categories', () => {
+    const payload = buildGdprExportPayload({
+      userProfile: { id: 'u1' },
+      wallet: { id: 'w1' },
+      transactions: [],
+      transfers: [],
+      withdrawals: [],
+      deposits: [],
+      payLinks: [],
+      contacts: [],
+      notifications: [],
+      supportTickets: [],
+      loginHistory: [],
+      deviceTokens: [] as any,
+      kycSubmissions: [] as any,
+      referrals: [],
+      feedback: [],
+    });
+
+    const categories = (payload.categories ?? {}) as Record<string, unknown>;
+    expect(categories.userProfile).toBeDefined();
+    expect(categories.wallet).toBeDefined();
+    expect(categories.transactions).toBeDefined();
+    expect(categories.transfers).toBeDefined();
+    expect(categories.withdrawals).toBeDefined();
+    expect(categories.deposits).toBeDefined();
+    expect(categories.payLinks).toBeDefined();
+    expect(categories.contacts).toBeDefined();
+    expect(categories.notifications).toBeDefined();
+    expect(categories.supportTickets).toBeDefined();
+    expect(categories.loginHistory).toBeDefined();
+    expect(categories.deviceTokens).toBeDefined();
+    expect(categories.kycSubmissions).toBeDefined();
+    expect(categories.referrals).toBeDefined();
+    expect(categories.feedback).toBeDefined();
+  });
+});

--- a/backend/src/reports/gdpr-export.util.ts
+++ b/backend/src/reports/gdpr-export.util.ts
@@ -1,0 +1,61 @@
+import { DeviceToken } from '../push/entities/device-token.entity';
+import { KycSubmission } from '../kyc/entities/kyc-submission.entity';
+
+export interface GdprExportCollections {
+  userProfile: unknown;
+  wallet: unknown;
+  transactions: unknown[];
+  transfers: unknown[];
+  withdrawals: unknown[];
+  deposits: unknown[];
+  payLinks: unknown[];
+  contacts: unknown[];
+  notifications: unknown[];
+  supportTickets: unknown[];
+  loginHistory: unknown[];
+  deviceTokens: DeviceToken[];
+  kycSubmissions: KycSubmission[];
+  referrals: unknown[];
+  feedback: unknown[];
+}
+
+export function buildGdprExportPayload(input: GdprExportCollections): Record<string, unknown> {
+  return {
+    generatedAt: new Date().toISOString(),
+    categories: {
+      userProfile: input.userProfile,
+      wallet: input.wallet,
+      transactions: input.transactions,
+      transfers: input.transfers,
+      withdrawals: input.withdrawals,
+      deposits: input.deposits,
+      payLinks: input.payLinks,
+      contacts: input.contacts,
+      notifications: input.notifications,
+      supportTickets: input.supportTickets,
+      loginHistory: input.loginHistory,
+      deviceTokens: input.deviceTokens.map((token) => ({
+        id: token.id,
+        userId: token.userId,
+        platform: token.platform,
+        isActive: token.isActive,
+        lastUsedAt: token.lastUsedAt,
+        createdAt: token.createdAt,
+        updatedAt: token.updatedAt,
+      })),
+      kycSubmissions: input.kycSubmissions.map((submission) => ({
+        id: submission.id,
+        userId: submission.userId,
+        targetTier: submission.targetTier,
+        status: submission.status,
+        reviewedAt: submission.reviewedAt,
+        createdAt: submission.createdAt,
+        updatedAt: submission.updatedAt,
+      })),
+      referrals: input.referrals,
+      feedback: input.feedback,
+    },
+  };
+}
+
+export const GDPR_EXPORT_README = `Cheese Personal Data Export\n\nThis archive contains your personal data as held by Cheese at the time of export.\n\nIncluded categories:\n- userProfile: account profile data\n- wallet: wallet profile and balances\n- transactions: account transaction history\n- transfers: transfer records\n- withdrawals: withdrawal records\n- deposits: deposit records\n- payLinks: links created and payment states\n- contacts: counterparties inferred from transfer/transaction activity\n- notifications: in-app notifications\n- supportTickets: support tickets linked to your account\n- loginHistory: login attempts and metadata\n- deviceTokens: device metadata only (token and web subscription values excluded)\n- kycSubmissions: KYC statuses only (document keys excluded)\n- referrals: referral records\n- feedback: submitted feedback records\n`;

--- a/backend/src/reports/reports.controller.ts
+++ b/backend/src/reports/reports.controller.ts
@@ -15,6 +15,7 @@ import { ReportsService } from './reports.service';
 import { CreateReportDto } from './dto/create-report.dto';
 import { SuperAdminGuard } from '../common/guards/super-admin.guard';
 import { User } from '../users/entities/user.entity';
+import { AccountStatementRequestDto } from './dto/account-statement-request.dto';
 
 type AuthReq = Request & { user: User };
 
@@ -41,6 +42,38 @@ export class ReportsController {
   @ApiOperation({ summary: 'Get a specific report job (own only)' })
   getOne(@Req() req: AuthReq, @Param('id') id: string) {
     return this.reportsService.getForUser(req.user.id, id);
+  }
+
+  @Post('account/export/data')
+  @ApiOperation({ summary: 'Request GDPR data export (one every 30 days)' })
+  requestGdprExport(@Req() req: AuthReq) {
+    return this.reportsService.requestGdprExport(req.user.id);
+  }
+
+  @Post('account/export/statement')
+  @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+  @ApiOperation({ summary: 'Request account statement export (max 12 months)' })
+  requestAccountStatement(
+    @Req() req: AuthReq,
+    @Body() body: AccountStatementRequestDto,
+  ) {
+    return this.reportsService.requestAccountStatement(
+      req.user.id,
+      body.dateFrom,
+      body.dateTo,
+    );
+  }
+
+  @Get('account/exports')
+  @ApiOperation({ summary: 'List account export requests for current user' })
+  listAccountExports(@Req() req: AuthReq) {
+    return this.reportsService.listAccountExports(req.user.id);
+  }
+
+  @Get('account/exports/:id')
+  @ApiOperation({ summary: 'Get account export status and download URL when ready' })
+  getAccountExport(@Req() req: AuthReq, @Param('id') id: string) {
+    return this.reportsService.getAccountExport(req.user.id, id);
   }
 
   @UseGuards(SuperAdminGuard)

--- a/backend/src/reports/reports.processor.spec.ts
+++ b/backend/src/reports/reports.processor.spec.ts
@@ -37,8 +37,13 @@ const mockEmailService = {
   queue: jest.fn().mockResolvedValue({}),
 };
 
+const mockUserRepo = {
+  findOne: jest.fn().mockResolvedValue({ id: 'user-uuid-1', email: 'user@example.com' }),
+};
+
 const mockDataSource = {
   query: jest.fn().mockResolvedValue([]),
+  getRepository: jest.fn().mockReturnValue(mockUserRepo),
 };
 
 const mockR2Config = {
@@ -129,6 +134,25 @@ describe('ReportsProcessor', () => {
 
       const secondCall = mockReportsService.update.mock.calls[1];
       expect(secondCall[1].fileUrl).toMatch(/^https:\/\//);
+    });
+
+    it('uses 48-hour expiry for GDPR export download links', async () => {
+      const reportJob = makeJob({
+        type: ReportType.GDPR_EXPORT,
+        params: {},
+      });
+      mockReportsService.findById.mockResolvedValue(reportJob);
+      jest
+        .spyOn(processor as any, 'generateGdprZip')
+        .mockResolvedValue(Buffer.from('zip'));
+
+      await processor.handleGenerate(makeBullJob({ jobId: reportJob.id }));
+
+      const secondCall = mockReportsService.update.mock.calls[1];
+      const expiresAt = secondCall[1].expiresAt as Date;
+      const hours = Math.round((expiresAt.getTime() - Date.now()) / (1000 * 60 * 60));
+      expect(hours).toBeGreaterThanOrEqual(47);
+      expect(hours).toBeLessThanOrEqual(48);
     });
 
     it('skips gracefully when job not found', async () => {

--- a/backend/src/reports/reports.processor.ts
+++ b/backend/src/reports/reports.processor.ts
@@ -13,12 +13,38 @@ import {
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { r2Config } from '../config/r2.config';
-import { ReportsService, REPORT_QUEUE, GENERATE_REPORT_JOB, CLEANUP_REPORT_JOB } from './reports.service';
-import { ReportStatus } from './entities/report-job.entity';
+import {
+  ReportsService,
+  REPORT_QUEUE,
+  GENERATE_REPORT_JOB,
+  CLEANUP_REPORT_JOB,
+} from './reports.service';
+import { ReportParams, ReportStatus, ReportType } from './entities/report-job.entity';
 import { EmailService } from '../email/email.service';
 import { generateCsv } from './report-generator';
+import { User } from '../users/entities/user.entity';
+import { Wallet } from '../wallets/entities/wallet.entity';
+import { Transaction } from '../transactions/entities/transaction.entity';
+import { Transfer } from '../transfers/entities/transfer.entity';
+import { Withdrawal } from '../withdrawals/entities/withdrawal.entity';
+import { Deposit } from '../deposits/entities/deposit.entity';
+import { PayLink } from '../paylink/entities/pay-link.entity';
+import { Notification } from '../notifications/entities/notification.entity';
+import { SupportTicket } from '../feedback/entities/support-ticket.entity';
+import { LoginHistory } from '../security/entities/login-history.entity';
+import { DeviceToken } from '../push/entities/device-token.entity';
+import { KycSubmission } from '../kyc/entities/kyc-submission.entity';
+import { Referral } from '../referrals/entities/referral.entity';
+import { Feedback } from '../feedback/entities/feedback.entity';
+import {
+  buildGdprExportPayload,
+  GDPR_EXPORT_README,
+} from './gdpr-export.util';
+import { createZip } from './zip.util';
+import { generateAccountStatementPdf } from './statement-pdf.util';
 
-const PRESIGN_EXPIRY_SECONDS = 24 * 60 * 60; // 24 hours
+const DEFAULT_PRESIGN_EXPIRY_SECONDS = 24 * 60 * 60;
+const GDPR_PRESIGN_EXPIRY_SECONDS = 48 * 60 * 60;
 
 export interface GenerateReportPayload {
   jobId: string;
@@ -58,29 +84,25 @@ export class ReportsProcessor {
       return;
     }
 
-    // Mark processing
     await this.reportsService.update(jobId, { status: ReportStatus.PROCESSING });
 
-    // Generate CSV via cursor-based streaming
-    const csvBuffer = await generateCsv(this.dataSource, reportJob.type, reportJob.params);
+    const generated = await this.generateByType(reportJob.requestedBy, reportJob.type, reportJob.params);
 
-    // Upload to R2
-    const fileKey = `reports/${reportJob.requestedBy}/${jobId}.csv`;
+    const fileKey = `reports/${reportJob.requestedBy}/${jobId}.${generated.extension}`;
     await this.s3.send(new PutObjectCommand({
       Bucket: this.bucket,
       Key: fileKey,
-      Body: csvBuffer,
-      ContentType: 'text/csv',
+      Body: generated.buffer,
+      ContentType: generated.contentType,
     }));
 
-    // Presigned GET URL — 24h expiry
     const fileUrl = await getSignedUrl(
       this.s3,
       new GetObjectCommand({ Bucket: this.bucket, Key: fileKey }),
-      { expiresIn: PRESIGN_EXPIRY_SECONDS },
+      { expiresIn: generated.expiresInSeconds },
     );
 
-    const expiresAt = new Date(Date.now() + PRESIGN_EXPIRY_SECONDS * 1000);
+    const expiresAt = new Date(Date.now() + generated.expiresInSeconds * 1000);
 
     await this.reportsService.update(jobId, {
       status: ReportStatus.READY,
@@ -91,12 +113,21 @@ export class ReportsProcessor {
 
     this.logger.log(`Report ${jobId} ready — key=${fileKey}`);
 
-    // Send download email (fire-and-forget)
+    const userEmail = await this.lookupUserEmail(reportJob.requestedBy);
+    if (!userEmail) {
+      this.logger.warn(`Unable to resolve user email for report ${jobId}`);
+      return;
+    }
+
     this.emailService
       .queue(
-        reportJob.requestedBy, // processor uses userId; controller layer resolves email
+        userEmail,
         'report-ready',
-        { reportType: reportJob.type, downloadUrl: fileUrl, expiresAt: expiresAt.toISOString() },
+        {
+          reportType: reportJob.type,
+          downloadUrl: fileUrl,
+          expiresAt: expiresAt.toISOString(),
+        },
         reportJob.requestedBy,
       )
       .catch((err: Error) => this.logger.warn(`Report email failed: ${err.message}`));
@@ -135,5 +166,176 @@ export class ReportsProcessor {
         errorMessage: err.message,
       });
     }
+  }
+
+  private async generateByType(
+    userId: string,
+    type: ReportType,
+    params: ReportParams,
+  ): Promise<{ buffer: Buffer; contentType: string; extension: string; expiresInSeconds: number }> {
+    if (type === ReportType.GDPR_EXPORT) {
+      const buffer = await this.generateGdprZip(userId);
+      return {
+        buffer,
+        contentType: 'application/zip',
+        extension: 'zip',
+        expiresInSeconds: GDPR_PRESIGN_EXPIRY_SECONDS,
+      };
+    }
+
+    if (type === ReportType.ACCOUNT_STATEMENT) {
+      const buffer = await this.generateStatementPdf(userId, params);
+      return {
+        buffer,
+        contentType: 'application/pdf',
+        extension: 'pdf',
+        expiresInSeconds: DEFAULT_PRESIGN_EXPIRY_SECONDS,
+      };
+    }
+
+    const csvBuffer = await generateCsv(this.dataSource, type, params as any);
+    return {
+      buffer: csvBuffer,
+      contentType: 'text/csv',
+      extension: 'csv',
+      expiresInSeconds: DEFAULT_PRESIGN_EXPIRY_SECONDS,
+    };
+  }
+
+  private async generateGdprZip(userId: string): Promise<Buffer> {
+    const userRepo = this.dataSource.getRepository(User);
+    const walletRepo = this.dataSource.getRepository(Wallet);
+    const txRepo = this.dataSource.getRepository(Transaction);
+    const transferRepo = this.dataSource.getRepository(Transfer);
+    const withdrawalRepo = this.dataSource.getRepository(Withdrawal);
+    const depositRepo = this.dataSource.getRepository(Deposit);
+    const payLinkRepo = this.dataSource.getRepository(PayLink);
+    const notificationRepo = this.dataSource.getRepository(Notification);
+    const supportTicketRepo = this.dataSource.getRepository(SupportTicket);
+    const loginRepo = this.dataSource.getRepository(LoginHistory);
+    const deviceTokenRepo = this.dataSource.getRepository(DeviceToken);
+    const kycRepo = this.dataSource.getRepository(KycSubmission);
+    const referralRepo = this.dataSource.getRepository(Referral);
+    const feedbackRepo = this.dataSource.getRepository(Feedback);
+
+    const [
+      userProfile,
+      wallet,
+      transactions,
+      transfersFrom,
+      transfersTo,
+      withdrawals,
+      deposits,
+      payLinks,
+      notifications,
+      supportTickets,
+      loginHistory,
+      deviceTokens,
+      kycSubmissions,
+      referralsFrom,
+      referralsTo,
+      feedback,
+    ] = await Promise.all([
+      userRepo.findOne({ where: { id: userId } }),
+      walletRepo.findOne({ where: { userId } }),
+      txRepo.find({ where: { userId }, order: { createdAt: 'DESC' } }),
+      transferRepo.find({ where: { fromUserId: userId }, order: { createdAt: 'DESC' } }),
+      transferRepo.find({ where: { toUserId: userId }, order: { createdAt: 'DESC' } }),
+      withdrawalRepo.find({ where: { userId }, order: { createdAt: 'DESC' } }),
+      depositRepo.find({ where: { userId }, order: { createdAt: 'DESC' } }),
+      payLinkRepo.find({ where: [{ creatorUserId: userId }, { paidByUserId: userId }], order: { createdAt: 'DESC' } }),
+      notificationRepo.find({ where: { userId }, order: { createdAt: 'DESC' } }),
+      supportTicketRepo.find({ where: { userId }, order: { createdAt: 'DESC' } }),
+      loginRepo.find({ where: { userId }, order: { createdAt: 'DESC' } }),
+      deviceTokenRepo.find({ where: { userId }, order: { createdAt: 'DESC' } }),
+      kycRepo.find({ where: { userId }, order: { createdAt: 'DESC' } }),
+      referralRepo.find({ where: { referrerId: userId }, order: { createdAt: 'DESC' } }),
+      referralRepo.find({ where: { referredUserId: userId }, order: { createdAt: 'DESC' } }),
+      feedbackRepo.find({ where: { userId }, order: { createdAt: 'DESC' } }),
+    ]);
+
+    const contactsSet = new Set<string>();
+    for (const transfer of [...transfersFrom, ...transfersTo]) {
+      if (transfer.fromUserId === userId && transfer.toUsername) {
+        contactsSet.add(transfer.toUsername);
+      }
+      if (transfer.toUserId === userId && transfer.fromUsername) {
+        contactsSet.add(transfer.fromUsername);
+      }
+    }
+    for (const tx of transactions) {
+      if (tx.counterpartyUsername) {
+        contactsSet.add(tx.counterpartyUsername);
+      }
+    }
+
+    const payload = buildGdprExportPayload({
+      userProfile,
+      wallet,
+      transactions,
+      transfers: [...transfersFrom, ...transfersTo],
+      withdrawals,
+      deposits,
+      payLinks,
+      contacts: Array.from(contactsSet).map((username) => ({ username })),
+      notifications,
+      supportTickets,
+      loginHistory,
+      deviceTokens,
+      kycSubmissions,
+      referrals: [...referralsFrom, ...referralsTo],
+      feedback,
+    });
+
+    return createZip([
+      {
+        name: 'README.txt',
+        content: Buffer.from(GDPR_EXPORT_README, 'utf8'),
+      },
+      {
+        name: 'personal-data.json',
+        content: Buffer.from(JSON.stringify(payload, null, 2), 'utf8'),
+      },
+    ]);
+  }
+
+  private async generateStatementPdf(
+    userId: string,
+    params: ReportParams,
+  ): Promise<Buffer> {
+    const dateFrom = String(params.dateFrom ?? '');
+    const dateTo = String(params.dateTo ?? '');
+
+    const userRepo = this.dataSource.getRepository(User);
+    const txRepo = this.dataSource.getRepository(Transaction);
+
+    const user = await userRepo.findOne({ where: { id: userId } });
+    if (!user) {
+      throw new Error('User not found for statement export');
+    }
+
+    const transactions = await txRepo
+      .createQueryBuilder('tx')
+      .where('tx.userId = :userId', { userId })
+      .andWhere('tx.createdAt >= :from', { from: new Date(dateFrom) })
+      .andWhere('tx.createdAt <= :to', { to: new Date(dateTo) })
+      .orderBy('tx.createdAt', 'ASC')
+      .getMany();
+
+    return generateAccountStatementPdf({
+      user: {
+        displayName: user.displayName,
+        username: user.username,
+        tier: user.tier,
+      },
+      dateFrom,
+      dateTo,
+      transactions,
+    });
+  }
+
+  private async lookupUserEmail(userId: string): Promise<string | null> {
+    const user = await this.dataSource.getRepository(User).findOne({ where: { id: userId } });
+    return user?.email ?? null;
   }
 }

--- a/backend/src/reports/reports.service.spec.ts
+++ b/backend/src/reports/reports.service.spec.ts
@@ -117,6 +117,27 @@ describe('ReportsService', () => {
     });
   });
 
+  describe('requestGdprExport', () => {
+    it('enforces one GDPR export per 30 days', async () => {
+      mockRepo.count.mockResolvedValue(1);
+
+      await expect(service.requestGdprExport('user-uuid-1')).rejects.toThrow(
+        BadRequestException,
+      );
+
+      expect(mockRepo.save).not.toHaveBeenCalled();
+      expect(mockQueue.add).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('requestAccountStatement', () => {
+    it('rejects ranges longer than 12 months', async () => {
+      await expect(
+        service.requestAccountStatement('user-uuid-1', '2025-01-01', '2026-12-01'),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
   // ── getForUser ────────────────────────────────────────────────────────────
 
   describe('getForUser', () => {

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -6,9 +6,9 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { InjectQueue } from '@nestjs/bull';
-import { Repository } from 'typeorm';
+import { MoreThanOrEqual, Repository } from 'typeorm';
 import type { Queue } from 'bull';
-import { ReportJob, ReportStatus } from './entities/report-job.entity';
+import { ReportJob, ReportStatus, ReportType } from './entities/report-job.entity';
 import { CreateReportDto } from './dto/create-report.dto';
 
 export const REPORT_QUEUE = 'report-jobs';
@@ -16,6 +16,8 @@ export const GENERATE_REPORT_JOB = 'generate-report';
 export const CLEANUP_REPORT_JOB = 'cleanup-expired-reports';
 
 const MAX_DATE_RANGE_DAYS = 90;
+const MAX_STATEMENT_RANGE_DAYS = 366;
+const GDPR_EXPORT_COOLDOWN_DAYS = 30;
 
 @Injectable()
 export class ReportsService {
@@ -51,14 +53,120 @@ export class ReportsService {
       }),
     );
 
-    await this.queue.add(GENERATE_REPORT_JOB, { jobId: job.id }, {
-      attempts: 3,
-      backoff: { type: 'exponential', delay: 5000 },
-      removeOnComplete: true,
-      removeOnFail: false,
-    });
+    await this.enqueue(job.id);
 
     return job;
+  }
+
+  async requestGdprExport(userId: string): Promise<{ jobId: string; estimatedReadyAt: string }> {
+    const since = new Date(Date.now() - GDPR_EXPORT_COOLDOWN_DAYS * 24 * 60 * 60 * 1000);
+    const recent = await this.repo.count({
+      where: {
+        requestedBy: userId,
+        type: ReportType.GDPR_EXPORT,
+        createdAt: MoreThanOrEqual(since),
+      },
+    });
+
+    if (recent > 0) {
+      throw new BadRequestException('You can request a GDPR export once every 30 days');
+    }
+
+    const job = await this.repo.save(
+      this.repo.create({
+        requestedBy: userId,
+        type: ReportType.GDPR_EXPORT,
+        params: {},
+        status: ReportStatus.QUEUED,
+      }),
+    );
+
+    await this.enqueue(job.id);
+
+    return {
+      jobId: job.id,
+      estimatedReadyAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    };
+  }
+
+  async requestAccountStatement(
+    userId: string,
+    dateFrom: string,
+    dateTo: string,
+  ): Promise<{ jobId: string; estimatedReadyAt: string }> {
+    const from = new Date(dateFrom);
+    const to = new Date(dateTo);
+    const diffDays = (to.getTime() - from.getTime()) / (1000 * 60 * 60 * 24);
+
+    if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) {
+      throw new BadRequestException('Invalid statement date range');
+    }
+    if (diffDays < 0) {
+      throw new BadRequestException('dateFrom must be before dateTo');
+    }
+    if (diffDays > MAX_STATEMENT_RANGE_DAYS) {
+      throw new BadRequestException('Statement range cannot exceed 12 months');
+    }
+
+    const job = await this.repo.save(
+      this.repo.create({
+        requestedBy: userId,
+        type: ReportType.ACCOUNT_STATEMENT,
+        params: { dateFrom, dateTo },
+        status: ReportStatus.QUEUED,
+      }),
+    );
+
+    await this.enqueue(job.id);
+
+    return {
+      jobId: job.id,
+      estimatedReadyAt: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+    };
+  }
+
+  async listAccountExports(userId: string): Promise<ReportJob[]> {
+    return this.repo
+      .createQueryBuilder('r')
+      .where('r.requested_by = :userId', { userId })
+      .andWhere('r.type IN (:...types)', {
+        types: [ReportType.GDPR_EXPORT, ReportType.ACCOUNT_STATEMENT],
+      })
+      .orderBy('r.created_at', 'DESC')
+      .getMany();
+  }
+
+  async getAccountExport(userId: string, id: string): Promise<{
+    id: string;
+    type: ReportType;
+    status: ReportStatus;
+    requestedAt: Date;
+    expiresAt: Date | null;
+    downloadUrl: string | null;
+    errorMessage: string | null;
+  }> {
+    const job = await this.repo
+      .createQueryBuilder('r')
+      .where('r.id = :id', { id })
+      .andWhere('r.requested_by = :userId', { userId })
+      .andWhere('r.type IN (:...types)', {
+        types: [ReportType.GDPR_EXPORT, ReportType.ACCOUNT_STATEMENT],
+      })
+      .getOne();
+
+    if (!job) {
+      throw new NotFoundException('Export job not found');
+    }
+
+    return {
+      id: job.id,
+      type: job.type,
+      status: job.status,
+      requestedAt: job.createdAt,
+      expiresAt: job.expiresAt,
+      downloadUrl: job.status === ReportStatus.READY ? job.fileUrl : null,
+      errorMessage: job.errorMessage,
+    };
   }
 
   async listForUser(userId: string): Promise<ReportJob[]> {
@@ -97,5 +205,14 @@ export class ReportsService {
       await this.repo.remove(expired);
     }
     return expired;
+  }
+
+  private async enqueue(jobId: string): Promise<void> {
+    await this.queue.add(GENERATE_REPORT_JOB, { jobId }, {
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 5000 },
+      removeOnComplete: true,
+      removeOnFail: false,
+    });
   }
 }

--- a/backend/src/reports/statement-pdf.util.spec.ts
+++ b/backend/src/reports/statement-pdf.util.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from '@jest/globals';
+import { computeStatement } from './statement-pdf.util';
+import {
+  Transaction,
+  TransactionStatus,
+  TransactionType,
+} from '../transactions/entities/transaction.entity';
+
+function tx(overrides: Partial<Transaction>): Transaction {
+  return {
+    id: 't1',
+    userId: 'u1',
+    type: TransactionType.DEPOSIT,
+    amountUsdc: '0',
+    amount: 0,
+    currency: 'USDC',
+    fee: '0',
+    balanceAfter: '0',
+    status: TransactionStatus.COMPLETED,
+    reference: null,
+    counterpartyUsername: null,
+    description: null,
+    metadata: {},
+    depositId: null,
+    deposit: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  } as Transaction;
+}
+
+describe('computeStatement', () => {
+  it('calculates running balance boundaries correctly', () => {
+    const rows = [
+      tx({
+        id: 'a',
+        type: TransactionType.DEPOSIT,
+        amountUsdc: '100.00',
+        balanceAfter: '100.00',
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+      }),
+      tx({
+        id: 'b',
+        type: TransactionType.TRANSFER_OUT,
+        amountUsdc: '30.00',
+        fee: '1.50',
+        balanceAfter: '70.00',
+        createdAt: new Date('2026-01-02T00:00:00Z'),
+      }),
+      tx({
+        id: 'c',
+        type: TransactionType.YIELD_CREDIT,
+        amountUsdc: '5.00',
+        balanceAfter: '75.00',
+        createdAt: new Date('2026-01-03T00:00:00Z'),
+      }),
+    ];
+
+    const statement = computeStatement(rows);
+
+    expect(statement.openingBalance).toBe(0);
+    expect(statement.closingBalance).toBe(75);
+    expect(statement.totalIn).toBe(105);
+    expect(statement.totalOut).toBe(30);
+    expect(statement.feesPaid).toBeCloseTo(1.5);
+    expect(statement.rows[1]?.runningBalance).toBe(70);
+  });
+});

--- a/backend/src/reports/statement-pdf.util.ts
+++ b/backend/src/reports/statement-pdf.util.ts
@@ -1,0 +1,193 @@
+import * as PDFDocument from 'pdfkit';
+import { Transaction, TransactionType } from '../transactions/entities/transaction.entity';
+
+interface StatementUser {
+  displayName: string | null;
+  username: string;
+  tier: string;
+}
+
+export interface StatementComputation {
+  openingBalance: number;
+  closingBalance: number;
+  totalIn: number;
+  totalOut: number;
+  feesPaid: number;
+  rows: Array<{
+    createdAt: Date;
+    type: string;
+    reference: string | null;
+    amountSigned: number;
+    fee: number;
+    runningBalance: number;
+    status: string;
+  }>;
+}
+
+const INCOMING_TYPES = new Set<TransactionType>([
+  TransactionType.DEPOSIT,
+  TransactionType.TRANSFER_IN,
+  TransactionType.PAYLINK_RECEIVED,
+  TransactionType.UNSTAKE,
+  TransactionType.YIELD_CREDIT,
+]);
+
+function toNumber(value: string | number | null | undefined): number {
+  if (value === null || value === undefined) {
+    return 0;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function signedAmount(tx: Transaction): number {
+  const amount = toNumber(tx.amountUsdc ?? tx.amount);
+  return INCOMING_TYPES.has(tx.type) ? amount : -amount;
+}
+
+export function computeStatement(transactions: Transaction[]): StatementComputation {
+  const sorted = [...transactions].sort(
+    (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+  );
+
+  if (sorted.length === 0) {
+    return {
+      openingBalance: 0,
+      closingBalance: 0,
+      totalIn: 0,
+      totalOut: 0,
+      feesPaid: 0,
+      rows: [],
+    };
+  }
+
+  const first = sorted[0]!;
+  const openingBalance = toNumber(first.balanceAfter) - signedAmount(first);
+
+  let totalIn = 0;
+  let totalOut = 0;
+  let feesPaid = 0;
+
+  const rows = sorted.map((tx) => {
+    const amountSigned = signedAmount(tx);
+    if (amountSigned >= 0) {
+      totalIn += amountSigned;
+    } else {
+      totalOut += Math.abs(amountSigned);
+    }
+
+    const fee = toNumber(tx.fee);
+    feesPaid += fee;
+
+    return {
+      createdAt: tx.createdAt,
+      type: tx.type,
+      reference: tx.reference,
+      amountSigned,
+      fee,
+      runningBalance: toNumber(tx.balanceAfter),
+      status: tx.status,
+    };
+  });
+
+  const closingBalance = rows[rows.length - 1]!.runningBalance;
+
+  return {
+    openingBalance,
+    closingBalance,
+    totalIn,
+    totalOut,
+    feesPaid,
+    rows,
+  };
+}
+
+export async function generateAccountStatementPdf(params: {
+  user: StatementUser;
+  dateFrom: string;
+  dateTo: string;
+  transactions: Transaction[];
+}): Promise<Buffer> {
+  const summary = computeStatement(params.transactions);
+
+  return new Promise((resolve, reject) => {
+    const doc = new (PDFDocument as any)({ size: 'A4', margin: 40 });
+    const chunks: Buffer[] = [];
+    let page = 1;
+
+    const addHeader = (): void => {
+      doc.font('Helvetica-Bold').fontSize(18).fillColor('#0B3D2E').text('Cheese Account Statement');
+      doc.moveDown(0.4);
+      doc.font('Helvetica').fontSize(10).fillColor('#1A1A1A').text(
+        `Account: ${params.user.displayName ?? params.user.username} (@${params.user.username})`,
+      );
+      doc.text(`Tier: ${params.user.tier}`);
+      doc.text(`Date Range: ${params.dateFrom} to ${params.dateTo}`);
+      doc.text(`Generated At: ${new Date().toISOString()}`);
+      doc.moveDown(0.8);
+    };
+
+    const addFooter = (): void => {
+      doc.font('Helvetica').fontSize(9).fillColor('#666666');
+      doc.text(`Page ${page}`, 40, 800, { align: 'right', width: 520 });
+    };
+
+    const ensureSpace = (height: number): void => {
+      if (doc.y + height <= 760) {
+        return;
+      }
+      addFooter();
+      doc.addPage();
+      page += 1;
+      addHeader();
+    };
+
+    doc.on('data', (chunk: Buffer) => chunks.push(chunk));
+    doc.on('end', () => resolve(Buffer.concat(chunks)));
+    doc.on('error', reject);
+
+    addHeader();
+
+    doc.font('Helvetica-Bold').fontSize(11).text('Summary');
+    doc.font('Helvetica').fontSize(10);
+    doc.text(`Opening Balance: ${summary.openingBalance.toFixed(6)} USDC`);
+    doc.text(`Closing Balance: ${summary.closingBalance.toFixed(6)} USDC`);
+    doc.text(`Total In: ${summary.totalIn.toFixed(6)} USDC`);
+    doc.text(`Total Out: ${summary.totalOut.toFixed(6)} USDC`);
+    doc.text(`Fees Paid: ${summary.feesPaid.toFixed(6)} USDC`);
+    doc.moveDown(0.8);
+
+    doc.font('Helvetica-Bold').fontSize(11).text('Transactions');
+    doc.moveDown(0.4);
+
+    if (summary.rows.length === 0) {
+      doc.font('Helvetica').fontSize(10).text('No transactions in this period.');
+    } else {
+      doc.font('Helvetica-Bold').fontSize(9).text(
+        'Date                 Type                  Reference                Amount        Fee      Running Bal.   Status',
+      );
+      doc.moveDown(0.2);
+
+      for (const row of summary.rows) {
+        ensureSpace(16);
+        const date = row.createdAt.toISOString().slice(0, 10);
+        const type = row.type.slice(0, 20).padEnd(20, ' ');
+        const ref = (row.reference ?? '-').slice(0, 22).padEnd(22, ' ');
+        const amount = `${row.amountSigned >= 0 ? '+' : ''}${row.amountSigned.toFixed(2)}`.padStart(8, ' ');
+        const fee = row.fee.toFixed(2).padStart(8, ' ');
+        const bal = row.runningBalance.toFixed(2).padStart(10, ' ');
+        doc.font('Helvetica').fontSize(8.5).text(
+          `${date}   ${type}   ${ref}   ${amount}   ${fee}   ${bal}   ${row.status}`,
+        );
+      }
+    }
+
+    ensureSpace(60);
+    doc.moveDown(1);
+    doc.font('Helvetica').fontSize(10).text('Digital Signature', { underline: false });
+    doc.moveTo(40, doc.y + 6).lineTo(260, doc.y + 6).strokeColor('#111111').stroke();
+
+    addFooter();
+    doc.end();
+  });
+}

--- a/backend/src/reports/zip.util.ts
+++ b/backend/src/reports/zip.util.ts
@@ -1,0 +1,105 @@
+interface ZipEntry {
+  name: string;
+  content: Buffer;
+}
+
+const CRC_TABLE = (() => {
+  const table: number[] = [];
+  for (let i = 0; i < 256; i += 1) {
+    let c = i;
+    for (let j = 0; j < 8; j += 1) {
+      c = (c & 1) ? (0xedb88320 ^ (c >>> 1)) : (c >>> 1);
+    }
+    table[i] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(buffer: Buffer): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < buffer.length; i += 1) {
+    crc = CRC_TABLE[(crc ^ buffer[i]!) & 0xff]! ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function writeUInt16LE(value: number): Buffer {
+  const buf = Buffer.allocUnsafe(2);
+  buf.writeUInt16LE(value, 0);
+  return buf;
+}
+
+function writeUInt32LE(value: number): Buffer {
+  const buf = Buffer.allocUnsafe(4);
+  buf.writeUInt32LE(value >>> 0, 0);
+  return buf;
+}
+
+export function createZip(entries: ZipEntry[]): Buffer {
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const fileName = Buffer.from(entry.name, 'utf8');
+    const data = entry.content;
+    const checksum = crc32(data);
+
+    const localHeader = Buffer.concat([
+      writeUInt32LE(0x04034b50),
+      writeUInt16LE(20),
+      writeUInt16LE(0),
+      writeUInt16LE(0),
+      writeUInt16LE(0),
+      writeUInt16LE(0),
+      writeUInt32LE(checksum),
+      writeUInt32LE(data.length),
+      writeUInt32LE(data.length),
+      writeUInt16LE(fileName.length),
+      writeUInt16LE(0),
+      fileName,
+    ]);
+
+    localParts.push(localHeader, data);
+
+    const centralHeader = Buffer.concat([
+      writeUInt32LE(0x02014b50),
+      writeUInt16LE(20),
+      writeUInt16LE(20),
+      writeUInt16LE(0),
+      writeUInt16LE(0),
+      writeUInt16LE(0),
+      writeUInt16LE(0),
+      writeUInt32LE(checksum),
+      writeUInt32LE(data.length),
+      writeUInt32LE(data.length),
+      writeUInt16LE(fileName.length),
+      writeUInt16LE(0),
+      writeUInt16LE(0),
+      writeUInt16LE(0),
+      writeUInt16LE(0),
+      writeUInt32LE(0),
+      writeUInt32LE(offset),
+      fileName,
+    ]);
+
+    centralParts.push(centralHeader);
+    offset += localHeader.length + data.length;
+  }
+
+  const centralDirectory = Buffer.concat(centralParts);
+  const centralOffset = offset;
+
+  const end = Buffer.concat([
+    writeUInt32LE(0x06054b50),
+    writeUInt16LE(0),
+    writeUInt16LE(0),
+    writeUInt16LE(entries.length),
+    writeUInt16LE(entries.length),
+    writeUInt32LE(centralDirectory.length),
+    writeUInt32LE(centralOffset),
+    writeUInt16LE(0),
+  ]);
+
+  return Buffer.concat([...localParts, centralDirectory, end]);
+}


### PR DESCRIPTION
## Summary
- adds user-facing account export endpoints for GDPR data portability and account statements
- extends async report jobs with gdpr_export and account_statement types
- generates GDPR ZIP exports and statement PDFs, uploads to R2, and emails download links

## Key Notes
- enforces one GDPR export request per 30 days
- enforces statement date range up to 12 months
- GDPR download links expire after 48 hours

## Issue
- Closes #495 
