### PR TITLE
feat(tier): in-app upgrade flow with KYC gating and pending target

### DIFF
--- a/backend/src/database/migrations/1770500000000-AddPendingTierUpgradeToUsers.ts
+++ b/backend/src/database/migrations/1770500000000-AddPendingTierUpgradeToUsers.ts
@@ -1,0 +1,18 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddPendingTierUpgradeToUsers1770500000000 implements MigrationInterface {
+  name = 'AddPendingTierUpgradeToUsers1770500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "users"
+      ADD COLUMN IF NOT EXISTS "pending_tier_upgrade" character varying(10) NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "users" DROP COLUMN IF EXISTS "pending_tier_upgrade"
+    `);
+  }
+}

--- a/backend/src/kyc/kyc.module.ts
+++ b/backend/src/kyc/kyc.module.ts
@@ -9,6 +9,7 @@ import { EmailModule } from '../email/email.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { R2Module } from '../r2/r2.module';
 import { PremblyModule } from '../prembly/prembly.module';
+import { TierConfigModule } from '../tier-config/tier-config.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { PremblyModule } from '../prembly/prembly.module';
     NotificationsModule,
     R2Module,
     PremblyModule,
+    TierConfigModule,
   ],
   providers: [KycService],
   controllers: [KycController],

--- a/backend/src/kyc/kyc.service.spec.ts
+++ b/backend/src/kyc/kyc.service.spec.ts
@@ -1,3 +1,11 @@
+jest.mock('../r2/r2.service', () => ({
+  R2Service: class MockR2Service {},
+}));
+
+jest.mock('../prembly/prembly.service', () => ({
+  PremblyService: class MockPremblyService {},
+}));
+
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ConflictException, NotFoundException } from '@nestjs/common';
@@ -8,6 +16,10 @@ import { TierName } from '../tier-config/entities/tier-config.entity';
 import { EmailService } from '../email/email.service';
 import { NotificationService } from '../notifications/notifications.service';
 import { r2Config } from '../config/r2.config';
+import { VerificationResult } from './entities/verification-result.entity';
+import { R2Service } from '../r2/r2.service';
+import { PremblyService } from '../prembly/prembly.service';
+import { TierUpgradeService } from '../tier-config/tier-upgrade.service';
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
@@ -25,6 +37,25 @@ const mockUserRepo = {
 
 const mockEmail = { queue: jest.fn().mockResolvedValue({}) };
 const mockNotification = { create: jest.fn().mockResolvedValue({}) };
+
+const mockVerificationRepo = {
+  create: jest.fn(),
+  save: jest.fn(),
+};
+
+const mockR2 = {
+  getPresignedDownloadUrl: jest.fn(),
+};
+
+const mockPrembly = {
+  verifyBvn: jest.fn(),
+  verifyNin: jest.fn(),
+};
+
+const mockTierUpgrade = {
+  checkAutoUpgrade: jest.fn(),
+  applySubmissionTierAfterKyc: jest.fn(),
+};
 
 const mockR2Config = {
   accountId: 'test-account',
@@ -86,9 +117,16 @@ describe('KycService', () => {
         KycService,
         { provide: getRepositoryToken(KycSubmission), useValue: mockKycRepo },
         { provide: getRepositoryToken(User), useValue: mockUserRepo },
+        {
+          provide: getRepositoryToken(VerificationResult),
+          useValue: mockVerificationRepo,
+        },
         { provide: r2Config.KEY, useValue: mockR2Config },
+        { provide: R2Service, useValue: mockR2 },
         { provide: EmailService, useValue: mockEmail },
         { provide: NotificationService, useValue: mockNotification },
+        { provide: PremblyService, useValue: mockPrembly },
+        { provide: TierUpgradeService, useValue: mockTierUpgrade },
       ],
     }).compile();
 
@@ -152,14 +190,22 @@ describe('KycService', () => {
       mockKycRepo.findOne.mockResolvedValue(submission);
       mockKycRepo.save.mockResolvedValue({ ...submission, status: KycSubmissionStatus.APPROVED });
       mockUserRepo.update.mockResolvedValue(undefined);
-      mockUserRepo.findOne.mockResolvedValue(makeUser());
+      mockTierUpgrade.checkAutoUpgrade.mockResolvedValue(false);
+      mockTierUpgrade.applySubmissionTierAfterKyc.mockResolvedValue(undefined);
+      mockUserRepo.findOne.mockResolvedValue(
+        makeUser({ tier: TierName.GOLD, kycStatus: KycStatus.APPROVED }),
+      );
 
       const result = await service.approve('kyc-uuid-1', 'admin-uuid');
 
       expect(mockUserRepo.update).toHaveBeenCalledWith('user-uuid-1', {
-        tier: TierName.GOLD,
         kycStatus: KycStatus.APPROVED,
       });
+      expect(mockTierUpgrade.checkAutoUpgrade).toHaveBeenCalledWith('user-uuid-1');
+      expect(mockTierUpgrade.applySubmissionTierAfterKyc).toHaveBeenCalledWith(
+        'user-uuid-1',
+        TierName.GOLD,
+      );
       expect(mockNotification.create).toHaveBeenCalledWith(
         'user-uuid-1',
         'tier_upgraded',
@@ -168,10 +214,30 @@ describe('KycService', () => {
         expect.any(Object),
       );
       await new Promise(process.nextTick);
-      expect(mockEmail.queue).toHaveBeenCalledWith(
-        'alice@example.com', 'kyc-approved', expect.any(Object),
-      );
+      expect(mockEmail.queue).not.toHaveBeenCalled();
       expect(result.status).toBe(KycSubmissionStatus.APPROVED);
+    });
+
+    it('uses pending tier when checkAutoUpgrade applies it', async () => {
+      const submission = makeSubmission({ status: KycSubmissionStatus.PENDING });
+      mockKycRepo.findOne.mockResolvedValue(submission);
+      mockKycRepo.save.mockResolvedValue({ ...submission, status: KycSubmissionStatus.APPROVED });
+      mockUserRepo.update.mockResolvedValue(undefined);
+      mockTierUpgrade.checkAutoUpgrade.mockResolvedValue(true);
+      mockUserRepo.findOne.mockResolvedValue(
+        makeUser({ tier: TierName.BLACK, kycStatus: KycStatus.APPROVED }),
+      );
+
+      await service.approve('kyc-uuid-1', 'admin-uuid');
+
+      expect(mockTierUpgrade.applySubmissionTierAfterKyc).not.toHaveBeenCalled();
+      expect(mockNotification.create).toHaveBeenCalledWith(
+        'user-uuid-1',
+        'tier_upgraded',
+        'KYC Approved',
+        expect.stringContaining('Black'),
+        expect.any(Object),
+      );
     });
 
     it('throws 404 for unknown submission id', async () => {

--- a/backend/src/kyc/kyc.service.ts
+++ b/backend/src/kyc/kyc.service.ts
@@ -17,6 +17,7 @@ import { NotificationService } from '../notifications/notifications.service';
 import { NotificationType } from '../notifications/notifications.types';
 import { R2Service } from '../r2/r2.service';
 import { PremblyService, VerifyResult } from '../prembly/prembly.service';
+import { TierUpgradeService } from '../tier-config/tier-upgrade.service';
 
 @Injectable()
 export class KycService {
@@ -31,6 +32,7 @@ export class KycService {
     private readonly emailService: EmailService,
     private readonly notificationService: NotificationService,
     private readonly premblyService: PremblyService,
+    private readonly tierUpgradeService: TierUpgradeService,
   ) {}
 
   // ── User endpoints ──────────────────────────────────────────────────────────
@@ -130,27 +132,31 @@ export class KycService {
     submission.reviewedAt = new Date();
     await this.repo.save(submission);
 
-    const newTier = submission.targetTier as TierName;
     await this.userRepo.update(submission.userId, {
-      tier: newTier,
       kycStatus: KycStatus.APPROVED,
     });
 
+    const upgradedViaPending = await this.tierUpgradeService.checkAutoUpgrade(
+      submission.userId,
+    );
+
+    if (!upgradedViaPending) {
+      await this.tierUpgradeService.applySubmissionTierAfterKyc(
+        submission.userId,
+        submission.targetTier as TierName,
+      );
+    }
+
     const user = await this.userRepo.findOne({ where: { id: submission.userId } });
+    const effectiveTier = user?.tier ?? (submission.targetTier as TierName);
 
     await this.notificationService.create(
       submission.userId,
       NotificationType.TIER_UPGRADED,
       'KYC Approved',
-      `Your KYC has been approved. You are now on the ${newTier} tier.`,
-      { submissionId: id, tier: newTier },
+      `Your KYC has been approved. You are now on the ${effectiveTier} tier.`,
+      { submissionId: id, tier: effectiveTier },
     );
-
-    if (user) {
-      this.emailService
-        .queue(user.email, 'kyc-approved', { tier: newTier })
-        .catch(() => undefined);
-    }
 
     return submission;
   }

--- a/backend/src/tier-config/dto/initiate-tier-upgrade.dto.ts
+++ b/backend/src/tier-config/dto/initiate-tier-upgrade.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+import { TierName } from '../entities/tier-config.entity';
+
+export class InitiateTierUpgradeDto {
+  @ApiProperty({ enum: TierName, example: TierName.GOLD })
+  @IsEnum(TierName)
+  targetTier!: TierName;
+}

--- a/backend/src/tier-config/dto/tier-benefits.dto.ts
+++ b/backend/src/tier-config/dto/tier-benefits.dto.ts
@@ -1,0 +1,101 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { TierName } from '../entities/tier-config.entity';
+
+export class TierLimitPairDto {
+  @ApiProperty({ example: '1000.00000000' })
+  current!: string;
+
+  @ApiProperty({ example: '5000.00000000' })
+  target!: string;
+}
+
+export class TierFeeDiscountPairDto {
+  @ApiProperty({ example: 0 })
+  current!: number;
+
+  @ApiProperty({ example: 20 })
+  target!: number;
+}
+
+export class TierVirtualCardPairDto {
+  @ApiProperty({ example: false })
+  current!: boolean;
+
+  @ApiProperty({ example: true })
+  target!: boolean;
+}
+
+/** Side-by-side comparison of current vs target tier limits and perks. */
+export class TierBenefitsDto {
+  @ApiProperty({ type: TierLimitPairDto })
+  dailyTransferLimitUsdc!: TierLimitPairDto;
+
+  @ApiProperty({ type: TierLimitPairDto })
+  monthlyTransferLimitUsdc!: TierLimitPairDto;
+
+  @ApiProperty({ type: TierFeeDiscountPairDto })
+  feeDiscountPercent!: TierFeeDiscountPairDto;
+
+  @ApiProperty({ type: TierLimitPairDto })
+  yieldApyPercent!: TierLimitPairDto;
+
+  @ApiProperty({ type: TierLimitPairDto })
+  minStakeAmountUsdc!: TierLimitPairDto;
+
+  /** Virtual card access is available from Gold upward. */
+  @ApiProperty({ type: TierVirtualCardPairDto })
+  virtualCardAccess!: TierVirtualCardPairDto;
+}
+
+export class TierUpgradeRequirementsDto {
+  @ApiProperty()
+  emailVerified!: boolean;
+
+  @ApiProperty()
+  phoneVerified!: boolean;
+
+  @ApiProperty({
+    description: 'Whether KYC must be completed to reach the target tier',
+  })
+  kycRequired!: boolean;
+
+  @ApiProperty({ example: 'none' })
+  kycStatus!: string;
+
+  @ApiProperty({ enum: TierName })
+  currentTier!: TierName;
+
+  @ApiProperty({ enum: TierName })
+  targetTier!: TierName;
+
+  @ApiProperty({ type: TierBenefitsDto })
+  benefits!: TierBenefitsDto;
+}
+
+export class TierBenefitsRowDto {
+  @ApiProperty({ enum: TierName })
+  tier!: TierName;
+
+  @ApiProperty()
+  dailyTransferLimitUsdc!: string;
+
+  @ApiProperty()
+  monthlyTransferLimitUsdc!: string;
+
+  @ApiProperty()
+  feeDiscountPercent!: number;
+
+  @ApiProperty()
+  yieldApyPercent!: string;
+
+  @ApiProperty()
+  minStakeAmountUsdc!: string;
+
+  @ApiProperty()
+  virtualCardAccess!: boolean;
+}
+
+export class TierBenefitsTableDto {
+  @ApiProperty({ type: [TierBenefitsRowDto] })
+  tiers!: TierBenefitsRowDto[];
+}

--- a/backend/src/tier-config/dto/tier-upgrade-requirements-query.dto.ts
+++ b/backend/src/tier-config/dto/tier-upgrade-requirements-query.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+import { TierName } from '../entities/tier-config.entity';
+
+export class TierUpgradeRequirementsQueryDto {
+  @ApiProperty({ enum: TierName, example: TierName.GOLD })
+  @IsEnum(TierName)
+  target!: TierName;
+}

--- a/backend/src/tier-config/tier-config.module.ts
+++ b/backend/src/tier-config/tier-config.module.ts
@@ -4,12 +4,17 @@ import { TierConfig } from './entities/tier-config.entity';
 import { User } from '../users/entities/user.entity';
 import { Transaction } from '../transactions/entities/transaction.entity';
 import { TierService } from './tier.service';
+import { TierUpgradeService } from './tier-upgrade.service';
 import { TierController } from './tier.controller';
+import { EmailModule } from '../email/email.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([TierConfig, User, Transaction])],
-  providers: [TierService],
+  imports: [
+    TypeOrmModule.forFeature([TierConfig, User, Transaction]),
+    EmailModule,
+  ],
+  providers: [TierService, TierUpgradeService],
   controllers: [TierController],
-  exports: [TierService],
+  exports: [TierService, TierUpgradeService],
 })
 export class TierConfigModule {}

--- a/backend/src/tier-config/tier-upgrade.service.spec.ts
+++ b/backend/src/tier-config/tier-upgrade.service.spec.ts
@@ -1,0 +1,215 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { TierUpgradeService } from './tier-upgrade.service';
+import { TierService } from './tier.service';
+import { TierConfig, TierName } from './entities/tier-config.entity';
+import { User, KycStatus } from '../users/entities/user.entity';
+import { EmailService } from '../email/email.service';
+
+const mockCfg = (tier: TierName, overrides: Partial<TierConfig> = {}): TierConfig =>
+  ({
+    id: 'cfg-id',
+    tier,
+    dailyTransferLimitUsdc: '1000',
+    monthlyTransferLimitUsdc: '10000',
+    maxSingleWithdrawalUsdc: '500',
+    feeDiscountPercent: tier === TierName.SILVER ? 0 : tier === TierName.GOLD ? 20 : 50,
+    yieldApyPercent: '1.00',
+    minStakeAmountUsdc: '0',
+    stakeLockupDays: 0,
+    isActive: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }) as TierConfig;
+
+describe('TierUpgradeService', () => {
+  let service: TierUpgradeService;
+
+  const tierRepo = {
+    findOne: jest.fn(),
+    find: jest.fn(),
+  };
+
+  const userRepo = {
+    findOne: jest.fn(),
+    update: jest.fn(),
+  };
+
+  const tierService = {
+    upgradeTier: jest.fn(),
+  };
+
+  const emailService = {
+    queue: jest.fn().mockResolvedValue({}),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TierUpgradeService,
+        { provide: getRepositoryToken(TierConfig), useValue: tierRepo },
+        { provide: getRepositoryToken(User), useValue: userRepo },
+        { provide: TierService, useValue: tierService },
+        { provide: EmailService, useValue: emailService },
+      ],
+    }).compile();
+
+    service = module.get(TierUpgradeService);
+  });
+
+  describe('initiateUpgrade', () => {
+    const baseUser: Partial<User> = {
+      id: 'u1',
+      emailVerified: true,
+      phoneVerified: true,
+      tier: TierName.SILVER,
+      kycStatus: KycStatus.APPROVED,
+      pendingTierUpgrade: null,
+    };
+
+    it('upgrades immediately when all requirements met', async () => {
+      const u = { ...baseUser, email: 'a@b.c' } as User;
+      userRepo.findOne.mockResolvedValueOnce(u).mockResolvedValueOnce(u);
+      tierRepo.findOne.mockResolvedValue(mockCfg(TierName.GOLD));
+      tierService.upgradeTier.mockResolvedValue({
+        ...u,
+        tier: TierName.GOLD,
+      });
+      userRepo.update.mockResolvedValue(undefined);
+
+      const result = await service.initiateUpgrade('u1', TierName.GOLD);
+
+      expect(result).toEqual({ status: 'upgraded', tier: TierName.GOLD });
+      expect(tierService.upgradeTier).toHaveBeenCalledWith('u1', TierName.GOLD);
+      expect(userRepo.update).toHaveBeenCalledWith('u1', {
+        pendingTierUpgrade: null,
+      });
+      expect(emailService.queue).toHaveBeenCalledWith(
+        expect.any(String),
+        'tier-upgraded',
+        expect.objectContaining({ tier: TierName.GOLD }),
+      );
+    });
+
+    it('throws 400 when KYC pending and sets pending tier', async () => {
+      userRepo.findOne.mockResolvedValue({
+        ...baseUser,
+        kycStatus: KycStatus.PENDING,
+      } as User);
+      userRepo.update.mockResolvedValue(undefined);
+
+      await expect(service.initiateUpgrade('u1', TierName.GOLD)).rejects.toThrow(
+        'KYC review in progress, upgrade will be automatic on approval',
+      );
+
+      expect(userRepo.update).toHaveBeenCalledWith('u1', {
+        pendingTierUpgrade: TierName.GOLD,
+      });
+      expect(tierService.upgradeTier).not.toHaveBeenCalled();
+    });
+
+    it('throws 400 with redirect when KYC not submitted', async () => {
+      userRepo.findOne.mockResolvedValue({
+        ...baseUser,
+        kycStatus: KycStatus.NONE,
+      } as User);
+      userRepo.update.mockResolvedValue(undefined);
+
+      try {
+        await service.initiateUpgrade('u1', TierName.GOLD);
+        fail('expected throw');
+      } catch (e) {
+        expect(e).toBeInstanceOf(BadRequestException);
+        const r = (e as BadRequestException).getResponse() as {
+          message: string;
+          redirectTo: string;
+        };
+        expect(r.message).toBe('Please complete KYC verification first');
+        expect(r.redirectTo).toBe('/kyc');
+      }
+
+      expect(userRepo.update).toHaveBeenCalledWith('u1', {
+        pendingTierUpgrade: TierName.GOLD,
+      });
+    });
+
+    it('rejects same tier (Silver → Silver)', async () => {
+      userRepo.findOne.mockResolvedValue({
+        ...baseUser,
+        tier: TierName.SILVER,
+      } as User);
+
+      await expect(
+        service.initiateUpgrade('u1', TierName.SILVER),
+      ).rejects.toThrow(BadRequestException);
+      expect(tierService.upgradeTier).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('checkAutoUpgrade', () => {
+    it('applies pending tier on KYC approval path', async () => {
+      userRepo.findOne.mockResolvedValue({
+        id: 'u1',
+        email: 'a@b.c',
+        tier: TierName.SILVER,
+        pendingTierUpgrade: TierName.GOLD,
+      } as User);
+      tierService.upgradeTier.mockResolvedValue({} as User);
+      userRepo.update.mockResolvedValue(undefined);
+      tierRepo.findOne.mockResolvedValue(mockCfg(TierName.GOLD));
+
+      const ok = await service.checkAutoUpgrade('u1');
+
+      expect(ok).toBe(true);
+      expect(tierService.upgradeTier).toHaveBeenCalledWith('u1', TierName.GOLD);
+      expect(userRepo.update).toHaveBeenCalledWith('u1', {
+        pendingTierUpgrade: null,
+      });
+    });
+
+    it('returns false when no pending target', async () => {
+      userRepo.findOne.mockResolvedValue({
+        id: 'u1',
+        pendingTierUpgrade: null,
+      } as User);
+
+      const ok = await service.checkAutoUpgrade('u1');
+
+      expect(ok).toBe(false);
+      expect(tierService.upgradeTier).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getUpgradeRequirements', () => {
+    it('throws when user missing', async () => {
+      userRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.getUpgradeRequirements('x', TierName.GOLD),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('returns kycRequired for Gold target when KYC not approved', async () => {
+      userRepo.findOne.mockResolvedValue({
+        id: 'u1',
+        emailVerified: true,
+        phoneVerified: true,
+        tier: TierName.SILVER,
+        kycStatus: KycStatus.NONE,
+      } as User);
+      tierRepo.findOne
+        .mockResolvedValueOnce(mockCfg(TierName.SILVER))
+        .mockResolvedValueOnce(mockCfg(TierName.GOLD));
+
+      const r = await service.getUpgradeRequirements('u1', TierName.GOLD);
+      expect(r.kycRequired).toBe(true);
+      expect(r.benefits.virtualCardAccess).toEqual({
+        current: false,
+        target: true,
+      });
+    });
+  });
+});

--- a/backend/src/tier-config/tier-upgrade.service.ts
+++ b/backend/src/tier-config/tier-upgrade.service.ts
@@ -1,0 +1,277 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TierConfig, TierName } from './entities/tier-config.entity';
+import { User, KycStatus } from '../users/entities/user.entity';
+import { TierService } from './tier.service';
+import { EmailService } from '../email/email.service';
+import {
+  TierBenefitsDto,
+  TierBenefitsRowDto,
+  TierBenefitsTableDto,
+  TierUpgradeRequirementsDto,
+} from './dto/tier-benefits.dto';
+
+const TIER_RANK: Record<TierName, number> = {
+  [TierName.SILVER]: 0,
+  [TierName.GOLD]: 1,
+  [TierName.BLACK]: 2,
+};
+
+function tierRank(tier: TierName): number {
+  return TIER_RANK[tier];
+}
+
+function virtualCardAccessForTier(tier: TierName): boolean {
+  return tierRank(tier) >= tierRank(TierName.GOLD);
+}
+
+@Injectable()
+export class TierUpgradeService {
+  constructor(
+    @InjectRepository(TierConfig)
+    private readonly tierRepo: Repository<TierConfig>,
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+    private readonly tierService: TierService,
+    private readonly emailService: EmailService,
+  ) {}
+
+  async getUpgradeRequirements(
+    userId: string,
+    targetTier: TierName,
+  ): Promise<TierUpgradeRequirementsDto> {
+    const user = await this.userRepo.findOne({ where: { id: userId } });
+    if (!user) throw new NotFoundException('User not found');
+
+    const currentCfg = await this.requireConfigForTier(user.tier);
+    const targetCfg = await this.requireConfigForTier(targetTier);
+
+    const kycRequired =
+      tierRank(targetTier) > tierRank(TierName.SILVER) &&
+      user.kycStatus !== KycStatus.APPROVED;
+
+    return {
+      emailVerified: user.emailVerified,
+      phoneVerified: user.phoneVerified,
+      kycRequired,
+      kycStatus: user.kycStatus,
+      currentTier: user.tier,
+      targetTier,
+      benefits: this.buildBenefitsDto(currentCfg, targetCfg),
+    };
+  }
+
+  async initiateUpgrade(
+    userId: string,
+    targetTier: TierName,
+  ): Promise<{ status: 'upgraded'; tier: TierName }> {
+    const user = await this.userRepo.findOne({ where: { id: userId } });
+    if (!user) throw new NotFoundException('User not found');
+
+    if (user.tier === targetTier) {
+      throw new BadRequestException(
+        'You are already on this tier; choose a higher tier to upgrade.',
+      );
+    }
+
+    if (tierRank(targetTier) < tierRank(user.tier)) {
+      throw new BadRequestException('Tier downgrades are not supported');
+    }
+
+    if (!user.emailVerified || !user.phoneVerified) {
+      throw new BadRequestException(
+        'Verify your email and phone before upgrading tiers',
+      );
+    }
+
+    if (user.kycStatus === KycStatus.APPROVED) {
+      await this.tierService.upgradeTier(userId, targetTier);
+      await this.userRepo.update(userId, { pendingTierUpgrade: null });
+      await this.sendTierUpgradedEmail(userId, targetTier);
+      return { status: 'upgraded', tier: targetTier };
+    }
+
+    await this.userRepo.update(userId, { pendingTierUpgrade: targetTier });
+
+    if (user.kycStatus === KycStatus.PENDING) {
+      throw new BadRequestException(
+        'KYC review in progress, upgrade will be automatic on approval',
+      );
+    }
+
+    throw new BadRequestException({
+      message: 'Please complete KYC verification first',
+      redirectTo: '/kyc',
+    });
+  }
+
+  /**
+   * Called after KYC is marked approved. Applies pending target tier if set.
+   * @returns true when a pending upgrade was applied
+   */
+  async checkAutoUpgrade(userId: string): Promise<boolean> {
+    const user = await this.userRepo.findOne({ where: { id: userId } });
+    if (!user?.pendingTierUpgrade) return false;
+
+    const target = user.pendingTierUpgrade;
+    await this.tierService.upgradeTier(userId, target);
+    await this.userRepo.update(userId, { pendingTierUpgrade: null });
+    await this.sendTierUpgradedEmail(userId, target);
+    return true;
+  }
+
+  /** When KYC is approved and there was no pending in-app upgrade target. */
+  async applySubmissionTierAfterKyc(
+    userId: string,
+    submissionTargetTier: TierName,
+  ): Promise<void> {
+    await this.tierService.upgradeTier(userId, submissionTargetTier);
+    await this.sendTierUpgradedEmail(userId, submissionTargetTier);
+  }
+
+  async getUpgradeStatus(userId: string): Promise<{
+    pendingTargetTier: TierName | null;
+    blockingReasons: string[];
+    requirements: TierUpgradeRequirementsDto | null;
+  }> {
+    const user = await this.userRepo.findOne({ where: { id: userId } });
+    if (!user) throw new NotFoundException('User not found');
+
+    const pendingTargetTier = user.pendingTierUpgrade;
+    if (!pendingTargetTier) {
+      return {
+        pendingTargetTier: null,
+        blockingReasons: [],
+        requirements: null,
+      };
+    }
+
+    const requirements = await this.getUpgradeRequirements(
+      userId,
+      pendingTargetTier,
+    );
+    const blockingReasons = this.blockingReasonsFromRequirements(requirements);
+
+    return { pendingTargetTier, blockingReasons, requirements };
+  }
+
+  async getPublicTierBenefitsTable(): Promise<TierBenefitsTableDto> {
+    const configs = await this.tierRepo.find({
+      where: { isActive: true },
+      order: { tier: 'ASC' },
+    });
+
+    const byTier = new Map<TierName, TierConfig>();
+    for (const c of configs) {
+      byTier.set(c.tier, c);
+    }
+
+    const tiers: TierBenefitsRowDto[] = [TierName.SILVER, TierName.GOLD, TierName.BLACK].map(
+      (name) => {
+        const cfg = byTier.get(name);
+        if (!cfg) {
+          return {
+            tier: name,
+            dailyTransferLimitUsdc: '0',
+            monthlyTransferLimitUsdc: '0',
+            feeDiscountPercent: 0,
+            yieldApyPercent: '0.00',
+            minStakeAmountUsdc: '0',
+            virtualCardAccess: virtualCardAccessForTier(name),
+          };
+        }
+        return {
+          tier: name,
+          dailyTransferLimitUsdc: cfg.dailyTransferLimitUsdc,
+          monthlyTransferLimitUsdc: cfg.monthlyTransferLimitUsdc,
+          feeDiscountPercent: cfg.feeDiscountPercent,
+          yieldApyPercent: cfg.yieldApyPercent,
+          minStakeAmountUsdc: cfg.minStakeAmountUsdc,
+          virtualCardAccess: virtualCardAccessForTier(name),
+        };
+      },
+    );
+
+    return { tiers };
+  }
+
+  async sendTierUpgradedEmail(
+    userId: string,
+    newTier: TierName,
+  ): Promise<void> {
+    const user = await this.userRepo.findOne({ where: { id: userId } });
+    if (!user) return;
+
+    const cfg = await this.tierRepo.findOne({ where: { tier: newTier } });
+    const benefitsSummary = cfg
+      ? {
+          dailyTransferLimitUsdc: cfg.dailyTransferLimitUsdc,
+          monthlyTransferLimitUsdc: cfg.monthlyTransferLimitUsdc,
+          feeDiscountPercent: cfg.feeDiscountPercent,
+          yieldApyPercent: cfg.yieldApyPercent,
+          minStakeAmountUsdc: cfg.minStakeAmountUsdc,
+          virtualCardAccess: virtualCardAccessForTier(newTier),
+        }
+      : { tier: newTier };
+
+    await this.emailService
+      .queue(user.email, 'tier-upgraded', {
+        tier: newTier,
+        benefitsSummary,
+      })
+      .catch(() => undefined);
+  }
+
+  private blockingReasonsFromRequirements(
+    r: TierUpgradeRequirementsDto,
+  ): string[] {
+    const reasons: string[] = [];
+    if (!r.emailVerified) reasons.push('email_not_verified');
+    if (!r.phoneVerified) reasons.push('phone_not_verified');
+    if (r.kycRequired) reasons.push('kyc_not_approved');
+    return reasons;
+  }
+
+  private async requireConfigForTier(tier: TierName): Promise<TierConfig> {
+    const cfg = await this.tierRepo.findOne({ where: { tier, isActive: true } });
+    if (!cfg) throw new NotFoundException(`Tier configuration not found for ${tier}`);
+    return cfg;
+  }
+
+  private buildBenefitsDto(
+    current: TierConfig,
+    target: TierConfig,
+  ): TierBenefitsDto {
+    return {
+      dailyTransferLimitUsdc: {
+        current: current.dailyTransferLimitUsdc,
+        target: target.dailyTransferLimitUsdc,
+      },
+      monthlyTransferLimitUsdc: {
+        current: current.monthlyTransferLimitUsdc,
+        target: target.monthlyTransferLimitUsdc,
+      },
+      feeDiscountPercent: {
+        current: current.feeDiscountPercent,
+        target: target.feeDiscountPercent,
+      },
+      yieldApyPercent: {
+        current: current.yieldApyPercent,
+        target: target.yieldApyPercent,
+      },
+      minStakeAmountUsdc: {
+        current: current.minStakeAmountUsdc,
+        target: target.minStakeAmountUsdc,
+      },
+      virtualCardAccess: {
+        current: virtualCardAccessForTier(current.tier),
+        target: virtualCardAccessForTier(target.tier),
+      },
+    };
+  }
+}

--- a/backend/src/tier-config/tier.controller.ts
+++ b/backend/src/tier-config/tier.controller.ts
@@ -1,19 +1,36 @@
 import {
+  Body,
   Controller,
   Get,
-  Patch,
-  Body,
   Param,
+  Patch,
+  Post,
+  Query,
+  Req,
   UseInterceptors,
+  UsePipes,
+  ValidationPipe,
 } from '@nestjs/common';
+import type { Request } from 'express';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { TierService } from './tier.service';
+import { TierUpgradeService } from './tier-upgrade.service';
 import { TierName } from './entities/tier-config.entity';
 import { Public } from '../auth/decorators/public.decorator';
 import { AuditInterceptor, Audit } from '../audit/audit.interceptor';
+import { User } from '../users/entities/user.entity';
+import { TierUpgradeRequirementsQueryDto } from './dto/tier-upgrade-requirements-query.dto';
+import { InitiateTierUpgradeDto } from './dto/initiate-tier-upgrade.dto';
 
+type AuthReq = Request & { user: User };
+
+@ApiTags('tier')
 @Controller({ version: '1' })
 export class TierController {
-  constructor(private readonly tierService: TierService) {}
+  constructor(
+    private readonly tierService: TierService,
+    private readonly tierUpgradeService: TierUpgradeService,
+  ) {}
 
   @Public()
   @Get('tier')
@@ -25,6 +42,47 @@ export class TierController {
   @Get('tier/limits')
   async getAllLimits() {
     return this.tierService.getTierConfigs();
+  }
+
+  @Public()
+  @Get('tier/benefits')
+  @ApiOperation({
+    summary: 'Public tier comparison (limits, fees, APY, stake, virtual card)',
+  })
+  async getTierBenefitsTable() {
+    return this.tierUpgradeService.getPublicTierBenefitsTable();
+  }
+
+  @ApiBearerAuth()
+  @Get('tier/upgrade/requirements')
+  @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+  @ApiOperation({ summary: 'What is still required to reach the target tier' })
+  async getUpgradeRequirements(
+    @Req() req: AuthReq,
+    @Query() query: TierUpgradeRequirementsQueryDto,
+  ) {
+    return this.tierUpgradeService.getUpgradeRequirements(
+      req.user.id,
+      query.target,
+    );
+  }
+
+  @ApiBearerAuth()
+  @Get('tier/upgrade/status')
+  @ApiOperation({ summary: 'Pending upgrade target and blocking reasons' })
+  async getUpgradeStatus(@Req() req: AuthReq) {
+    return this.tierUpgradeService.getUpgradeStatus(req.user.id);
+  }
+
+  @ApiBearerAuth()
+  @Post('tier/upgrade')
+  @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+  @ApiOperation({ summary: 'Start or complete tier upgrade from the app' })
+  async initiateTierUpgrade(
+    @Req() req: AuthReq,
+    @Body() body: InitiateTierUpgradeDto,
+  ) {
+    return this.tierUpgradeService.initiateUpgrade(req.user.id, body.targetTier);
   }
 
   @Patch('admin/users/:id/tier')

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -42,7 +42,7 @@ export class User extends BaseEntity {
   @Column({ name: 'phone_verified', default: false })
   phoneVerified!: boolean;
 
-@Column({ name: 'display_name', length: 100, nullable: true, default: null })
+  @Column({ name: 'display_name', length: 100, nullable: true, default: null })
   displayName!: string | null;
 
   @Column({ length: 160, nullable: true, default: null })
@@ -63,6 +63,19 @@ export class User extends BaseEntity {
     default: TierName.SILVER,
   })
   tier!: TierName;
+
+  /**
+   * Target tier from an in-app upgrade while KYC is not yet approved.
+   * Cleared after automatic or manual tier application.
+   */
+  @Column({
+    name: 'pending_tier_upgrade',
+    type: 'varchar',
+    length: 10,
+    nullable: true,
+    default: null,
+  })
+  pendingTierUpgrade!: TierName | null;
 
   @Column({
     name: 'kyc_status',


### PR DESCRIPTION
## Summary

Adds an in-app **tier upgrade** flow: requirements (email, phone, KYC), comparison of tier benefits, initiate upgrade with clear errors when KYC is missing or in review, **pending target tier** on the user while KYC is incomplete, and **automatic upgrade** when KYC is approved (pending target takes precedence over submission `targetTier` when both apply). Sends **`tier-upgraded`** email (Zepto template alias) with a benefits summary.

## Changes

- **`User.pendingTierUpgrade`** + migration `1770500000000-AddPendingTierUpgradeToUsers.ts`
- **`TierUpgradeService`**: `getUpgradeRequirements`, `initiateUpgrade`, `checkAutoUpgrade`, `getUpgradeStatus`, public tier benefits table, `sendTierUpgradedEmail`
- **Routes (v1)**  
  - `GET /tier/upgrade/requirements?target=Gold` (auth)  
  - `POST /tier/upgrade` `{ targetTier }` (auth)  
  - `GET /tier/upgrade/status` (auth)  
  - `GET /tier/benefits` (public)
- **`KycService.approve`**: KYC approved → `checkAutoUpgrade` → else `applySubmissionTierAfterKyc`; tier change email via **`tier-upgraded`** (replaces `kyc-approved` on this path)
- **Tests**: `tier-upgrade.service.spec.ts`; `kyc.service.spec.ts` updated (+ `jest.mock` for R2/Prembly in tests)

closes #483 
## Branch

`feature/tier-upgrade-journey`