### PR TITLE
fix(rates): hourly history, rate-alert email via user lookup, jest te…

### DIFF
--- a/backend/jest.setup.js
+++ b/backend/jest.setup.js
@@ -41,3 +41,24 @@ process.env.FLUTTERWAVE_WEBHOOK_SECRET = 'test';
 process.env.WEBAUTHN_RP_ID = 'localhost';
 process.env.WEBAUTHN_ORIGIN = 'http://localhost:3000';
 process.env.WALLET_ENCRYPTION_KEY = 'test-wallet-encryption-key-32chars!!';
+
+// Required by AppConfigModule Joi schema when any import pulls in `src/config` barrel (e.g. via redis.module).
+process.env.BULL_BOARD_USERNAME = 'test-bull-board';
+process.env.BULL_BOARD_PASSWORD = 'test-bull-board-secret';
+process.env.STELLAR_RECEIVE_ADDRESS =
+  'GDMXN67BPZJWG4R7M6YMTBWOUIURNHSF34AHPGCBUOPNSWKYSXXPMQOZ';
+process.env.STELLAR_USDC_ISSUER =
+  'GDMXN67BPZJWG4R7M6YMTBWOUIURNHSF34AHPGCBUOPNSWKYSXXPMQOZ';
+process.env.R2_PUBLIC_DOMAIN = 'https://cdn.test.example';
+process.env.FIREBASE_SERVICE_ACCOUNT = '{}';
+process.env.VAPID_PUBLIC_KEY = 'test-vapid-public-key';
+process.env.VAPID_PRIVATE_KEY = 'test-vapid-private-key';
+process.env.SUDO_AFRICA_API_KEY = 'test';
+process.env.SUDO_AFRICA_WEBHOOK_SECRET = 'test';
+process.env.PREMBLY_API_KEY = 'test';
+process.env.PREMBLY_APP_ID = 'test';
+process.env.APPLE_TEAM_ID = 'TESTTEAMID';
+process.env.APPLE_BUNDLE_ID = 'com.test.app';
+process.env.ANDROID_PACKAGE = 'com.test.app';
+process.env.ANDROID_SHA256_FINGERPRINT =
+  'AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99';

--- a/backend/src/rates/rate-alert.processor.ts
+++ b/backend/src/rates/rate-alert.processor.ts
@@ -9,6 +9,13 @@ import { EmailService } from '../email/email.service';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { RateAlert } from './entities/rate-alert.entity';
+import { User } from '../users/entities/user.entity';
+
+function formatNgn(value: string): string {
+  const n = parseFloat(value);
+  if (Number.isNaN(n)) return value;
+  return n.toLocaleString('en-NG', { maximumFractionDigits: 2 });
+}
 
 @Processor(RATE_ALERT_QUEUE)
 export class RateAlertProcessor {
@@ -20,12 +27,16 @@ export class RateAlertProcessor {
     private readonly emailService: EmailService,
     @InjectRepository(RateAlert)
     private readonly alertRepo: Repository<RateAlert>,
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
   ) {}
 
   @Process(FIRE_RATE_ALERT_JOB)
   async handleFireAlert(job: Job<FireRateAlertPayload>): Promise<void> {
     const { alertId, userId, targetRate, currentRate } = job.data;
-    const message = `NGN/USDC rate hit your target of ₦${targetRate}. Current rate: ₦${currentRate}`;
+    const t = formatNgn(targetRate);
+    const c = formatNgn(currentRate);
+    const message = `NGN/USDC rate hit your target of ₦${t}. Current rate: ₦${c}`;
 
     const channels: string[] = [];
 
@@ -53,14 +64,18 @@ export class RateAlertProcessor {
     }
 
     try {
-      // email address resolved at send time by the email processor via userId lookup
-      await this.emailService.queue(
-        userId, // treated as userId; email processor resolves address
-        'RATE_ALERT_TRIGGERED',
-        { targetRate, currentRate, message },
-        userId,
-      );
-      channels.push('email');
+      const user = await this.userRepo.findOne({ where: { id: userId } });
+      if (user?.email) {
+        await this.emailService.queue(
+          user.email,
+          'rate-alert-triggered',
+          { targetRate: t, currentRate: c, message },
+          userId,
+        );
+        channels.push('email');
+      } else {
+        this.logger.warn(`No email for user ${userId}; skipping rate alert email`);
+      }
     } catch (err) {
       this.logger.warn(`Email failed for alert ${alertId}: ${(err as Error).message}`);
     }

--- a/backend/src/rates/rate-alert.service.ts
+++ b/backend/src/rates/rate-alert.service.ts
@@ -120,9 +120,4 @@ export class RateAlertService {
     await this.alertRepo.update(alertId, { status: AlertStatus.CANCELLED });
     return { ...alert, status: AlertStatus.CANCELLED };
   }
-
-  async getRateHistory(): Promise<unknown[]> {
-    // Delegated to RatesService — this method exists for controller wiring
-    return [];
-  }
 }

--- a/backend/src/rates/rates.module.ts
+++ b/backend/src/rates/rates.module.ts
@@ -8,6 +8,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
 import { PushModule } from '../push/push.module';
 import { RateSnapshot } from './entities/rate-snapshot.entity';
 import { RateAlert } from './entities/rate-alert.entity';
+import { User } from '../users/entities/user.entity';
 import { RatesService } from './rates.service';
 import { RatesProcessor } from './rates.processor';
 import { RatesController } from './rates.controller';
@@ -16,7 +17,7 @@ import { RateAlertProcessor } from './rate-alert.processor';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([RateSnapshot, RateAlert]),
+    TypeOrmModule.forFeature([RateSnapshot, RateAlert, User]),
     CacheModule,
     BullModule.registerQueue({ name: 'rates' }),
     BullModule.registerQueue({ name: RATE_ALERT_QUEUE }),

--- a/backend/src/rates/rates.service.spec.ts
+++ b/backend/src/rates/rates.service.spec.ts
@@ -5,7 +5,12 @@ import { RateSnapshot } from './entities/rate-snapshot.entity';
 import { CacheService } from '../cache/cache.service';
 
 const mockCache = { get: jest.fn(), set: jest.fn() };
-const mockRepo = { findOne: jest.fn(), save: jest.fn(), create: jest.fn() };
+const mockRepo = {
+  findOne: jest.fn(),
+  save: jest.fn(),
+  create: jest.fn(),
+  manager: { query: jest.fn() },
+};
 
 const freshSnapshot: Partial<RateSnapshot> = {
   rate: '1580.00',
@@ -75,5 +80,42 @@ describe('RatesService.getRate', () => {
     await expect(service.getRate('USDC', 'NGN')).rejects.toBeInstanceOf(
       StaleRateException,
     );
+  });
+});
+
+describe('RatesService.getRateHistory', () => {
+  let service: RatesService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RatesService,
+        { provide: getRepositoryToken(RateSnapshot), useValue: mockRepo },
+        { provide: CacheService, useValue: mockCache },
+      ],
+    }).compile();
+    service = module.get(RatesService);
+  });
+
+  it('returns hourly buckets for last 7 days from rate_snapshots', async () => {
+    const bucket = new Date('2026-03-20T14:00:00.000Z');
+    mockRepo.manager.query.mockResolvedValue([
+      { bucket, rate: '1580.12345678' },
+    ]);
+
+    const rows = await service.getRateHistory();
+
+    expect(mockRepo.manager.query).toHaveBeenCalledWith(
+      expect.stringContaining("date_trunc('hour'"),
+      ['USDC', 'NGN', expect.any(Date)],
+    );
+    expect(rows).toEqual([
+      {
+        fetchedAt: bucket,
+        rate: '1580.12345678',
+        source: 'hourly_avg',
+      },
+    ]);
   });
 });

--- a/backend/src/rates/rates.service.ts
+++ b/backend/src/rates/rates.service.ts
@@ -84,14 +84,34 @@ export class RatesService {
     return snapshot;
   }
 
-  async getRateHistory(): Promise<RateSnapshot[]> {
+  /**
+   * Last 7 days of USDC/NGN, one row per clock hour (mean rate within the hour).
+   * Suitable for exchange screen charts without returning every 30s poll row.
+   */
+  async getRateHistory(): Promise<
+    Array<{ fetchedAt: Date; rate: string; source: string }>
+  > {
     const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-    return this.snapshotRepo
-      .createQueryBuilder('s')
-      .where('s.base = :base AND s.quote = :quote', { base: 'USDC', quote: 'NGN' })
-      .andWhere('s.fetchedAt >= :since', { since: sevenDaysAgo })
-      .orderBy('s.fetchedAt', 'ASC')
-      .getMany();
+    const rows = await this.snapshotRepo.manager.query<
+      Array<{ bucket: Date; rate: string }>
+    >(
+      `
+      SELECT
+        date_trunc('hour', s.fetched_at) AS bucket,
+        (AVG(s.rate::numeric))::text AS rate
+      FROM rate_snapshots s
+      WHERE s.base = $1 AND s.quote = $2 AND s.fetched_at >= $3
+      GROUP BY 1
+      ORDER BY 1 ASC
+      `,
+      ['USDC', 'NGN', sevenDaysAgo],
+    );
+
+    return rows.map((r) => ({
+      fetchedAt: r.bucket,
+      rate: r.rate,
+      source: 'hourly_avg',
+    }));
   }
 
   /** Converts NGN amount to USDC using the latest stored NGN-per-USDC rate. */


### PR DESCRIPTION
## Summary

Refines **NGN/USDC rate alerts** and public **rate history** on top of the existing alerts implementation: hourly chart data for the last 7 days, correct **email delivery** for fired alerts (real user email + template alias), test env fixes for `rates` specs, and a unit test for history aggregation.
closes #484 
## Changes

- **`RatesService.getRateHistory`**: last **7 days**, **one row per clock hour** — `AVG(rate)` over `rate_snapshots` for `USDC`/`NGN` (avoids returning every ~30s poll row).
- **`RateAlertProcessor`**: resolve **`User.email`** before `EmailService.queue`; template **`rate-alert-triggered`**; formatted ₦ amounts in the shared message string.
- **`RateAlertService`**: remove unused **`getRateHistory`** stub (history stays on `RatesService` / `GET /rates/history`).
- **`RatesModule`**: register **`User`** for the alert processor.
- **`jest.setup.js`**: add env vars required when the config barrel loads (e.g. via `redis.module`) so **`rates.service.spec.ts`** runs under Joi validation.
- **`rates.service.spec.ts`**: test **`getRateHistory`** (`manager.query` + hourly SQL).

## Checklist

- [ ] Zepto (or mail provider): template **`rate-alert-triggered`** with `targetRate`, `currentRate`, `message`

## Branch

`feature/rate-alerts`