### PR TITLE
feat: standardized pagination utility (#772)

### DIFF
--- a/backend/src/common/dto/pagination.dto.ts
+++ b/backend/src/common/dto/pagination.dto.ts
@@ -1,0 +1,38 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class PaginationDto {
+  @ApiPropertyOptional({ default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page: number = 1;
+
+  @ApiPropertyOptional({ default: 20, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit: number = 20;
+}
+
+export class PaginatedResponseDto<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+
+  static of<T>(data: T[], total: number, page: number, limit: number): PaginatedResponseDto<T> {
+    const dto = new PaginatedResponseDto<T>();
+    dto.data = data;
+    dto.total = total;
+    dto.page = page;
+    dto.limit = limit;
+    dto.totalPages = Math.ceil(total / limit);
+    return dto;
+  }
+}

--- a/backend/src/payments/payments.controller.ts
+++ b/backend/src/payments/payments.controller.ts
@@ -1,8 +1,9 @@
 import { Controller, Post, Get, Param, Body, Query, UseGuards, Request } from '@nestjs/common';
-import { ApiTags, ApiBearerAuth, ApiOperation, ApiQuery } from '@nestjs/swagger';
+import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
 import { PaymentsService } from './payments.service';
 import { CreatePaymentDto } from './dto/create-payment.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt.guard';
+import { PaginationDto } from '../common/dto/pagination.dto';
 
 @ApiTags('payments')
 @ApiBearerAuth()
@@ -19,10 +20,8 @@ export class PaymentsController {
 
   @Get()
   @ApiOperation({ summary: 'List all payments' })
-  @ApiQuery({ name: 'page', required: false })
-  @ApiQuery({ name: 'limit', required: false })
-  findAll(@Request() req, @Query('page') page = 1, @Query('limit') limit = 20) {
-    return this.paymentsService.findAll(req.user.merchantId, +page, +limit);
+  findAll(@Request() req, @Query() pagination: PaginationDto) {
+    return this.paymentsService.findAll(req.user.merchantId, pagination.page, pagination.limit);
   }
 
   @Get('stats')

--- a/backend/src/payments/payments.service.ts
+++ b/backend/src/payments/payments.service.ts
@@ -6,6 +6,7 @@ import * as QRCode from 'qrcode';
 import { Payment, PaymentStatus } from './entities/payment.entity';
 import { CreatePaymentDto } from './dto/create-payment.dto';
 import { StellarService } from '../stellar/stellar.service';
+import { PaginatedResponseDto } from '../common/dto/pagination.dto';
 
 @Injectable()
 export class PaymentsService {
@@ -48,14 +49,14 @@ export class PaymentsService {
   }
 
   async findAll(merchantId: string, page = 1, limit = 20) {
-    const [payments, total] = await this.paymentsRepo.findAndCount({
+    const [data, total] = await this.paymentsRepo.findAndCount({
       where: { merchantId },
       order: { createdAt: 'DESC' },
       skip: (page - 1) * limit,
       take: limit,
     });
 
-    return { payments, total, page, limit };
+    return PaginatedResponseDto.of(data, total, page, limit);
   }
 
   async findOne(id: string, merchantId: string): Promise<Payment> {

--- a/backend/src/settlements/settlements.controller.ts
+++ b/backend/src/settlements/settlements.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Query, UseGuards, Request } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
 import { SettlementsService } from './settlements.service';
 import { JwtAuthGuard } from '../auth/guards/jwt.guard';
+import { PaginationDto } from '../common/dto/pagination.dto';
 
 @ApiTags('settlements')
 @ApiBearerAuth()
@@ -12,7 +13,7 @@ export class SettlementsController {
 
   @Get()
   @ApiOperation({ summary: 'List settlements' })
-  findAll(@Request() req, @Query('page') page = 1, @Query('limit') limit = 20) {
-    return this.settlementsService.findAll(req.user.merchantId, +page, +limit);
+  findAll(@Request() req, @Query() pagination: PaginationDto) {
+    return this.settlementsService.findAll(req.user.merchantId, pagination.page, pagination.limit);
   }
 }

--- a/backend/src/settlements/settlements.service.ts
+++ b/backend/src/settlements/settlements.service.ts
@@ -6,6 +6,7 @@ import axios from 'axios';
 import { Settlement, SettlementStatus } from './entities/settlement.entity';
 import { Payment, PaymentStatus } from '../payments/entities/payment.entity';
 import { WebhooksService } from '../webhooks/webhooks.service';
+import { PaginatedResponseDto } from '../common/dto/pagination.dto';
 
 @Injectable()
 export class SettlementsService {
@@ -96,13 +97,13 @@ export class SettlementsService {
   }
 
   async findAll(merchantId: string, page = 1, limit = 20) {
-    const [settlements, total] = await this.settlementsRepo.findAndCount({
+    const [data, total] = await this.settlementsRepo.findAndCount({
       where: { merchantId },
       order: { createdAt: 'DESC' },
       skip: (page - 1) * limit,
       take: limit,
     });
 
-    return { settlements, total, page, limit };
+    return PaginatedResponseDto.of(data, total, page, limit);
   }
 }


### PR DESCRIPTION
## Summary
Closes #772

Implements consistent pagination across all list endpoints.

## Changes
- **`src/common/dto/pagination.dto.ts`** — new shared `PaginationDto` and generic `PaginatedResponseDto`
- **Payments** — controller uses `PaginationDto`, service returns `PaginatedResponseDto`
- **Settlements** — controller uses `PaginationDto`, service returns `PaginatedResponseDto`

## Response shape
```json
{
  "data": [...],
  "total": 42,
  "page": 1,
  "limit": 20,
  "totalPages": 3
}
```

## Acceptance criteria
- [x] `PaginationDto`: `page` (default 1), `limit` (default 20, max 100)
- [x] Generic `PaginatedResponseDto<T>` with `{ data, total, page, limit, totalPages }`
- [x] All list endpoints share the same pagination structure
- [x] `totalPages` calculated and returned
- [x] Out-of-range page returns empty `data` array (not 404)