### PR TITLE
feat(security): global rate limiting with @nestjs/throttler

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -29,6 +29,7 @@
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/schedule": "^4.0.0",
     "@nestjs/swagger": "^7.0.0",
+    "@nestjs/throttler": "^6.0.0",
     "@nestjs/typeorm": "^10.0.0",
     "@stellar/stellar-sdk": "^12.0.0",
     "axios": "^1.6.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,31 +1,41 @@
-import { Module } from '@nestjs/common';
-import { ConfigModule, ConfigService } from '@nestjs/config';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { ScheduleModule } from '@nestjs/schedule';
-import { AuthModule } from './auth/auth.module';
-import { MerchantsModule } from './merchants/merchants.module';
-import { PaymentsModule } from './payments/payments.module';
-import { StellarModule } from './stellar/stellar.module';
-import { SettlementsModule } from './settlements/settlements.module';
-import { WebhooksModule } from './webhooks/webhooks.module';
-import { WaitlistModule } from './waitlist/waitlist.module';
+import { Module } from "@nestjs/common";
+import { APP_GUARD } from "@nestjs/core";
+import { ConfigModule, ConfigService } from "@nestjs/config";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { ScheduleModule } from "@nestjs/schedule";
+import { ThrottlerModule } from "@nestjs/throttler";
+import { AuthModule } from "./auth/auth.module";
+import { MerchantsModule } from "./merchants/merchants.module";
+import { PaymentsModule } from "./payments/payments.module";
+import { StellarModule } from "./stellar/stellar.module";
+import { SettlementsModule } from "./settlements/settlements.module";
+import { WebhooksModule } from "./webhooks/webhooks.module";
+import { WaitlistModule } from "./waitlist/waitlist.module";
+import { HealthController } from "./health.controller";
+import { AppThrottlerGuard } from "./auth/guards/throttler.guard";
 
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
     ScheduleModule.forRoot(),
+    ThrottlerModule.forRoot({
+      throttlers: [
+        { name: "default", ttl: 60000, limit: 100 },
+        { name: "authenticated", ttl: 60000, limit: 1000 },
+      ],
+    }),
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],
       useFactory: (config: ConfigService) => ({
-        type: 'postgres',
-        host: config.get('DB_HOST', 'localhost'),
-        port: config.get<number>('DB_PORT', 5432),
-        username: config.get('DB_USER', 'postgres'),
-        password: config.get('DB_PASSWORD'),
-        database: config.get('DB_NAME', 'cheesepay'),
-        entities: [__dirname + '/**/*.entity{.ts,.js}'],
-        synchronize: config.get('NODE_ENV') !== 'production',
-        logging: config.get('NODE_ENV') === 'development',
+        type: "postgres",
+        host: config.get("DB_HOST", "localhost"),
+        port: config.get<number>("DB_PORT", 5432),
+        username: config.get("DB_USER", "postgres"),
+        password: config.get("DB_PASSWORD"),
+        database: config.get("DB_NAME", "cheesepay"),
+        entities: [__dirname + "/**/*.entity{.ts,.js}"],
+        synchronize: config.get("NODE_ENV") !== "production",
+        logging: config.get("NODE_ENV") === "development",
       }),
       inject: [ConfigService],
     }),
@@ -36,6 +46,13 @@ import { WaitlistModule } from './waitlist/waitlist.module';
     SettlementsModule,
     WebhooksModule,
     WaitlistModule,
+  ],
+  controllers: [HealthController],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: AppThrottlerGuard,
+    },
   ],
 })
 export class AppModule {}

--- a/backend/src/auth/guards/throttler.guard.spec.ts
+++ b/backend/src/auth/guards/throttler.guard.spec.ts
@@ -1,0 +1,76 @@
+import { ExecutionContext } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { AppThrottlerGuard } from "./throttler.guard";
+
+function makeContext(
+  path: string,
+  user?: { merchantId: string },
+): ExecutionContext {
+  const req = { path, ip: "127.0.0.1", user };
+  return {
+    switchToHttp: () => ({ getRequest: () => req, getResponse: () => ({}) }),
+    getHandler: () => ({}),
+    getClass: () => ({}),
+  } as unknown as ExecutionContext;
+}
+
+describe("AppThrottlerGuard", () => {
+  let guard: AppThrottlerGuard;
+
+  beforeEach(() => {
+    guard = new AppThrottlerGuard(
+      { throttlers: [{ name: "default", ttl: 60000, limit: 100 }] },
+      {
+        increment: jest.fn().mockResolvedValue({
+          totalHits: 1,
+          timeToExpire: 60,
+          isBlocked: false,
+          timeToBlockExpire: 0,
+        }),
+      } as any,
+      new Reflector(),
+    );
+  });
+
+  it("should skip /health endpoint", async () => {
+    const ctx = makeContext("/api/v1/health");
+    const result = await (guard as any).shouldSkip(ctx);
+    expect(result).toBe(true);
+  });
+
+  it("should not skip non-health endpoints", async () => {
+    const ctx = makeContext("/api/v1/payments");
+    const result = await (guard as any).shouldSkip(ctx);
+    expect(result).toBe(false);
+  });
+
+  it("should use IP as tracker for unauthenticated requests", async () => {
+    const req = { ip: "10.0.0.1" };
+    const tracker = await (guard as any).getTracker(req);
+    expect(tracker).toBe("10.0.0.1");
+  });
+
+  it("should use merchantId as tracker for authenticated requests", async () => {
+    const req = { ip: "10.0.0.1", user: { merchantId: "merchant-123" } };
+    const tracker = await (guard as any).getTracker(req);
+    expect(tracker).toBe("merchant:merchant-123");
+  });
+
+  it('should skip "authenticated" throttler for unauthenticated requests', async () => {
+    const ctx = makeContext("/api/v1/payments");
+    const result = await (guard as any).handleRequest({
+      context: ctx,
+      throttler: { name: "authenticated" },
+    });
+    expect(result).toBe(true);
+  });
+
+  it('should skip "default" throttler for authenticated requests', async () => {
+    const ctx = makeContext("/api/v1/payments", { merchantId: "merchant-abc" });
+    const result = await (guard as any).handleRequest({
+      context: ctx,
+      throttler: { name: "default" },
+    });
+    expect(result).toBe(true);
+  });
+});

--- a/backend/src/auth/guards/throttler.guard.ts
+++ b/backend/src/auth/guards/throttler.guard.ts
@@ -1,0 +1,35 @@
+import { ExecutionContext, Injectable } from "@nestjs/common";
+import { ThrottlerGuard } from "@nestjs/throttler";
+
+@Injectable()
+export class AppThrottlerGuard extends ThrottlerGuard {
+  protected async getTracker(req: Record<string, any>): Promise<string> {
+    // Authenticated merchants are tracked by merchantId; others by IP
+    if (req.user?.merchantId) {
+      return `merchant:${req.user.merchantId}`;
+    }
+    return req.ip ?? req.connection?.remoteAddress ?? "unknown";
+  }
+
+  protected async shouldSkip(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+    // Exempt /health from all rate limiting
+    if ((req.path as string)?.endsWith("/health")) {
+      return true;
+    }
+    return false;
+  }
+
+  protected async handleRequest(requestProps: any): Promise<boolean> {
+    const { context } = requestProps;
+    const req = context.switchToHttp().getRequest();
+    const isAuthenticated = Boolean(req.user?.merchantId);
+
+    // Only apply the throttler that matches the authentication state
+    const throttlerName: string = requestProps.throttler?.name ?? "";
+    if (throttlerName === "authenticated" && !isAuthenticated) return true;
+    if (throttlerName === "default" && isAuthenticated) return true;
+
+    return super.handleRequest(requestProps);
+  }
+}

--- a/backend/src/health.controller.ts
+++ b/backend/src/health.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get } from "@nestjs/common";
+import { ApiTags, ApiOperation } from "@nestjs/swagger";
+import { SkipThrottle } from "@nestjs/throttler";
+
+@ApiTags("health")
+@SkipThrottle()
+@Controller("health")
+export class HealthController {
+  @Get()
+  @ApiOperation({ summary: "Health check" })
+  check() {
+    return { status: "ok" };
+  }
+}


### PR DESCRIPTION
- Install and configure @nestjs/throttler v6
- Register ThrottlerModule globally with two named throttlers:
  - 'default': 100 req/min per IP (unauthenticated)
  - 'authenticated': 1,000 req/min per merchantId (authenticated)
- Implement AppThrottlerGuard extending ThrottlerGuard:
  - getTracker(): uses merchantId for authenticated requests, IP otherwise
  - shouldSkip(): exempts /health endpoint from all rate limiting
  - handleRequest(): routes each request to the correct throttler bucket so authenticated merchants are never penalised by the default limit and unauthenticated callers cannot consume the merchant quota
- Bind AppThrottlerGuard as APP_GUARD so it applies to every route
- Add HealthController (GET /health) decorated with @SkipThrottle() as an explicit belt-and-suspenders exemption
- Add unit tests covering all guard behaviours (6 tests, all passing)

Closes #722