### PR TITLE
feat(security): configure CORS for trusted origins

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,6 +2,9 @@
 PORT=3000
 NODE_ENV=development
 
+# CORS - comma-separated list of trusted frontend origins (production only)
+ALLOWED_ORIGINS=https://app.cheesepay.xyz,https://cheesepay.xyz
+
 # Database
 DB_HOST=localhost
 DB_PORT=5432

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -8,7 +8,26 @@ async function bootstrap() {
 
   app.setGlobalPrefix('api/v1');
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
-  app.enableCors();
+
+  const isDevelopment = process.env.NODE_ENV !== 'production';
+  const allowedOrigins = process.env.ALLOWED_ORIGINS
+    ? process.env.ALLOWED_ORIGINS.split(',').map((o) => o.trim())
+    : [];
+
+  app.enableCors({
+    origin: isDevelopment
+      ? true
+      : (origin, callback) => {
+          if (!origin || allowedOrigins.includes(origin)) {
+            callback(null, true);
+          } else {
+            callback(new Error(`CORS: origin '${origin}' not allowed`));
+          }
+        },
+    credentials: true,
+    methods: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'x-api-key'],
+  });
 
   const config = new DocumentBuilder()
     .setTitle('CheesePay API')


### PR DESCRIPTION
- Replace open app.enableCors() with an origin-aware CORS config
- In development (NODE_ENV != 'production'), all origins are allowed
- In production, only origins listed in ALLOWED_ORIGINS env var are permitted; unknown origins receive a CORS rejection
- Credentials mode enabled to support cookie-based auth flows
- Preflight (OPTIONS) handled automatically by NestJS/Express with the configured allowed methods and headers (Content-Type, Authorization, x-api-key)
- Added ALLOWED_ORIGINS to .env.example with example frontend domains

Closes #724