### PR TITLE
feat(security): global input validation and sanitization

### DIFF
--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,9 +1,11 @@
 import { IsEmail, IsString } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class LoginDto {
   @ApiProperty({ example: 'merchant@example.com' })
   @IsEmail()
+  @Transform(({ value }) => value?.trim())
   email: string;
 
   @ApiProperty({ example: 'SecurePass123!' })

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -1,9 +1,11 @@
 import { IsEmail, IsString, MinLength, IsOptional } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class RegisterDto {
   @ApiProperty({ example: 'merchant@example.com' })
   @IsEmail()
+  @Transform(({ value }) => value?.trim())
   email: string;
 
   @ApiProperty({ example: 'SecurePass123!' })
@@ -13,15 +15,18 @@ export class RegisterDto {
 
   @ApiProperty({ example: 'Acme Corp' })
   @IsString()
+  @Transform(({ value }) => value?.trim())
   businessName: string;
 
   @ApiPropertyOptional({ example: 'retail' })
   @IsOptional()
   @IsString()
+  @Transform(({ value }) => value?.trim())
   businessType?: string;
 
   @ApiPropertyOptional({ example: 'NG' })
   @IsOptional()
   @IsString()
+  @Transform(({ value }) => value?.trim())
   country?: string;
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -7,7 +7,14 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   app.setGlobalPrefix('api/v1');
-  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: false,
+      transform: true,
+      transformOptions: { enableImplicitConversion: true },
+    }),
+  );
   app.enableCors();
 
   const config = new DocumentBuilder()

--- a/backend/src/merchants/dto/create-merchant.dto.ts
+++ b/backend/src/merchants/dto/create-merchant.dto.ts
@@ -1,34 +1,41 @@
 import { IsString, IsOptional } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateMerchantDto {
   @ApiPropertyOptional()
   @IsOptional()
   @IsString()
+  @Transform(({ value }) => value?.trim())
   businessName?: string;
 
   @ApiPropertyOptional()
   @IsOptional()
   @IsString()
+  @Transform(({ value }) => value?.trim())
   businessType?: string;
 
   @ApiPropertyOptional()
   @IsOptional()
   @IsString()
+  @Transform(({ value }) => value?.trim())
   country?: string;
 
   @ApiPropertyOptional()
   @IsOptional()
   @IsString()
+  @Transform(({ value }) => value?.trim())
   bankAccountNumber?: string;
 
   @ApiPropertyOptional()
   @IsOptional()
   @IsString()
+  @Transform(({ value }) => value?.trim())
   bankCode?: string;
 
   @ApiPropertyOptional()
   @IsOptional()
   @IsString()
+  @Transform(({ value }) => value?.trim())
   bankName?: string;
 }

--- a/backend/src/payments/dto/create-payment.dto.ts
+++ b/backend/src/payments/dto/create-payment.dto.ts
@@ -1,4 +1,5 @@
 import { IsNumber, IsPositive, IsString, IsOptional, IsEmail, IsObject } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreatePaymentDto {
@@ -10,11 +11,13 @@ export class CreatePaymentDto {
   @ApiPropertyOptional({ example: 'Payment for order #123' })
   @IsOptional()
   @IsString()
+  @Transform(({ value }) => value?.trim())
   description?: string;
 
   @ApiPropertyOptional({ example: 'customer@example.com' })
   @IsOptional()
   @IsEmail()
+  @Transform(({ value }) => value?.trim())
   customerEmail?: string;
 
   @ApiPropertyOptional()

--- a/backend/src/payments/payments.controller.ts
+++ b/backend/src/payments/payments.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Get, Param, Body, Query, UseGuards, Request } from '@nestjs/common';
+import { Controller, Post, Get, Param, Body, Query, UseGuards, Request, ParseUUIDPipe } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation, ApiQuery } from '@nestjs/swagger';
 import { PaymentsService } from './payments.service';
 import { CreatePaymentDto } from './dto/create-payment.dto';
@@ -33,7 +33,7 @@ export class PaymentsController {
 
   @Get(':id')
   @ApiOperation({ summary: 'Get payment by ID' })
-  findOne(@Request() req, @Param('id') id: string) {
+  findOne(@Request() req, @Param('id', ParseUUIDPipe) id: string) {
     return this.paymentsService.findOne(id, req.user.merchantId);
   }
 }

--- a/backend/src/waitlist/waitlist.service.ts
+++ b/backend/src/waitlist/waitlist.service.ts
@@ -2,13 +2,14 @@ import { Injectable, ConflictException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { IsEmail, IsOptional, IsString } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { WaitlistEntry } from './entities/waitlist.entity';
 
 export class JoinWaitlistDto {
-  @IsEmail() email: string;
-  @IsOptional() @IsString() username?: string;
-  @IsOptional() @IsString() businessName?: string;
-  @IsOptional() @IsString() country?: string;
+  @IsEmail() @Transform(({ value }) => value?.trim()) email: string;
+  @IsOptional() @IsString() @Transform(({ value }) => value?.trim()) username?: string;
+  @IsOptional() @IsString() @Transform(({ value }) => value?.trim()) businessName?: string;
+  @IsOptional() @IsString() @Transform(({ value }) => value?.trim()) country?: string;
 }
 
 @Injectable()

--- a/backend/src/webhooks/webhooks.controller.ts
+++ b/backend/src/webhooks/webhooks.controller.ts
@@ -1,13 +1,14 @@
-import { Controller, Get, Post, Delete, Param, Body, UseGuards, Request } from '@nestjs/common';
+import { Controller, Get, Post, Delete, Param, Body, UseGuards, Request, ParseUUIDPipe } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
 import { IsString, IsArray, IsOptional } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { WebhooksService } from './webhooks.service';
 import { JwtAuthGuard } from '../auth/guards/jwt.guard';
 
 class CreateWebhookDto {
-  @IsString() url: string;
+  @IsString() @Transform(({ value }) => value?.trim()) url: string;
   @IsArray() events: string[];
-  @IsOptional() @IsString() secret?: string;
+  @IsOptional() @IsString() @Transform(({ value }) => value?.trim()) secret?: string;
 }
 
 @ApiTags('webhooks')
@@ -31,7 +32,7 @@ export class WebhooksController {
 
   @Delete(':id')
   @ApiOperation({ summary: 'Delete webhook' })
-  remove(@Request() req, @Param('id') id: string) {
+  remove(@Request() req, @Param('id', ParseUUIDPipe) id: string) {
     return this.webhooksService.remove(id, req.user.merchantId);
   }
 }


### PR DESCRIPTION
- Expand ValidationPipe options in main.ts:
    - forbidNonWhitelisted: false (silently strip unknown fields, no error)
    - transformOptions.enableImplicitConversion: true (proper type coercion for query params and path params without explicit @Type decorators)
- Add @Transform(({ value }) => value?.trim()) to all @IsString() fields across every DTO and inline DTO class to sanitize leading/trailing whitespace before validation runs:
    - auth/dto/login.dto.ts (email)
    - auth/dto/register.dto.ts (email, businessName, businessType, country)
    - merchants/dto/create-merchant.dto.ts (all 6 string fields)
    - payments/dto/create-payment.dto.ts (description, customerEmail)
    - waitlist/waitlist.service.ts JoinWaitlistDto (email, username, businessName, country)
    - webhooks/webhooks.controller.ts CreateWebhookDto (url, secret)
- Apply ParseUUIDPipe to all UUID path params:
    - GET /payments/:id
    - DELETE /webhooks/:id Invalid UUIDs now return HTTP 400 with field-level detail before reaching the service layer.

Closes #725