### PR TITLE
feat(security): partner API webhook signature validation

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -26,6 +26,7 @@ STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 # Fiat Settlement Partner
 PARTNER_API_URL=https://partner-api.example.com/v1
 PARTNER_API_KEY=your_partner_api_key
+PARTNER_WEBHOOK_SECRET=your_partner_webhook_secret
 
 # Webhooks
 WEBHOOK_SECRET=your_webhook_signing_secret

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -4,7 +4,7 @@ import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, { rawBody: true });
 
   app.setGlobalPrefix('api/v1');
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));

--- a/backend/src/settlements/guards/partner-signature.guard.ts
+++ b/backend/src/settlements/guards/partner-signature.guard.ts
@@ -1,0 +1,66 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHmac, timingSafeEqual } from 'crypto';
+import { Request } from 'express';
+
+@Injectable()
+export class PartnerSignatureGuard implements CanActivate {
+  private readonly logger = new Logger(PartnerSignatureGuard.name);
+
+  constructor(private readonly config: ConfigService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const req = context.switchToHttp().getRequest<Request & { rawBody?: Buffer }>();
+    const signature = req.headers['x-partner-signature'] as string | undefined;
+
+    if (!signature) {
+      this.logger.warn('[SECURITY] Partner callback missing X-Partner-Signature header', {
+        ip: req.ip,
+        path: req.path,
+      });
+      throw new ForbiddenException('Missing signature');
+    }
+
+    const secret = this.config.get<string>('PARTNER_WEBHOOK_SECRET');
+    if (!secret) {
+      this.logger.error('[SECURITY] PARTNER_WEBHOOK_SECRET is not configured');
+      throw new ForbiddenException('Signature verification unavailable');
+    }
+
+    const rawBody = req.rawBody;
+    if (!rawBody) {
+      this.logger.error('[SECURITY] Raw body unavailable for signature verification');
+      throw new ForbiddenException('Signature verification unavailable');
+    }
+
+    const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
+
+    let valid = false;
+    try {
+      const expectedBuf = Buffer.from(expected, 'hex');
+      const receivedBuf = Buffer.from(signature.replace(/^sha256=/, ''), 'hex');
+      valid =
+        expectedBuf.length === receivedBuf.length &&
+        timingSafeEqual(expectedBuf, receivedBuf);
+    } catch {
+      valid = false;
+    }
+
+    if (!valid) {
+      this.logger.warn('[SECURITY] Partner callback signature mismatch — possible forgery', {
+        ip: req.ip,
+        path: req.path,
+        receivedSignature: signature,
+      });
+      throw new ForbiddenException('Invalid signature');
+    }
+
+    return true;
+  }
+}

--- a/backend/src/settlements/settlements.controller.ts
+++ b/backend/src/settlements/settlements.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Get, Query, UseGuards, Request } from '@nestjs/common';
-import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
-import { SettlementsService } from './settlements.service';
+import { Controller, Get, Post, Query, UseGuards, Request, Body, HttpCode, HttpStatus } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiHeader } from '@nestjs/swagger';
+import { SettlementsService, PartnerCallbackPayload } from './settlements.service';
 import { JwtAuthGuard } from '../auth/guards/jwt.guard';
+import { PartnerSignatureGuard } from './guards/partner-signature.guard';
 
 @ApiTags('settlements')
 @ApiBearerAuth()
@@ -14,5 +15,20 @@ export class SettlementsController {
   @ApiOperation({ summary: 'List settlements' })
   findAll(@Request() req, @Query('page') page = 1, @Query('limit') limit = 20) {
     return this.settlementsService.findAll(req.user.merchantId, +page, +limit);
+  }
+}
+
+@ApiTags('settlements')
+@Controller('settlements')
+export class PartnerCallbackController {
+  constructor(private readonly settlementsService: SettlementsService) {}
+
+  @Post('partner-callback')
+  @UseGuards(PartnerSignatureGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Receive fiat settlement status callback from partner API' })
+  @ApiHeader({ name: 'X-Partner-Signature', description: 'HMAC-SHA256 signature of the request body', required: true })
+  handleCallback(@Body() payload: PartnerCallbackPayload) {
+    return this.settlementsService.handlePartnerCallback(payload);
   }
 }

--- a/backend/src/settlements/settlements.module.ts
+++ b/backend/src/settlements/settlements.module.ts
@@ -1,18 +1,19 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { SettlementsService } from './settlements.service';
-import { SettlementsController } from './settlements.controller';
+import { SettlementsController, PartnerCallbackController } from './settlements.controller';
 import { Settlement } from './entities/settlement.entity';
 import { Payment } from '../payments/entities/payment.entity';
 import { WebhooksModule } from '../webhooks/webhooks.module';
+import { PartnerSignatureGuard } from './guards/partner-signature.guard';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Settlement, Payment]),
     WebhooksModule,
   ],
-  controllers: [SettlementsController],
-  providers: [SettlementsService],
+  controllers: [SettlementsController, PartnerCallbackController],
+  providers: [SettlementsService, PartnerSignatureGuard],
   exports: [SettlementsService],
 })
 export class SettlementsModule {}

--- a/backend/src/settlements/settlements.service.ts
+++ b/backend/src/settlements/settlements.service.ts
@@ -7,6 +7,12 @@ import { Settlement, SettlementStatus } from './entities/settlement.entity';
 import { Payment, PaymentStatus } from '../payments/entities/payment.entity';
 import { WebhooksService } from '../webhooks/webhooks.service';
 
+export interface PartnerCallbackPayload {
+  reference: string;
+  status: 'success' | 'failed';
+  failureReason?: string;
+}
+
 @Injectable()
 export class SettlementsService {
   private readonly logger = new Logger(SettlementsService.name);
@@ -104,5 +110,49 @@ export class SettlementsService {
     });
 
     return { settlements, total, page, limit };
+  }
+
+  async handlePartnerCallback(payload: PartnerCallbackPayload): Promise<void> {
+    const settlement = await this.settlementsRepo.findOne({
+      where: { id: payload.reference },
+    });
+
+    if (!settlement) {
+      this.logger.warn(`Partner callback for unknown settlement reference: ${payload.reference}`);
+      return;
+    }
+
+    const payment = await this.paymentsRepo.findOne({
+      where: { settlementId: settlement.id },
+    });
+
+    if (payload.status === 'success') {
+      settlement.status = SettlementStatus.COMPLETED;
+      settlement.completedAt = new Date();
+      await this.settlementsRepo.save(settlement);
+
+      if (payment) {
+        payment.status = PaymentStatus.SETTLED;
+        await this.paymentsRepo.save(payment);
+        await this.webhooks.dispatch(settlement.merchantId, 'payment.settled', {
+          paymentId: payment.id,
+          settlementId: settlement.id,
+          amount: settlement.netAmountUsd,
+        });
+      }
+    } else {
+      settlement.status = SettlementStatus.FAILED;
+      settlement.failureReason = payload.failureReason ?? 'Partner reported failure';
+      await this.settlementsRepo.save(settlement);
+
+      if (payment) {
+        payment.status = PaymentStatus.FAILED;
+        await this.paymentsRepo.save(payment);
+        await this.webhooks.dispatch(settlement.merchantId, 'payment.failed', {
+          paymentId: payment.id,
+          reason: settlement.failureReason,
+        });
+      }
+    }
   }
 }


### PR DESCRIPTION
- Add PartnerSignatureGuard (settlements/guards/partner-signature.guard.ts):
    - Reads X-Partner-Signature header from incoming partner callbacks
    - Computes HMAC-SHA256 of the raw request body using PARTNER_WEBHOOK_SECRET
    - Compares expected vs received digest with crypto.timingSafeEqual to prevent timing-based side-channel attacks
    - Handles sha256= prefix convention used by many webhook providers
    - Returns 403 ForbiddenException on missing or invalid signatures
    - Logs all verification failures as [SECURITY] warn events including IP, path, and received signature for audit/alerting
    - Logs error if PARTNER_WEBHOOK_SECRET is not configured

- Enable rawBody capture in main.ts (NestFactory.create rawBody: true) so the guard can compute the HMAC over the exact bytes the partner sent

- Add POST /api/v1/settlements/partner-callback endpoint (PartnerCallbackController) protected by PartnerSignatureGuard:
    - No JWT auth — this is an inbound server-to-server callback
    - Accepts { reference, status, failureReason? } payload
    - Delegates to SettlementsService.handlePartnerCallback

- Add handlePartnerCallback to SettlementsService:
    - Looks up settlement by partner reference
    - On success: marks settlement COMPLETED, payment SETTLED, fires payment.settled webhook
    - On failure: marks settlement FAILED with reason, payment FAILED, fires payment.failed webhook
    - Logs unknown references as warnings (idempotent, no error thrown)

- Export PartnerCallbackPayload interface from settlements.service.ts
- Register PartnerCallbackController and PartnerSignatureGuard in SettlementsModule
- Add PARTNER_WEBHOOK_SECRET to .env.example

Closes #730