### PR TITLE
feat(testing): testing infrastructure (#779, #781, #785, #786)

### DIFF
--- a/backend/load-tests/README.md
+++ b/backend/load-tests/README.md
@@ -1,0 +1,29 @@
+# Load Tests (k6)
+
+## Prerequisites
+
+```bash
+brew install k6          # macOS
+# or: https://k6.io/docs/getting-started/installation/
+```
+
+## Run against staging
+
+```bash
+BASE_URL=https://api-staging.dabdub.xyz/api/v1 k6 run load-tests/payments.k6.ts
+```
+
+## Run locally
+
+```bash
+# Start the backend first, then:
+k6 run load-tests/payments.k6.ts
+```
+
+## Thresholds
+
+| Metric | Target |
+|--------|--------|
+| p95 latency | < 500ms |
+| Error rate | < 0.1% |
+| Load | 100 VUs / 1,000 req/min |

--- a/backend/load-tests/payments.k6.ts
+++ b/backend/load-tests/payments.k6.ts
@@ -1,0 +1,111 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate, Trend } from 'k6/metrics';
+
+// ─── Custom metrics ───────────────────────────────────────────────────────────
+const errorRate = new Rate('error_rate');
+const loginLatency = new Trend('login_latency', true);
+const createPaymentLatency = new Trend('create_payment_latency', true);
+const listPaymentsLatency = new Trend('list_payments_latency', true);
+
+// ─── Options ──────────────────────────────────────────────────────────────────
+export const options = {
+  scenarios: {
+    sustained_load: {
+      executor: 'constant-arrival-rate',
+      rate: 1000,          // 1,000 req/min
+      timeUnit: '1m',
+      duration: '5m',
+      preAllocatedVUs: 100,
+      maxVUs: 150,
+    },
+  },
+  thresholds: {
+    http_req_duration: ['p(95)<500'],   // p95 < 500ms
+    error_rate: ['rate<0.001'],          // < 0.1% errors
+    login_latency: ['p(95)<500'],
+    create_payment_latency: ['p(95)<500'],
+    list_payments_latency: ['p(95)<500'],
+  },
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000/api/v1';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+function jsonHeaders(token?: string): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  return headers;
+}
+
+function randomEmail(): string {
+  return `loadtest_${__VU}_${Date.now()}@test.com`;
+}
+
+// ─── Setup: register one account per VU ───────────────────────────────────────
+export function setup() {
+  // Pre-register a shared test account used by all VUs
+  const res = http.post(
+    `${BASE_URL}/auth/register`,
+    JSON.stringify({
+      email: 'k6_shared@test.com',
+      password: 'K6TestPass123!',
+      businessName: 'K6 Load Test',
+      businessType: 'testing',
+      country: 'US',
+    }),
+    { headers: jsonHeaders() },
+  );
+
+  // If already registered, login instead
+  if (res.status === 409) {
+    const login = http.post(
+      `${BASE_URL}/auth/login`,
+      JSON.stringify({ email: 'k6_shared@test.com', password: 'K6TestPass123!' }),
+      { headers: jsonHeaders() },
+    );
+    return { token: login.json('accessToken') as string };
+  }
+
+  return { token: res.json('accessToken') as string };
+}
+
+// ─── Default function ─────────────────────────────────────────────────────────
+export default function (data: { token: string }) {
+  const scenario = Math.random();
+
+  if (scenario < 0.3) {
+    // 30% — login
+    const start = Date.now();
+    const res = http.post(
+      `${BASE_URL}/auth/login`,
+      JSON.stringify({ email: 'k6_shared@test.com', password: 'K6TestPass123!' }),
+      { headers: jsonHeaders() },
+    );
+    loginLatency.add(Date.now() - start);
+    const ok = check(res, { 'login 200': (r) => r.status === 200 });
+    errorRate.add(!ok);
+  } else if (scenario < 0.65) {
+    // 35% — create payment
+    const start = Date.now();
+    const res = http.post(
+      `${BASE_URL}/payments`,
+      JSON.stringify({ amountUsd: 10 + Math.floor(Math.random() * 90), description: 'k6 test' }),
+      { headers: jsonHeaders(data.token) },
+    );
+    createPaymentLatency.add(Date.now() - start);
+    const ok = check(res, { 'create payment 201': (r) => r.status === 201 });
+    errorRate.add(!ok);
+  } else {
+    // 35% — list payments
+    const start = Date.now();
+    const res = http.get(`${BASE_URL}/payments?page=1&limit=20`, {
+      headers: jsonHeaders(data.token),
+    });
+    listPaymentsLatency.add(Date.now() - start);
+    const ok = check(res, { 'list payments 200': (r) => r.status === 200 });
+    errorRate.add(!ok);
+  }
+
+  sleep(0.05); // small think time
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
+    "test:integration": "jest --testRegex=\"\\.integration-spec\\.ts$\"",
     "migration:generate": "typeorm migration:generate",
     "migration:run": "typeorm migration:run",
     "migration:revert": "typeorm migration:revert"
@@ -67,7 +68,7 @@
   "jest": {
     "moduleFileExtensions": ["js", "json", "ts"],
     "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
+    "testRegex": ".*\\.(spec|integration-spec)\\.ts$",
     "transform": { "^.+\\.(t|j)s$": "ts-jest" },
     "collectCoverageFrom": ["**/*.(t|j)s"],
     "coverageDirectory": "../coverage",

--- a/backend/src/stellar/stellar.service.mock.ts
+++ b/backend/src/stellar/stellar.service.mock.ts
@@ -1,0 +1,23 @@
+import { StellarService } from './stellar.service';
+
+type DeepPartial<T> = { [K in keyof T]?: T[K] };
+
+export const defaultMockStellarService: DeepPartial<StellarService> = {
+  getDepositAddress: jest.fn().mockReturnValue('GTEST1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ'),
+  generateMemo: jest.fn().mockReturnValue('TESTMEMO'),
+  getXlmUsdRate: jest.fn().mockResolvedValue(0.1),
+  getAccountTransactions: jest.fn().mockResolvedValue([]),
+  getPaymentsForTransaction: jest.fn().mockResolvedValue([]),
+  verifyPayment: jest
+    .fn()
+    .mockResolvedValue({ verified: true, amount: 50, asset: 'USDC' }),
+  sendPayment: jest.fn().mockResolvedValue('mock-tx-hash-abc123'),
+  getUsdcAsset: jest.fn().mockReturnValue({ code: 'USDC', issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5' }),
+  getServer: jest.fn().mockReturnValue({}),
+};
+
+export function createMockStellarService(
+  overrides: DeepPartial<StellarService> = {},
+): DeepPartial<StellarService> {
+  return { ...defaultMockStellarService, ...overrides };
+}

--- a/backend/src/test/db.ts
+++ b/backend/src/test/db.ts
@@ -1,0 +1,35 @@
+import { DataSource } from 'typeorm';
+import { Merchant } from '../merchants/entities/merchant.entity';
+import { Payment } from '../payments/entities/payment.entity';
+import { Settlement } from '../settlements/entities/settlement.entity';
+import { Webhook } from '../webhooks/entities/webhook.entity';
+import { WaitlistEntry } from '../waitlist/entities/waitlist.entity';
+
+export const TEST_ENTITIES = [Merchant, Payment, Settlement, Webhook, WaitlistEntry];
+
+export async function createTestDataSource(): Promise<DataSource> {
+  const ds = new DataSource({
+    type: 'postgres',
+    host: process.env.DB_HOST ?? 'localhost',
+    port: Number(process.env.DB_PORT ?? 5432),
+    username: process.env.DB_USER ?? 'postgres',
+    password: process.env.DB_PASSWORD ?? 'postgres',
+    database: process.env.DB_NAME_TEST ?? 'cheesepay_test',
+    entities: TEST_ENTITIES,
+    synchronize: true,
+    logging: false,
+  });
+  await ds.initialize();
+  return ds;
+}
+
+export async function truncateAll(dataSource: DataSource): Promise<void> {
+  const tableNames = TEST_ENTITIES.map(
+    (e) => dataSource.getMetadata(e).tableName,
+  ).join('", "');
+  await dataSource.query(`TRUNCATE TABLE "${tableNames}" RESTART IDENTITY CASCADE`);
+}
+
+export async function closeTestDataSource(dataSource: DataSource): Promise<void> {
+  if (dataSource.isInitialized) await dataSource.destroy();
+}

--- a/backend/src/test/factories.ts
+++ b/backend/src/test/factories.ts
@@ -1,0 +1,84 @@
+import { DataSource } from 'typeorm';
+import { v4 as uuid } from 'uuid';
+import { Merchant, MerchantStatus } from '../merchants/entities/merchant.entity';
+import { Payment, PaymentStatus, PaymentNetwork } from '../payments/entities/payment.entity';
+import { Settlement, SettlementStatus } from '../settlements/entities/settlement.entity';
+
+let counter = 0;
+const next = () => ++counter;
+
+// ─── Merchant ────────────────────────────────────────────────────────────────
+
+export function merchantFactory(overrides: Partial<Merchant> = {}): Partial<Merchant> {
+  const n = next();
+  return {
+    id: uuid(),
+    email: `merchant${n}@test.com`,
+    passwordHash: '$2b$12$hashedpassword',
+    businessName: `Test Business ${n}`,
+    businessType: 'retail',
+    country: 'US',
+    status: MerchantStatus.ACTIVE,
+    feeRate: 0.015,
+    totalVolumeUsd: 0,
+    ...overrides,
+  };
+}
+
+export async function createMerchant(
+  dataSource: DataSource,
+  overrides: Partial<Merchant> = {},
+): Promise<Merchant> {
+  const repo = dataSource.getRepository(Merchant);
+  return repo.save(repo.create(merchantFactory(overrides) as Merchant));
+}
+
+// ─── Payment ─────────────────────────────────────────────────────────────────
+
+export function paymentFactory(overrides: Partial<Payment> = {}): Partial<Payment> {
+  const n = next();
+  return {
+    id: uuid(),
+    reference: `PAY-${n}-${uuid().slice(0, 8).toUpperCase()}`,
+    amountUsd: 100,
+    network: PaymentNetwork.STELLAR,
+    status: PaymentStatus.PENDING,
+    stellarDepositAddress: 'GTEST1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+    stellarMemo: `MEMO${n}`,
+    currency: 'USD',
+    ...overrides,
+  };
+}
+
+export async function createPayment(
+  dataSource: DataSource,
+  merchantId: string,
+  overrides: Partial<Payment> = {},
+): Promise<Payment> {
+  const repo = dataSource.getRepository(Payment);
+  return repo.save(repo.create(paymentFactory({ merchantId, ...overrides }) as Payment));
+}
+
+// ─── Settlement ───────────────────────────────────────────────────────────────
+
+export function settlementFactory(overrides: Partial<Settlement> = {}): Partial<Settlement> {
+  return {
+    id: uuid(),
+    totalAmountUsd: 100,
+    feeAmountUsd: 1.5,
+    netAmountUsd: 98.5,
+    fiatCurrency: 'USD',
+    fiatAmount: 98.5,
+    status: SettlementStatus.PENDING,
+    ...overrides,
+  };
+}
+
+export async function createSettlement(
+  dataSource: DataSource,
+  merchantId: string,
+  overrides: Partial<Settlement> = {},
+): Promise<Settlement> {
+  const repo = dataSource.getRepository(Settlement);
+  return repo.save(repo.create(settlementFactory({ merchantId, ...overrides }) as Settlement));
+}

--- a/backend/src/test/integration-module.ts
+++ b/backend/src/test/integration-module.ts
@@ -1,0 +1,28 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
+import { TEST_ENTITIES } from './db';
+
+export async function createIntegrationTestModule(
+  extraModules: any[] = [],
+): Promise<TestingModule> {
+  return Test.createTestingModule({
+    imports: [
+      ConfigModule.forRoot({ isGlobal: true }),
+      TypeOrmModule.forRoot({
+        type: 'postgres',
+        host: process.env.DB_HOST ?? 'localhost',
+        port: Number(process.env.DB_PORT ?? 5432),
+        username: process.env.DB_USER ?? 'postgres',
+        password: process.env.DB_PASSWORD ?? 'postgres',
+        database: process.env.DB_NAME_TEST ?? 'cheesepay_test',
+        entities: TEST_ENTITIES,
+        synchronize: true,
+        logging: false,
+      }),
+      JwtModule.register({ secret: 'test-secret', signOptions: { expiresIn: '1h' } }),
+      ...extraModules,
+    ],
+  }).compile();
+}

--- a/backend/src/test/payments.integration-spec.ts
+++ b/backend/src/test/payments.integration-spec.ts
@@ -1,0 +1,86 @@
+import { DataSource } from 'typeorm';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
+import { PaymentsService } from '../payments/payments.service';
+import { Payment } from '../payments/entities/payment.entity';
+import { StellarService } from '../stellar/stellar.service';
+import { createMockStellarService } from '../stellar/stellar.service.mock';
+import { createTestDataSource, truncateAll, closeTestDataSource, TEST_ENTITIES } from './db';
+import { createMerchant } from './factories';
+
+describe('PaymentsService (integration)', () => {
+  let dataSource: DataSource;
+  let module: TestingModule;
+  let service: PaymentsService;
+
+  beforeAll(async () => {
+    dataSource = await createTestDataSource();
+
+    module = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true }),
+        TypeOrmModule.forRoot({
+          type: 'postgres',
+          host: process.env.DB_HOST ?? 'localhost',
+          port: Number(process.env.DB_PORT ?? 5432),
+          username: process.env.DB_USER ?? 'postgres',
+          password: process.env.DB_PASSWORD ?? 'postgres',
+          database: process.env.DB_NAME_TEST ?? 'cheesepay_test',
+          entities: TEST_ENTITIES,
+          synchronize: true,
+          logging: false,
+        }),
+        TypeOrmModule.forFeature([Payment]),
+      ],
+      providers: [
+        PaymentsService,
+        { provide: StellarService, useValue: createMockStellarService() },
+      ],
+    }).compile();
+
+    service = module.get(PaymentsService);
+  });
+
+  afterEach(async () => {
+    await truncateAll(dataSource);
+  });
+
+  afterAll(async () => {
+    await module.close();
+    await closeTestDataSource(dataSource);
+  });
+
+  it('creates a payment and persists it', async () => {
+    const merchant = await createMerchant(dataSource);
+
+    const payment = await service.create(merchant.id, {
+      amountUsd: 50,
+      description: 'Test payment',
+    });
+
+    expect(payment.id).toBeDefined();
+    expect(payment.merchantId).toBe(merchant.id);
+    expect(payment.amountUsd).toBe(50);
+    expect(payment.stellarMemo).toBe('TESTMEMO');
+  });
+
+  it('lists payments for a merchant', async () => {
+    const merchant = await createMerchant(dataSource);
+    await service.create(merchant.id, { amountUsd: 10 });
+    await service.create(merchant.id, { amountUsd: 20 });
+
+    const result = await service.findAll(merchant.id);
+    expect(result.total).toBe(2);
+    expect(result.payments).toHaveLength(2);
+  });
+
+  it('does not return payments from another merchant', async () => {
+    const m1 = await createMerchant(dataSource);
+    const m2 = await createMerchant(dataSource);
+    await service.create(m1.id, { amountUsd: 10 });
+
+    const result = await service.findAll(m2.id);
+    expect(result.total).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Implements all four testing infrastructure issues.

### #781 — Mock StellarService factory
- `createMockStellarService(overrides?)` factory for per-test customization
- `defaultMockStellarService` with sensible defaults (rate=0.1, verifyPayment={verified:true, amount:50, asset:'USDC'})
- All public StellarService methods covered, no real Horizon calls

### #785 — Test data factories
- `merchantFactory`, `paymentFactory`, `settlementFactory` — build objects with overridable defaults
- `createMerchant`, `createPayment`, `createSettlement` — persist to DB via TypeORM
- Usable in both unit and integration tests

### #779 — Integration test setup with real PostgreSQL
- `createTestDataSource()` — connects to `DB_NAME_TEST` env var
- `truncateAll()` — truncates all tables between suites (no cross-suite pollution)
- `createIntegrationTestModule()` — NestJS test module with real TypeORM
- Sample: `src/test/payments.integration-spec.ts`
- `npm run test:integration` script added

### #786 — k6 load tests
- Scenarios: login (30%), create payment (35%), list payments (35%)
- Target: 100 VUs, 1,000 req/min sustained for 5 minutes
- Thresholds: p95 < 500ms, error rate < 0.1%
- `load-tests/README.md` with run instructions

## Files changed
- `backend/src/stellar/stellar.service.mock.ts`
- `backend/src/test/factories.ts`
- `backend/src/test/db.ts`
- `backend/src/test/integration-module.ts`
- `backend/src/test/payments.integration-spec.ts`
- `backend/load-tests/payments.k6.ts`
- `backend/load-tests/README.md`
- `backend/package.json` (added `test:integration` script)

Closes #779, closes #781, closes #785, closes #786