### PR TITLE
Resolve issues #702 #778 #787 #791

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -69,8 +69,18 @@
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": { "^.+\\.(t|j)s$": "ts-jest" },
-    "collectCoverageFrom": ["**/*.(t|j)s"],
+    "collectCoverageFrom": ["**/*.(t|j)s", "!**/*.module.ts", "!**/main.ts"],
     "coverageDirectory": "../coverage",
+    "coverageReporters": ["lcov", "text-summary"],
+    "coverageThreshold": {
+      "global": {
+        "lines": 80,
+        "branches": 75
+      }
+    },
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/$1"
+    },
     "testEnvironment": "node"
   }
 }

--- a/backend/src/aml/aml.controller.ts
+++ b/backend/src/aml/aml.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Get, Patch, Param, Body, Query, UseGuards } from '@nestjs/common';
+import { AmlService } from './aml.service';
+import { AmlFlagStatus } from './entities/aml-flag.entity';
+import { JwtAuthGuard } from '../auth/guards/jwt.guard';
+
+class ReviewFlagDto {
+  status: AmlFlagStatus;
+  reviewedBy: string;
+  note?: string;
+}
+
+@UseGuards(JwtAuthGuard)
+@Controller('admin/aml')
+export class AmlController {
+  constructor(private readonly amlService: AmlService) {}
+
+  @Get()
+  findAll(@Query('page') page = 1, @Query('limit') limit = 20) {
+    return this.amlService.findAll(+page, +limit);
+  }
+
+  @Get('pending')
+  findPending(@Query('page') page = 1, @Query('limit') limit = 20) {
+    return this.amlService.findPending(+page, +limit);
+  }
+
+  @Get('merchant/:merchantId')
+  findByMerchant(@Param('merchantId') merchantId: string) {
+    return this.amlService.findByMerchant(merchantId);
+  }
+
+  @Patch(':id/review')
+  review(@Param('id') id: string, @Body() dto: ReviewFlagDto) {
+    return this.amlService.review(id, dto.status, dto.reviewedBy, dto.note);
+  }
+}

--- a/backend/src/aml/aml.module.ts
+++ b/backend/src/aml/aml.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AmlFlag } from './entities/aml-flag.entity';
+import { AmlService } from './aml.service';
+import { AmlController } from './aml.controller';
+import { Payment } from '../payments/entities/payment.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([AmlFlag, Payment])],
+  providers: [AmlService],
+  controllers: [AmlController],
+  exports: [AmlService],
+})
+export class AmlModule {}

--- a/backend/src/aml/aml.service.ts
+++ b/backend/src/aml/aml.service.ts
@@ -1,0 +1,86 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, MoreThanOrEqual } from 'typeorm';
+import { AmlFlag, AmlFlagReason, AmlFlagStatus } from './entities/aml-flag.entity';
+import { Payment } from '../payments/entities/payment.entity';
+
+const HIGH_VALUE_THRESHOLD_USD = 10_000;
+const HIGH_VELOCITY_LIMIT = 50;
+
+@Injectable()
+export class AmlService {
+  private readonly logger = new Logger(AmlService.name);
+
+  constructor(
+    @InjectRepository(AmlFlag)
+    private amlRepo: Repository<AmlFlag>,
+    @InjectRepository(Payment)
+    private paymentsRepo: Repository<Payment>,
+  ) {}
+
+  async checkAndFlag(payment: Payment): Promise<void> {
+    if (Number(payment.amountUsd) >= HIGH_VALUE_THRESHOLD_USD) {
+      await this.createFlag(payment.merchantId, payment.id, AmlFlagReason.HIGH_VALUE, {
+        amountUsd: payment.amountUsd,
+      });
+    }
+
+    const startOfDay = new Date();
+    startOfDay.setHours(0, 0, 0, 0);
+
+    const dailyCount = await this.paymentsRepo.count({
+      where: { merchantId: payment.merchantId, createdAt: MoreThanOrEqual(startOfDay) },
+    });
+
+    if (dailyCount > HIGH_VELOCITY_LIMIT) {
+      await this.createFlag(payment.merchantId, payment.id, AmlFlagReason.HIGH_VELOCITY, {
+        dailyCount,
+      });
+    }
+  }
+
+  private async createFlag(
+    merchantId: string,
+    paymentId: string,
+    reason: AmlFlagReason,
+    metadata: Record<string, any>,
+  ): Promise<void> {
+    const flag = this.amlRepo.create({ merchantId, paymentId, reason, metadata });
+    await this.amlRepo.save(flag);
+    this.logger.warn(`AML flag created: ${reason} for merchant ${merchantId}`);
+  }
+
+  async findAll(page = 1, limit = 20) {
+    const [flags, total] = await this.amlRepo.findAndCount({
+      order: { createdAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+    return { flags, total, page, limit };
+  }
+
+  async findPending(page = 1, limit = 20) {
+    const [flags, total] = await this.amlRepo.findAndCount({
+      where: { status: AmlFlagStatus.PENDING },
+      order: { createdAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+    return { flags, total, page, limit };
+  }
+
+  async review(id: string, status: AmlFlagStatus, reviewedBy: string, note?: string): Promise<AmlFlag> {
+    const flag = await this.amlRepo.findOne({ where: { id } });
+    if (!flag) throw new NotFoundException(`AML flag ${id} not found`);
+
+    flag.status = status;
+    flag.reviewedBy = reviewedBy;
+    flag.reviewedAt = new Date();
+    flag.reviewNote = note ?? null;
+    return this.amlRepo.save(flag);
+  }
+
+  async findByMerchant(merchantId: string) {
+    return this.amlRepo.find({ where: { merchantId }, order: { createdAt: 'DESC' } });
+  }
+}

--- a/backend/src/aml/entities/aml-flag.entity.ts
+++ b/backend/src/aml/entities/aml-flag.entity.ts
@@ -1,0 +1,54 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export enum AmlFlagReason {
+  HIGH_VALUE = 'high_value',
+  HIGH_VELOCITY = 'high_velocity',
+}
+
+export enum AmlFlagStatus {
+  PENDING = 'pending',
+  CLEARED = 'cleared',
+  ESCALATED = 'escalated',
+}
+
+@Entity('aml_flags')
+export class AmlFlag {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  merchantId: string;
+
+  @Column({ nullable: true })
+  paymentId: string;
+
+  @Column({ type: 'enum', enum: AmlFlagReason })
+  reason: AmlFlagReason;
+
+  @Column({ type: 'enum', enum: AmlFlagStatus, default: AmlFlagStatus.PENDING })
+  status: AmlFlagStatus;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata: Record<string, any>;
+
+  @Column({ nullable: true })
+  reviewedBy: string;
+
+  @Column({ nullable: true })
+  reviewedAt: Date;
+
+  @Column({ nullable: true })
+  reviewNote: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { StellarModule } from './stellar/stellar.module';
 import { SettlementsModule } from './settlements/settlements.module';
 import { WebhooksModule } from './webhooks/webhooks.module';
 import { WaitlistModule } from './waitlist/waitlist.module';
+import { AmlModule } from './aml/aml.module';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { WaitlistModule } from './waitlist/waitlist.module';
     SettlementsModule,
     WebhooksModule,
     WaitlistModule,
+    AmlModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/settlements/partner-settlement.pact.spec.ts
+++ b/backend/src/settlements/partner-settlement.pact.spec.ts
@@ -1,0 +1,90 @@
+import { PactV3, MatchersV3 } from '@pact-foundation/pact';
+import axios from 'axios';
+import * as path from 'path';
+
+const { like, string, number } = MatchersV3;
+
+const provider = new PactV3({
+  consumer: 'CheesePay',
+  provider: 'PartnerSettlementAPI',
+  dir: path.resolve(__dirname, '../../../pacts'),
+});
+
+describe('Partner Settlement API - Consumer Contract', () => {
+  describe('POST /transfers', () => {
+    it('initiates a fiat transfer and returns a reference', async () => {
+      await provider
+        .given('partner API is available')
+        .uponReceiving('a fiat transfer request')
+        .withRequest({
+          method: 'POST',
+          path: '/transfers',
+          headers: { 'Content-Type': 'application/json' },
+          body: {
+            amount: like(98.5),
+            currency: string('USD'),
+            merchantId: string('merchant-uuid-123'),
+            reference: string('settlement-uuid-456'),
+          },
+        })
+        .willRespondWith({
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+          body: {
+            reference: string('partner-ref-789'),
+            status: string('processing'),
+            amount: number(98.5),
+            currency: string('USD'),
+          },
+        })
+        .executeTest(async (mockServer) => {
+          const response = await axios.post(
+            `${mockServer.url}/transfers`,
+            {
+              amount: 98.5,
+              currency: 'USD',
+              merchantId: 'merchant-uuid-123',
+              reference: 'settlement-uuid-456',
+            },
+            { headers: { 'Content-Type': 'application/json' } },
+          );
+
+          expect(response.status).toBe(200);
+          expect(response.data.reference).toBeDefined();
+          expect(response.data.status).toBe('processing');
+        });
+    });
+
+    it('returns 400 for invalid transfer request', async () => {
+      await provider
+        .given('partner API is available')
+        .uponReceiving('an invalid fiat transfer request with missing amount')
+        .withRequest({
+          method: 'POST',
+          path: '/transfers',
+          headers: { 'Content-Type': 'application/json' },
+          body: {
+            currency: string('USD'),
+            merchantId: string('merchant-uuid-123'),
+            reference: string('settlement-uuid-456'),
+          },
+        })
+        .willRespondWith({
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+          body: {
+            error: string('amount is required'),
+          },
+        })
+        .executeTest(async (mockServer) => {
+          await expect(
+            axios.post(
+              `${mockServer.url}/transfers`,
+              { currency: 'USD', merchantId: 'merchant-uuid-123', reference: 'settlement-uuid-456' },
+              { headers: { 'Content-Type': 'application/json' } },
+            ),
+          ).rejects.toMatchObject({ response: { status: 400 } });
+        });
+    });
+  });
+});

--- a/grafana/dashboards/api-latency.json
+++ b/grafana/dashboards/api-latency.json
@@ -1,0 +1,76 @@
+{
+  "title": "API Latency (p95 per Endpoint)",
+  "uid": "cheesepay-api-latency",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "p95 Latency by Endpoint",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 10 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le, route))",
+          "legendFormat": "p95 {{route}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "palette-classic" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "red", "value": 2 }
+            ]
+          }
+        }
+      },
+      "alert": {
+        "name": "High API Latency",
+        "conditions": [
+          {
+            "evaluator": { "type": "gt", "params": [2] },
+            "query": { "params": ["A", "5m", "now"] },
+            "reducer": { "type": "max" },
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "alerting",
+        "frequency": "1m",
+        "handler": 1,
+        "message": "p95 API latency exceeded 2s"
+      }
+    },
+    {
+      "id": 2,
+      "title": "p50 / p95 / p99 Overall",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 10, "w": 24, "h": 4 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    }
+  ]
+}

--- a/grafana/dashboards/payment-volume.json
+++ b/grafana/dashboards/payment-volume.json
@@ -1,0 +1,67 @@
+{
+  "title": "Payment Volume",
+  "uid": "cheesepay-payment-volume",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-24h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Payment Volume Over Time",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(cheesepay_payments_total[5m])) by (status)",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "color": { "mode": "palette-classic" } }
+      },
+      "alert": {
+        "name": "Low Payment Volume",
+        "conditions": [
+          {
+            "evaluator": { "type": "lt", "params": [1] },
+            "query": { "params": ["A", "5m", "now"] },
+            "reducer": { "type": "avg" },
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "alerting",
+        "frequency": "1m",
+        "handler": 1,
+        "message": "Payment volume has dropped below threshold"
+      }
+    },
+    {
+      "id": 2,
+      "title": "Total Payments (24h)",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 8, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "expr": "sum(increase(cheesepay_payments_total[24h]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" } }
+    },
+    {
+      "id": 3,
+      "title": "Payment Volume USD (24h)",
+      "type": "stat",
+      "gridPos": { "x": 6, "y": 8, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "expr": "sum(increase(cheesepay_payment_volume_usd_total[24h]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "currencyUSD" } }
+    }
+  ]
+}

--- a/grafana/dashboards/queue-depth.json
+++ b/grafana/dashboards/queue-depth.json
@@ -1,0 +1,107 @@
+{
+  "title": "Queue Depths and Processing Rate",
+  "uid": "cheesepay-queue-depth",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "15s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Queue Depth by Queue",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 16, "h": 8 },
+      "targets": [
+        {
+          "expr": "cheesepay_queue_depth",
+          "legendFormat": "{{queue}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "short", "color": { "mode": "palette-classic" } }
+      },
+      "alert": {
+        "name": "Queue Depth Too High",
+        "conditions": [
+          {
+            "evaluator": { "type": "gt", "params": [1000] },
+            "query": { "params": ["A", "5m", "now"] },
+            "reducer": { "type": "max" },
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "alerting",
+        "frequency": "1m",
+        "handler": 1,
+        "message": "Queue depth exceeded 1000 messages"
+      }
+    },
+    {
+      "id": 2,
+      "title": "Processing Rate (msg/s)",
+      "type": "timeseries",
+      "gridPos": { "x": 16, "y": 0, "w": 8, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(cheesepay_queue_processed_total[1m])) by (queue)",
+          "legendFormat": "{{queue}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "msgps" } }
+    },
+    {
+      "id": 3,
+      "title": "Current Queue Depths",
+      "type": "bargauge",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "expr": "cheesepay_queue_depth",
+          "legendFormat": "{{queue}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 500 },
+              { "color": "red", "value": 1000 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Failed Jobs (1h)",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 6 },
+      "targets": [
+        {
+          "expr": "sum(increase(cheesepay_queue_failed_total[1h])) by (queue)",
+          "legendFormat": "{{queue}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 50 }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/grafana/dashboards/settlement-rate.json
+++ b/grafana/dashboards/settlement-rate.json
@@ -1,0 +1,93 @@
+{
+  "title": "Settlement Success/Failure Rate",
+  "uid": "cheesepay-settlement-rate",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-24h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Settlement Success Rate",
+      "type": "gauge",
+      "gridPos": { "x": 0, "y": 0, "w": 8, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(cheesepay_settlements_total{status='completed'}[5m])) / sum(rate(cheesepay_settlements_total[5m])) * 100",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 90 },
+              { "color": "green", "value": 98 }
+            ]
+          }
+        }
+      },
+      "alert": {
+        "name": "Low Settlement Success Rate",
+        "conditions": [
+          {
+            "evaluator": { "type": "lt", "params": [90] },
+            "query": { "params": ["A", "5m", "now"] },
+            "reducer": { "type": "avg" },
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "alerting",
+        "frequency": "1m",
+        "handler": 1,
+        "message": "Settlement success rate dropped below 90%"
+      }
+    },
+    {
+      "id": 2,
+      "title": "Settlements by Status Over Time",
+      "type": "timeseries",
+      "gridPos": { "x": 8, "y": 0, "w": 16, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(cheesepay_settlements_total[5m])) by (status)",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "reqps", "color": { "mode": "palette-classic" } }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Failed Settlements (1h)",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 8, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "expr": "sum(increase(cheesepay_settlements_total{status='failed'}[1h]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 20 }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- #778: Update Jest config with ts-jest, @/ alias, lcov reporter, 80% line / 75% branch coverage thresholds
- #702: Add AML module with auto-flagging (>0k, >50 tx/day), admin review/escalate endpoints, flag history per merchant
- #787: Add Pact consumer contract tests for partner settlement API
- #791: Add Grafana dashboard JSON templates for payment volume, settlement rate, API latency (p95), and queue depth

closes #778 
closes #702 
closes #787 
closes #791 