### PR TITLE
feat: implement admin fee management with audit trail

### DIFF
--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -89,4 +89,28 @@ export class AdminController {
   ) {
     return this.adminService.broadcast(dto);
   }
+
+  @Get('fees')
+  @Roles(AdminRole.ADMIN, AdminRole.SUPERADMIN)
+  @ApiOperation({ summary: 'List all global fee configurations' })
+  async getFees() {
+    return this.adminService.getGlobalFees();
+  }
+
+  @Patch('fees')
+  @Roles(AdminRole.ADMIN, AdminRole.SUPERADMIN)
+  @Audit({ action: 'fee.update', resourceType: 'fee-config' })
+  @ApiOperation({ summary: 'Update a global fee rate' })
+  async updateFee(
+    @Body() dto: { feeType: string; newRate: string; reason?: string },
+    @Req() req: any,
+  ) {
+    const adminId = req.user.id;
+    return this.adminService.updateGlobalFee(
+      dto.feeType as any,
+      dto.newRate,
+      adminId,
+      dto.reason,
+    );
+  }
 }

--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -15,6 +15,8 @@ import { AnalyticsModule } from './analytics/analytics.module';
 import { CronModule } from '../cron/cron.module';
 import { CronAdminController } from './cron-admin.controller';
 import { AuditModule } from '../audit/audit.module';
+import { FeeConfig } from '../fee-config/entities/fee-config.entity';
+import { FeeHistory } from '../fee-config/entities/fee-history.entity';
 
 @Module({
   imports: [
@@ -25,6 +27,8 @@ import { AuditModule } from '../audit/audit.module';
       FraudFlag,
       Session,
       RefreshToken,
+      FeeConfig,
+      FeeHistory,
     ]),
     EmailModule,
     NotificationsModule,

--- a/backend/src/admin/admin.service.spec.ts
+++ b/backend/src/admin/admin.service.spec.ts
@@ -10,6 +10,8 @@ import { EmailService } from '../email/email.service';
 import { AuditService } from '../audit/audit.service';
 import { NotificationService } from '../notifications/notifications.service';
 import { CacheService } from '../cache/cache.service';
+import { FeeConfig, FeeType } from '../fee-config/entities/fee-config.entity';
+import { FeeHistory, FeeChangeType } from '../fee-config/entities/fee-history.entity';
 
 describe('AdminService', () => {
   let service: AdminService;
@@ -17,6 +19,8 @@ describe('AdminService', () => {
   let sessionRepo: any;
   let tokenRepo: any;
   let fraudRepo: any;
+  let feeConfigRepo: any;
+  let feeHistoryRepo: any;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -53,6 +57,21 @@ describe('AdminService', () => {
           useValue: { update: jest.fn() },
         },
         {
+          provide: getRepositoryToken(FeeConfig),
+          useValue: {
+            find: jest.fn(),
+            findOne: jest.fn(),
+            save: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(FeeHistory),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+          },
+        },
+        {
           provide: EmailService,
           useValue: { queue: jest.fn() },
         },
@@ -76,6 +95,8 @@ describe('AdminService', () => {
     sessionRepo = module.get(getRepositoryToken(Session));
     tokenRepo = module.get(getRepositoryToken(RefreshToken));
     fraudRepo = module.get(getRepositoryToken(FraudFlag));
+    feeConfigRepo = module.get(getRepositoryToken(FeeConfig));
+    feeHistoryRepo = module.get(getRepositoryToken(FeeHistory));
   });
 
   it('should revoke sessions on freezeUser', async () => {
@@ -99,5 +120,62 @@ describe('AdminService', () => {
       expect.objectContaining({ revokedAt: expect.any(Date) }),
     );
     expect(fraudRepo.save).toHaveBeenCalled();
+  });
+
+  describe('Fee Management', () => {
+    it('should return all global fees', async () => {
+      const fees = [
+        { feeType: FeeType.TRANSFER, baseFeeRate: '0.010000' },
+        { feeType: FeeType.WITHDRAWAL, baseFeeRate: '0.020000' },
+      ];
+      feeConfigRepo.find.mockResolvedValue(fees);
+
+      const result = await service.getGlobalFees();
+
+      expect(result).toEqual(fees);
+      expect(feeConfigRepo.find).toHaveBeenCalledWith({
+        order: { feeType: 'ASC' },
+      });
+    });
+
+    it('should update global fee and record history', async () => {
+      const feeConfig = {
+        feeType: FeeType.TRANSFER,
+        baseFeeRate: '0.010000',
+      };
+      feeConfigRepo.findOne.mockResolvedValue(feeConfig);
+      feeConfigRepo.save.mockResolvedValue({ ...feeConfig, baseFeeRate: '0.015000' });
+      feeHistoryRepo.create.mockReturnValue({});
+
+      const result = await service.updateGlobalFee(
+        FeeType.TRANSFER,
+        '0.015000',
+        'admin-123',
+        'Increased due to market conditions',
+      );
+
+      expect(feeConfigRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ baseFeeRate: '0.015000' }),
+      );
+      expect(feeHistoryRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          feeType: FeeType.TRANSFER,
+          changeType: FeeChangeType.GLOBAL,
+          previousValue: '0.010000',
+          newValue: '0.015000',
+          actorId: 'admin-123',
+          reason: 'Increased due to market conditions',
+        }),
+      );
+      expect(feeHistoryRepo.save).toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when fee config not found', async () => {
+      feeConfigRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.updateGlobalFee(FeeType.DEPOSIT, '0.005000', 'admin-123'),
+      ).rejects.toThrow('Fee config for deposit not found');
+    });
   });
 });

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, NotFoundException, Inject } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  Inject,
+  BadRequestException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, ILike, Raw } from 'typeorm';
 import { User, KycStatus } from '../users/entities/user.entity';
@@ -15,9 +20,14 @@ import { Session } from '../auth/entities/session.entity';
 import { RefreshToken } from '../auth/entities/refresh-token.entity';
 import { EmailService } from '../email/email.service';
 import { AuditService } from '../audit/audit.service';
-import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationService } from '../notifications/notifications.service';
 import { CacheService } from '../cache/cache.service';
 import { TierName } from '../tier-config/entities/tier-config.entity';
+import { FeeConfig, FeeType } from '../fee-config/entities/fee-config.entity';
+import {
+  FeeHistory,
+  FeeChangeType,
+} from '../fee-config/entities/fee-history.entity';
 
 @Injectable()
 export class AdminService {
@@ -32,9 +42,13 @@ export class AdminService {
     private readonly sessionRepo: Repository<Session>,
     @InjectRepository(RefreshToken)
     private readonly tokenRepo: Repository<RefreshToken>,
+    @InjectRepository(FeeConfig)
+    private readonly feeConfigRepo: Repository<FeeConfig>,
+    @InjectRepository(FeeHistory)
+    private readonly feeHistoryRepo: Repository<FeeHistory>,
     private readonly emailService: EmailService,
     private readonly auditService: AuditService,
-    private readonly notificationsService: NotificationsService,
+    private readonly notificationService: NotificationService,
     private readonly cacheService: CacheService,
   ) {}
 
@@ -241,9 +255,56 @@ export class AdminService {
   }
 
   async broadcast(dto: { title: string; body: string; segment: string }) {
-    // This would typically involve a background job
-    // NotificationsService should have a broadcast method
-    await this.notificationsService.broadcast(dto.title, dto.body, dto.segment);
+    await this.notificationService.broadcast(dto.title, dto.body, dto.segment);
     return { success: true };
+  }
+
+  // ── Fee Management ─────────────────────────────────────────────────────────
+
+  async getGlobalFees(): Promise<FeeConfig[]> {
+    return this.feeConfigRepo.find({ order: { feeType: 'ASC' } });
+  }
+
+  async updateGlobalFee(
+    feeType: FeeType,
+    newRate: string,
+    adminId: string,
+    reason?: string,
+  ): Promise<FeeConfig> {
+    const feeConfig = await this.feeConfigRepo.findOne({
+      where: { feeType },
+    });
+    if (!feeConfig) {
+      throw new NotFoundException(`Fee config for ${feeType} not found`);
+    }
+
+    const previousValue = feeConfig.baseFeeRate;
+    feeConfig.baseFeeRate = newRate;
+    const updated = await this.feeConfigRepo.save(feeConfig);
+
+    await this.recordFeeHistory({
+      feeType,
+      changeType: FeeChangeType.GLOBAL,
+      merchantId: null,
+      previousValue,
+      newValue: newRate,
+      actorId: adminId,
+      reason: reason ?? null,
+    });
+
+    return updated;
+  }
+
+  async recordFeeHistory(dto: {
+    feeType: string;
+    changeType: FeeChangeType;
+    merchantId: string | null;
+    previousValue: string;
+    newValue: string;
+    actorId: string;
+    reason: string | null;
+  }): Promise<FeeHistory> {
+    const entry = this.feeHistoryRepo.create(dto);
+    return this.feeHistoryRepo.save(entry);
   }
 }

--- a/backend/src/fee-config/entities/fee-config.entity.ts
+++ b/backend/src/fee-config/entities/fee-config.entity.ts
@@ -5,6 +5,7 @@ export enum FeeType {
   TRANSFER = 'transfer',
   WITHDRAWAL = 'withdrawal',
   DEPOSIT = 'deposit',
+  MERCHANT_SETTLEMENT = 'merchant_settlement',
 }
 
 /**

--- a/backend/src/fee-config/entities/fee-history.entity.ts
+++ b/backend/src/fee-config/entities/fee-history.entity.ts
@@ -1,0 +1,75 @@
+import { Entity, Column, CreateDateColumn, Index } from 'typeorm';
+import { BaseEntity } from '../../common/entities/base.entity';
+
+export enum FeeChangeType {
+  GLOBAL = 'global',
+  MERCHANT_OVERRIDE = 'merchant_override',
+}
+
+@Entity('fee_histories')
+@Index(['feeType', 'createdAt'])
+@Index(['merchantId', 'createdAt'])
+@Index(['actorId', 'createdAt'])
+export class FeeHistory extends BaseEntity {
+  @Column({
+    name: 'fee_type',
+    type: 'varchar',
+    length: 50,
+  })
+  feeType!: string;
+
+  @Column({
+    name: 'change_type',
+    type: 'enum',
+    enum: FeeChangeType,
+  })
+  changeType!: FeeChangeType;
+
+  /** Merchant ID for per-merchant overrides; null for global changes */
+  @Column({
+    name: 'merchant_id',
+    type: 'varchar',
+    length: 255,
+    nullable: true,
+    default: null,
+  })
+  merchantId!: string | null;
+
+  @Column({
+    name: 'previous_value',
+    type: 'numeric',
+    precision: 7,
+    scale: 6,
+  })
+  previousValue!: string;
+
+  @Column({
+    name: 'new_value',
+    type: 'numeric',
+    precision: 7,
+    scale: 6,
+  })
+  newValue!: string;
+
+  /** Who performed the action (adminId) */
+  @Column({ name: 'actor_id', type: 'varchar', length: 255 })
+  actorId!: string;
+
+  @Column({
+    name: 'actor_type',
+    type: 'varchar',
+    length: 50,
+    default: 'admin',
+  })
+  actorType!: string;
+
+  @Column({
+    name: 'reason',
+    type: 'text',
+    nullable: true,
+    default: null,
+  })
+  reason!: string | null;
+
+}
+

--- a/backend/src/merchants/dto/register-merchant.dto.ts
+++ b/backend/src/merchants/dto/register-merchant.dto.ts
@@ -63,4 +63,14 @@ export class RegisterMerchantDto {
   @IsNumber()
   @Min(0)
   threshold?: number;
+
+  @ApiPropertyOptional({
+    description: 'Custom fee rate override (e.g. 0.015 = 1.5%). Null to use global default.',
+    minimum: 0,
+    maximum: 1,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  customFeeRate?: number;
 }

--- a/backend/src/merchants/dto/update-merchant.dto.ts
+++ b/backend/src/merchants/dto/update-merchant.dto.ts
@@ -62,4 +62,14 @@ export class UpdateMerchantDto {
   @IsNumber()
   @Min(0)
   threshold?: number;
+
+  @ApiPropertyOptional({
+    description: 'Custom fee rate override (e.g. 0.015 = 1.5%). Null to use global default.',
+    minimum: 0,
+    maximum: 1,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  customFeeRate?: number;
 }

--- a/backend/src/merchants/entities/merchant.entity.ts
+++ b/backend/src/merchants/entities/merchant.entity.ts
@@ -62,4 +62,15 @@ export class Merchant extends BaseEntity {
     },
   })
   settlementThresholdUsdc!: number;
+
+  /** Per-merchant custom fee rate override. Null means use global default. */
+  @Column({
+    name: 'custom_fee_rate',
+    type: 'numeric',
+    precision: 7,
+    scale: 6,
+    nullable: true,
+    default: null,
+  })
+  customFeeRate!: string | null;
 }

--- a/backend/src/merchants/merchants-admin.controller.ts
+++ b/backend/src/merchants/merchants-admin.controller.ts
@@ -4,6 +4,7 @@ import {
   Param,
   Patch,
   Req,
+  Body,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -34,5 +35,24 @@ export class MerchantsAdminController {
     }
 
     return this.merchantsService.verifyMerchant(id);
+  }
+
+  @Patch(':id/fee')
+  @ApiOperation({ summary: 'Set custom fee rate for a merchant' })
+  @ApiResponse({ status: 200, type: Merchant })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Admin only' })
+  @ApiResponse({ status: 404, description: 'Merchant not found' })
+  async setMerchantFee(
+    @Param('id') id: string,
+    @Body('customFeeRate') customFeeRate: number | null,
+    @Req() req: Request,
+  ): Promise<Merchant> {
+    const user = (req as Request & { user?: { isAdmin?: boolean } }).user;
+    if (!user?.isAdmin) {
+      throw new ForbiddenException('Admin only');
+    }
+
+    return this.merchantsService.updateMerchantFee(id, customFeeRate);
   }
 }

--- a/backend/src/merchants/merchants.service.ts
+++ b/backend/src/merchants/merchants.service.ts
@@ -33,30 +33,6 @@ export class MerchantsService {
       throw new ConflictException('Merchant profile already exists');
     }
 
-    const merchant = await this.dataSource.transaction(
-      async (trx: EntityManager) => {
-        const merchantEntity = trx.getRepository(Merchant).create({
-          userId: user.id,
-          businessName: dto.businessName,
-          businessType: dto.businessType,
-          logoKey: dto.logoKey ?? null,
-          description: dto.description ?? null,
-          settlementCurrency: dto.settlementCurrency,
-          autoSettleEnabled: dto.autoSettleEnabled ?? true,
-          settlementThresholdUsdc: dto.threshold ?? 10,
-        });
-
-        const savedMerchant = await trx
-          .getRepository(Merchant)
-          .save(merchantEntity);
-
-        user.isMerchant = true;
-        user.role = UserRole.MERCHANT;
-        await trx.getRepository(User).save(user);
-
-        return savedMerchant;
-      },
-    );
     const merchant = await this.dataSource.transaction(async (trx: EntityManager) => {
       const merchantEntity = trx.getRepository(Merchant).create({
         userId: user.id,
@@ -67,6 +43,7 @@ export class MerchantsService {
         settlementCurrency: dto.settlementCurrency,
         autoSettleEnabled: dto.autoSettleEnabled ?? true,
         settlementThresholdUsdc: dto.threshold ?? 10,
+        customFeeRate: dto.customFeeRate != null ? String(dto.customFeeRate) : null,
       });
 
       const savedMerchant = await trx.getRepository(Merchant).save(merchantEntity);
@@ -113,6 +90,9 @@ export class MerchantsService {
     }
     if (dto.threshold !== undefined) {
       merchant.settlementThresholdUsdc = dto.threshold;
+    }
+    if (dto.customFeeRate !== undefined) {
+      merchant.customFeeRate = dto.customFeeRate != null ? String(dto.customFeeRate) : null;
     }
 
     return this.merchantRepo.save(merchant);
@@ -167,5 +147,21 @@ export class MerchantsService {
     }
 
     return merchant;
+  }
+
+  async updateMerchantFee(
+    merchantId: string,
+    customFeeRate: number | null,
+  ): Promise<Merchant> {
+    const merchant = await this.merchantRepo.findOne({
+      where: { id: merchantId },
+    });
+    if (!merchant) {
+      throw new NotFoundException('Merchant not found');
+    }
+
+    merchant.customFeeRate =
+      customFeeRate != null ? String(customFeeRate) : null;
+    return this.merchantRepo.save(merchant);
   }
 }


### PR DESCRIPTION
- Add FeeHistory entity for tracking fee changes
- Add MERCHANT_SETTLEMENT fee type to FeeConfig
- Add customFeeRate to Merchant entity and DTOs
- Implement global fee management endpoints (GET/PATCH /admin/fees)
- Implement per-merchant fee override (PATCH /admin/merchants/:id/fee)
- Add fee history recording with actor tracking
- Update admin service with getGlobalFees, updateGlobalFee, recordFeeHistory
- Add tests for admin fee operations
- Fix NotificationService import name
- closes #700 