### PR TITLE
[Payments] Refund processing

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -109,6 +109,9 @@
     "moduleNameMapper": {
       "^@/(.*)$": "<rootDir>/$1"
     },
+    "transformIgnorePatterns": [
+      "node_modules/(?!uuid)"
+    ],
     "testEnvironment": "node"
   },
   "pnpm": {

--- a/backend/src/payments/dto/refund-payment.dto.ts
+++ b/backend/src/payments/dto/refund-payment.dto.ts
@@ -1,0 +1,21 @@
+import { IsNotEmpty, IsOptional, IsNumber, IsString, Min } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class RefundPaymentDto {
+  @ApiPropertyOptional({
+    description: 'Amount to refund in USD. If not provided, the full payment amount will be refunded.',
+    example: 10.50,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0.01)
+  amountUsd?: number;
+
+  @ApiProperty({
+    description: 'Reason for the refund',
+    example: 'Customer requested a return',
+  })
+  @IsNotEmpty()
+  @IsString()
+  reason: string;
+}

--- a/backend/src/payments/entities/payment.entity.ts
+++ b/backend/src/payments/entities/payment.entity.ts
@@ -17,6 +17,7 @@ export enum PaymentStatus {
   SETTLED = 'settled',
   FAILED = 'failed',
   EXPIRED = 'expired',
+  REFUNDED = 'refunded',
 }
 
 export enum PaymentNetwork {
@@ -63,6 +64,9 @@ export class Payment {
   stellarMemo: string;
 
   @Column({ nullable: true })
+  customerWalletAddress: string;
+
+  @Column({ nullable: true })
   txHash: string;
 
   @Column({ nullable: true })
@@ -91,6 +95,18 @@ export class Payment {
 
   @Column({ nullable: true })
   confirmedAt: Date;
+
+  @Column({ type: 'decimal', precision: 18, scale: 6, nullable: true })
+  refundAmountUsd: number;
+
+  @Column({ nullable: true })
+  refundReason: string;
+
+  @Column({ nullable: true })
+  refundTxHash: string;
+
+  @Column({ nullable: true })
+  refundedAt: Date;
 
   @ManyToOne(() => Settlement, { nullable: true })
   @JoinColumn({ name: 'settlementId' })

--- a/backend/src/payments/payments.controller.spec.ts
+++ b/backend/src/payments/payments.controller.spec.ts
@@ -1,0 +1,57 @@
+jest.mock('uuid', () => ({ v4: () => 'mock-uuid' }));
+import { Test, TestingModule } from '@nestjs/testing';
+import { PaymentsController } from './payments.controller';
+import { PaymentsService } from './payments.service';
+import { JwtAuthGuard } from '../auth/guards/jwt.guard';
+import { IdempotencyInterceptor } from '../payment/idempotency.interceptor';
+import { CacheService } from '../cache/cache.service';
+import { PaymentStatus } from './entities/payment.entity';
+
+describe('PaymentsController', () => {
+  let controller: PaymentsController;
+  let service: PaymentsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PaymentsController],
+      providers: [
+        {
+          provide: PaymentsService,
+          useValue: {
+            create: jest.fn(),
+            findAll: jest.fn(),
+            findOne: jest.fn(),
+            getStats: jest.fn(),
+            refund: jest.fn(),
+          },
+        },
+        IdempotencyInterceptor,
+        {
+          provide: CacheService,
+          useValue: { get: jest.fn(), set: jest.fn() },
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<PaymentsController>(PaymentsController);
+    service = module.get<PaymentsService>(PaymentsService);
+  });
+
+  describe('refund', () => {
+    it('should call service.refund', async () => {
+      const dto = { reason: 'Test refund', amountUsd: 50 };
+      const req = { user: { merchantId: 'm1' } };
+      const paymentId = 'p1';
+
+      jest.spyOn(service, 'refund').mockResolvedValue({ id: paymentId, status: PaymentStatus.REFUNDED } as any);
+
+      const result = await controller.refund(req as any, paymentId, dto);
+
+      expect(service.refund).toHaveBeenCalledWith(paymentId, 'm1', dto);
+      expect(result.status).toBe(PaymentStatus.REFUNDED);
+    });
+  });
+});

--- a/backend/src/payments/payments.controller.ts
+++ b/backend/src/payments/payments.controller.ts
@@ -13,6 +13,7 @@ import {
 } from '@nestjs/swagger';
 import { PaymentsService } from './payments.service';
 import { CreatePaymentDto } from './dto/create-payment.dto';
+import { RefundPaymentDto } from './dto/refund-payment.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt.guard';
 import { PaginationDto } from '../common/dto/pagination.dto';
 import { IdempotencyInterceptor } from '../payment/idempotency.interceptor';
@@ -64,6 +65,22 @@ export class PaymentsController {
   @ApiResponse({ status: 500, description: 'Internal server error' })
   findOne(@Request() req: { user: { merchantId: string } }, @Param('id', ParseUUIDPipe) id: string) {
     return this.paymentsService.findOne(id, req.user.merchantId);
+  }
+
+  @Post(':id/refund')
+  @ApiOperation({ summary: 'Initiate a refund for a settled payment' })
+  @ApiParam({ name: 'id', description: 'Payment UUID' })
+  @ApiOkResponse({ description: 'Refund successful' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT' })
+  @ApiNotFoundResponse({ description: 'Payment not found' })
+  @ApiBadRequestResponse({ description: 'Refund not possible' })
+  @ApiResponse({ status: 500, description: 'Internal server error' })
+  refund(
+    @Request() req: { user: { merchantId: string } },
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: RefundPaymentDto,
+  ) {
+    return this.paymentsService.refund(id, req.user.merchantId, dto);
   }
 }
 

--- a/backend/src/payments/payments.module.ts
+++ b/backend/src/payments/payments.module.ts
@@ -6,9 +6,19 @@ import { Payment } from './entities/payment.entity';
 import { StellarModule } from '../stellar/stellar.module';
 import { CacheModule } from '../cache/cache.module';
 import { IdempotencyInterceptor } from '../payment/idempotency.interceptor';
+import { WebhooksModule } from '../webhooks/webhooks.module';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { MerchantsModule } from '../merchants/merchants.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Payment]), forwardRef(() => StellarModule), CacheModule],
+  imports: [
+    TypeOrmModule.forFeature([Payment]),
+    forwardRef(() => StellarModule),
+    CacheModule,
+    WebhooksModule,
+    NotificationsModule,
+    MerchantsModule,
+  ],
   controllers: [PaymentsController, PublicPaymentController],
   providers: [PaymentsService, IdempotencyInterceptor],
   exports: [PaymentsService],

--- a/backend/src/payments/payments.service.spec.ts
+++ b/backend/src/payments/payments.service.spec.ts
@@ -1,0 +1,145 @@
+jest.mock('uuid', () => ({ v4: () => 'mock-uuid' }));
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { PaymentsService } from './payments.service';
+import { Payment, PaymentStatus } from './entities/payment.entity';
+import { StellarService } from '../stellar/stellar.service';
+import { WebhooksService } from '../webhooks/webhooks.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { MerchantsService } from '../merchants/merchants.service';
+
+describe('PaymentsService', () => {
+  let service: PaymentsService;
+  let repo: Repository<Payment>;
+  let stellar: StellarService;
+  let webhooks: WebhooksService;
+  let notifications: NotificationsService;
+  let merchants: MerchantsService;
+
+  const mockMerchant = {
+    id: 'merchant-123',
+    email: 'merchant@example.com',
+    businessName: 'Test Merchant',
+  };
+
+  const mockPayment = {
+    id: 'payment-123',
+    merchantId: 'merchant-123',
+    reference: 'PAY-123',
+    status: PaymentStatus.SETTLED,
+    amountUsd: 100,
+    amountUsdc: 100,
+    customerWalletAddress: 'GDABC...',
+    customerEmail: 'customer@example.com',
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PaymentsService,
+        {
+          provide: getRepositoryToken(Payment),
+          useValue: {
+            findOne: jest.fn(),
+            save: jest.fn(),
+          },
+        },
+        {
+          provide: StellarService,
+          useValue: {
+            sendPayment: jest.fn(),
+            getUsdcAsset: jest.fn(),
+          },
+        },
+        {
+          provide: WebhooksService,
+          useValue: {
+            dispatch: jest.fn(),
+          },
+        },
+        {
+          provide: NotificationsService,
+          useValue: {
+            enqueueEmail: jest.fn(),
+          },
+        },
+        {
+          provide: MerchantsService,
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<PaymentsService>(PaymentsService);
+    repo = module.get<Repository<Payment>>(getRepositoryToken(Payment));
+    stellar = module.get<StellarService>(StellarService);
+    jest.spyOn(stellar, 'getUsdcAsset').mockReturnValue({ code: 'USDC' } as any);
+    webhooks = module.get<WebhooksService>(WebhooksService);
+    notifications = module.get<NotificationsService>(NotificationsService);
+    merchants = module.get<MerchantsService>(MerchantsService);
+  });
+
+  describe('refund', () => {
+    it('should throw NotFoundException if payment not found', async () => {
+      jest.spyOn(repo, 'findOne').mockResolvedValue(null);
+      await expect(service.refund('123', 'merchant-123', { reason: 'test' }))
+        .rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw BadRequestException if payment not settled', async () => {
+      jest.spyOn(repo, 'findOne').mockResolvedValue({ ...mockPayment, status: PaymentStatus.PENDING } as any);
+      await expect(service.refund('123', 'merchant-123', { reason: 'test' }))
+        .rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException if customer wallet unknown', async () => {
+      jest.spyOn(repo, 'findOne').mockResolvedValue({ ...mockPayment, customerWalletAddress: null } as any);
+      await expect(service.refund('123', 'merchant-123', { reason: 'test' }))
+        .rejects.toThrow(BadRequestException);
+    });
+
+    it('should successfully process full refund', async () => {
+      const payment = { ...mockPayment, status: PaymentStatus.SETTLED };
+      jest.spyOn(repo, 'findOne').mockResolvedValue(payment as any);
+      jest.spyOn(merchants, 'findOne').mockResolvedValue(mockMerchant as any);
+      jest.spyOn(stellar, 'sendPayment').mockResolvedValue('tx-hash-123');
+      jest.spyOn(repo, 'save').mockImplementation(async (p) => p as any);
+
+      const result = await service.refund('payment-123', 'merchant-123', { reason: 'Customer return' });
+
+      expect(result.status).toBe(PaymentStatus.REFUNDED);
+      expect(result.refundAmountUsd).toBe(100);
+      expect(stellar.sendPayment).toHaveBeenCalledWith(
+        'GDABC...',
+        '100.0000000',
+        expect.anything(),
+        'REFUND-123',
+      );
+      expect(webhooks.dispatch).toHaveBeenCalledWith('merchant-123', 'payment.refunded', expect.anything());
+      expect(notifications.enqueueEmail).toHaveBeenCalledTimes(2);
+    });
+
+    it('should successfully process partial refund', async () => {
+      const payment = { ...mockPayment, status: PaymentStatus.SETTLED };
+      jest.spyOn(repo, 'findOne').mockResolvedValue(payment as any);
+      jest.spyOn(merchants, 'findOne').mockResolvedValue(mockMerchant as any);
+      jest.spyOn(stellar, 'sendPayment').mockResolvedValue('tx-hash-123');
+      jest.spyOn(repo, 'save').mockImplementation(async (p) => p as any);
+
+      const result = await service.refund('payment-123', 'merchant-123', { amountUsd: 50, reason: 'Partial return' });
+
+      expect(result.status).toBe(PaymentStatus.REFUNDED);
+      expect(result.refundAmountUsd).toBe(50);
+      expect(stellar.sendPayment).toHaveBeenCalledWith(
+        'GDABC...',
+        '50.0000000',
+        expect.anything(),
+        'REFUND-123',
+      );
+    });
+  });
+});

--- a/backend/src/payments/payments.service.ts
+++ b/backend/src/payments/payments.service.ts
@@ -1,11 +1,16 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
 import * as QRCode from 'qrcode';
+import * as StellarSdk from '@stellar/stellar-sdk';
 import { Payment, PaymentStatus } from './entities/payment.entity';
 import { CreatePaymentDto } from './dto/create-payment.dto';
+import { RefundPaymentDto } from './dto/refund-payment.dto';
 import { StellarService } from '../stellar/stellar.service';
+import { WebhooksService } from '../webhooks/webhooks.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { MerchantsService } from '../merchants/merchants.service';
 import { PaginatedResponseDto } from '../common/dto/pagination.dto';
 
 @Injectable()
@@ -14,6 +19,9 @@ export class PaymentsService {
     @InjectRepository(Payment)
     private paymentsRepo: Repository<Payment>,
     private stellar: StellarService,
+    private webhooks: WebhooksService,
+    private notifications: NotificationsService,
+    private merchants: MerchantsService,
   ) {}
 
   async create(merchantId: string, dto: CreatePaymentDto): Promise<Payment> {
@@ -82,5 +90,89 @@ export class PaymentsService {
       .getRawMany();
 
     return result;
+  }
+
+  async refund(id: string, merchantId: string, dto: RefundPaymentDto): Promise<Payment> {
+    const payment = await this.findOne(id, merchantId);
+
+    if (payment.status !== PaymentStatus.SETTLED) {
+      throw new BadRequestException('Only settled payments can be refunded');
+    }
+
+    if (!payment.customerWalletAddress) {
+      throw new BadRequestException('Customer wallet address is unknown. Manual refund required.');
+    }
+
+    const merchant = await this.merchants.findOne(merchantId);
+
+    // Determine refund amount
+    const refundAmountUsd = dto.amountUsd || payment.amountUsd;
+    if (refundAmountUsd > payment.amountUsd) {
+      throw new BadRequestException('Refund amount cannot exceed original payment amount');
+    }
+
+    // Determine asset and amount for Stellar transfer
+    let asset: StellarSdk.Asset;
+    let amountStr: string;
+
+    if (payment.amountUsdc) {
+      asset = this.stellar.getUsdcAsset();
+      // If partial refund, we need to calculate USDC amount based on ratio
+      const ratio = refundAmountUsd / payment.amountUsd;
+      const amountUsdc = payment.amountUsdc * ratio;
+      amountStr = amountUsdc.toFixed(7);
+    } else {
+      asset = StellarSdk.Asset.native();
+      const ratio = refundAmountUsd / payment.amountUsd;
+      const amountXlm = payment.amountXlm * ratio;
+      amountStr = amountXlm.toFixed(7);
+    }
+
+    const memo = `REFUND-${payment.reference.split('-').pop()}`;
+
+    try {
+      const txHash = await this.stellar.sendPayment(
+        payment.customerWalletAddress,
+        amountStr,
+        asset,
+        memo,
+      );
+
+      payment.status = PaymentStatus.REFUNDED;
+      payment.refundAmountUsd = refundAmountUsd;
+      payment.refundReason = dto.reason;
+      payment.refundTxHash = txHash;
+      payment.refundedAt = new Date();
+
+      const saved = await this.paymentsRepo.save(payment);
+
+      // Dispatch webhook
+      await this.webhooks.dispatch(merchantId, 'payment.refunded', {
+        paymentId: payment.id,
+        reference: payment.reference,
+        refundAmountUsd,
+        refundTxHash: txHash,
+        reason: dto.reason,
+      });
+
+      // Send emails
+      await this.notifications.enqueueEmail({
+        recipient: merchant.email,
+        subject: `Refund processed: ${payment.reference}`,
+        html: `<p>A refund of $${refundAmountUsd} has been processed for payment ${payment.reference}.</p><p>Reason: ${dto.reason}</p>`,
+      });
+
+      if (payment.customerEmail) {
+        await this.notifications.enqueueEmail({
+          recipient: payment.customerEmail,
+          subject: `Refund received from ${merchant.businessName}`,
+          html: `<p>A refund of $${refundAmountUsd} has been processed for your payment ${payment.reference}.</p><p>The funds have been sent back to your Stellar wallet.</p>`,
+        });
+      }
+
+      return saved;
+    } catch (err) {
+      throw new BadRequestException(`Stellar refund failed: ${err.message}`);
+    }
   }
 }

--- a/backend/src/stellar/stellar-monitor.service.ts
+++ b/backend/src/stellar/stellar-monitor.service.ts
@@ -76,7 +76,7 @@ export class StellarMonitorService implements OnModuleInit {
       if (!result.verified) continue;
 
       try {
-        await this.confirmPayment(matched, tx.hash, result.amount, result.asset);
+        await this.confirmPayment(matched, tx.hash, result.amount, result.asset, result.from);
       } catch (err) {
         await this.adminAlerts.raise({
           type: AdminAlertType.STELLAR_MONITOR,
@@ -96,12 +96,14 @@ export class StellarMonitorService implements OnModuleInit {
     txHash: string,
     amount: number,
     asset: string,
+    from?: string,
   ) {
     this.logger.log(`Payment confirmed: ${payment.reference} | tx: ${txHash}`);
 
     payment.status = PaymentStatus.CONFIRMED;
     payment.txHash = txHash;
     payment.confirmedAt = new Date();
+    payment.customerWalletAddress = from;
 
     if (asset === 'USDC') payment.amountUsdc = amount;
     else payment.amountXlm = amount;

--- a/backend/src/stellar/stellar.service.ts
+++ b/backend/src/stellar/stellar.service.ts
@@ -90,7 +90,7 @@ export class StellarService implements OnModuleInit {
     txHash: string,
     expectedMemo: string,
     expectedAmountUsdc?: number,
-  ): Promise<{ verified: boolean; amount?: number; asset?: string }> {
+  ): Promise<{ verified: boolean; amount?: number; asset?: string; from?: string }> {
     try {
       const tx = await this.server.transactions().transaction(txHash).call();
 
@@ -109,7 +109,7 @@ export class StellarService implements OnModuleInit {
 
           if (isUsdc || isXlm) {
             const amount = parseFloat(op.amount);
-            return { verified: true, amount, asset: isUsdc ? 'USDC' : 'XLM' };
+            return { verified: true, amount, asset: isUsdc ? 'USDC' : 'XLM', from: op.from };
           }
         }
       }


### PR DESCRIPTION
Close: #797
I have successfully implemented the refund processing feature for settled payments.

Summary of Changes
Entity Updates: Added REFUNDED status and refund-specific fields (refundAmountUsd, refundReason, refundTxHash, refundedAt) to the Payment entity.
Stellar Integration: Updated the system to automatically capture the customer's Stellar wallet address during payment confirmation, enabling automated refunds.
New API Endpoint: Added POST /payments/:id/refund which handles the logic for transferring funds back to the customer.
Automated Notifications: Integrated with the webhook service to fire payment.refunded events and the notification service to send email confirmations to both merchants and customers.
Comprehensive Testing: Added unit tests for both the PaymentsService and PaymentsController to ensure the refund logic is robust and correctly handles edge cases.
You can find the full details in the 
walkthrough
The system is now ready to support merchant-initiated refunds for all future settled payments. For payments settled prior to this update, manual refunds will be required as the customer's wallet address was not previously recorded.