### PR TITLE
feat: per-endpoint HTTP request rate and latency Prometheus metrics

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -62,7 +62,9 @@
     "stellar-sdk": "^12.2.0",
     "typeorm": "^0.3.28",
     "uuid": "^13.0.0",
-    "winston": "^3.19.0"
+    "winston": "^3.19.0",
+    "@willsoto/nestjs-prometheus": "^6.0.2",
+    "prom-client": "^15.1.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -40,6 +40,7 @@
     "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^11.0.0",
     "@nestjs/websockets": "^11.0.1",
+    "@sentry/nestjs": "^8.47.0",
     "@simplewebauthn/server": "^13.3.0",
     "@stellar/stellar-sdk": "^14.6.1",
     "bcrypt": "^6.0.0",
@@ -53,8 +54,8 @@
     "nest-winston": "^1.10.2",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
-    "qrcode": "^1.5.4",
     "pg": "^8.20.0",
+    "qrcode": "^1.5.4",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "socket.io": "^4.8.1",
@@ -120,3 +121,4 @@
   },
   "packageManager": "pnpm@10.30.2+sha512.36cdc707e7b7940a988c9c1ecf88d084f8514b5c3f085f53a2e244c2921d3b2545bc20dd4ebe1fc245feec463bb298aecea7a63ed1f7680b877dc6379d8d0cb4"
 }
+

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -89,4 +89,28 @@ export class AdminController {
   ) {
     return this.adminService.broadcast(dto);
   }
+
+  @Get('fees')
+  @Roles(AdminRole.ADMIN, AdminRole.SUPERADMIN)
+  @ApiOperation({ summary: 'List all global fee configurations' })
+  async getFees() {
+    return this.adminService.getGlobalFees();
+  }
+
+  @Patch('fees')
+  @Roles(AdminRole.ADMIN, AdminRole.SUPERADMIN)
+  @Audit({ action: 'fee.update', resourceType: 'fee-config' })
+  @ApiOperation({ summary: 'Update a global fee rate' })
+  async updateFee(
+    @Body() dto: { feeType: string; newRate: string; reason?: string },
+    @Req() req: any,
+  ) {
+    const adminId = req.user.id;
+    return this.adminService.updateGlobalFee(
+      dto.feeType as any,
+      dto.newRate,
+      adminId,
+      dto.reason,
+    );
+  }
 }

--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -11,7 +11,12 @@ import { RefreshToken } from '../auth/entities/refresh-token.entity';
 import { EmailModule } from '../email/email.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { AdminAuthModule } from './auth/admin-auth.module';
+import { AnalyticsModule } from './analytics/analytics.module';
+import { CronModule } from '../cron/cron.module';
+import { CronAdminController } from './cron-admin.controller';
 import { AuditModule } from '../audit/audit.module';
+import { FeeConfig } from '../fee-config/entities/fee-config.entity';
+import { FeeHistory } from '../fee-config/entities/fee-history.entity';
 
 @Module({
   imports: [
@@ -22,14 +27,18 @@ import { AuditModule } from '../audit/audit.module';
       FraudFlag,
       Session,
       RefreshToken,
+      FeeConfig,
+      FeeHistory,
     ]),
     EmailModule,
     NotificationsModule,
     AdminAuthModule,
     AuditModule,
+    AnalyticsModule,
+    CronModule,
   ],
   providers: [AdminService],
-  controllers: [AdminController],
-  exports: [AdminService, AdminAuthModule],
+  controllers: [AdminController, CronAdminController],
+  exports: [AdminService, AdminAuthModule, AnalyticsModule],
 })
 export class AdminModule {}

--- a/backend/src/admin/admin.service.spec.ts
+++ b/backend/src/admin/admin.service.spec.ts
@@ -10,6 +10,8 @@ import { EmailService } from '../email/email.service';
 import { AuditService } from '../audit/audit.service';
 import { NotificationService } from '../notifications/notifications.service';
 import { CacheService } from '../cache/cache.service';
+import { FeeConfig, FeeType } from '../fee-config/entities/fee-config.entity';
+import { FeeHistory, FeeChangeType } from '../fee-config/entities/fee-history.entity';
 
 describe('AdminService', () => {
   let service: AdminService;
@@ -17,6 +19,8 @@ describe('AdminService', () => {
   let sessionRepo: any;
   let tokenRepo: any;
   let fraudRepo: any;
+  let feeConfigRepo: any;
+  let feeHistoryRepo: any;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -53,6 +57,21 @@ describe('AdminService', () => {
           useValue: { update: jest.fn() },
         },
         {
+          provide: getRepositoryToken(FeeConfig),
+          useValue: {
+            find: jest.fn(),
+            findOne: jest.fn(),
+            save: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(FeeHistory),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+          },
+        },
+        {
           provide: EmailService,
           useValue: { queue: jest.fn() },
         },
@@ -76,6 +95,8 @@ describe('AdminService', () => {
     sessionRepo = module.get(getRepositoryToken(Session));
     tokenRepo = module.get(getRepositoryToken(RefreshToken));
     fraudRepo = module.get(getRepositoryToken(FraudFlag));
+    feeConfigRepo = module.get(getRepositoryToken(FeeConfig));
+    feeHistoryRepo = module.get(getRepositoryToken(FeeHistory));
   });
 
   it('should revoke sessions on freezeUser', async () => {
@@ -99,5 +120,62 @@ describe('AdminService', () => {
       expect.objectContaining({ revokedAt: expect.any(Date) }),
     );
     expect(fraudRepo.save).toHaveBeenCalled();
+  });
+
+  describe('Fee Management', () => {
+    it('should return all global fees', async () => {
+      const fees = [
+        { feeType: FeeType.TRANSFER, baseFeeRate: '0.010000' },
+        { feeType: FeeType.WITHDRAWAL, baseFeeRate: '0.020000' },
+      ];
+      feeConfigRepo.find.mockResolvedValue(fees);
+
+      const result = await service.getGlobalFees();
+
+      expect(result).toEqual(fees);
+      expect(feeConfigRepo.find).toHaveBeenCalledWith({
+        order: { feeType: 'ASC' },
+      });
+    });
+
+    it('should update global fee and record history', async () => {
+      const feeConfig = {
+        feeType: FeeType.TRANSFER,
+        baseFeeRate: '0.010000',
+      };
+      feeConfigRepo.findOne.mockResolvedValue(feeConfig);
+      feeConfigRepo.save.mockResolvedValue({ ...feeConfig, baseFeeRate: '0.015000' });
+      feeHistoryRepo.create.mockReturnValue({});
+
+      const result = await service.updateGlobalFee(
+        FeeType.TRANSFER,
+        '0.015000',
+        'admin-123',
+        'Increased due to market conditions',
+      );
+
+      expect(feeConfigRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ baseFeeRate: '0.015000' }),
+      );
+      expect(feeHistoryRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          feeType: FeeType.TRANSFER,
+          changeType: FeeChangeType.GLOBAL,
+          previousValue: '0.010000',
+          newValue: '0.015000',
+          actorId: 'admin-123',
+          reason: 'Increased due to market conditions',
+        }),
+      );
+      expect(feeHistoryRepo.save).toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when fee config not found', async () => {
+      feeConfigRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.updateGlobalFee(FeeType.DEPOSIT, '0.005000', 'admin-123'),
+      ).rejects.toThrow('Fee config for deposit not found');
+    });
   });
 });

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, NotFoundException, Inject } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  Inject,
+  BadRequestException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, ILike, Raw } from 'typeorm';
 import { User, KycStatus } from '../users/entities/user.entity';
@@ -15,9 +20,14 @@ import { Session } from '../auth/entities/session.entity';
 import { RefreshToken } from '../auth/entities/refresh-token.entity';
 import { EmailService } from '../email/email.service';
 import { AuditService } from '../audit/audit.service';
-import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationService } from '../notifications/notifications.service';
 import { CacheService } from '../cache/cache.service';
 import { TierName } from '../tier-config/entities/tier-config.entity';
+import { FeeConfig, FeeType } from '../fee-config/entities/fee-config.entity';
+import {
+  FeeHistory,
+  FeeChangeType,
+} from '../fee-config/entities/fee-history.entity';
 
 @Injectable()
 export class AdminService {
@@ -32,9 +42,13 @@ export class AdminService {
     private readonly sessionRepo: Repository<Session>,
     @InjectRepository(RefreshToken)
     private readonly tokenRepo: Repository<RefreshToken>,
+    @InjectRepository(FeeConfig)
+    private readonly feeConfigRepo: Repository<FeeConfig>,
+    @InjectRepository(FeeHistory)
+    private readonly feeHistoryRepo: Repository<FeeHistory>,
     private readonly emailService: EmailService,
     private readonly auditService: AuditService,
-    private readonly notificationsService: NotificationsService,
+    private readonly notificationService: NotificationService,
     private readonly cacheService: CacheService,
   ) {}
 
@@ -241,9 +255,56 @@ export class AdminService {
   }
 
   async broadcast(dto: { title: string; body: string; segment: string }) {
-    // This would typically involve a background job
-    // NotificationsService should have a broadcast method
-    await this.notificationsService.broadcast(dto.title, dto.body, dto.segment);
+    await this.notificationService.broadcast(dto.title, dto.body, dto.segment);
     return { success: true };
+  }
+
+  // ── Fee Management ─────────────────────────────────────────────────────────
+
+  async getGlobalFees(): Promise<FeeConfig[]> {
+    return this.feeConfigRepo.find({ order: { feeType: 'ASC' } });
+  }
+
+  async updateGlobalFee(
+    feeType: FeeType,
+    newRate: string,
+    adminId: string,
+    reason?: string,
+  ): Promise<FeeConfig> {
+    const feeConfig = await this.feeConfigRepo.findOne({
+      where: { feeType },
+    });
+    if (!feeConfig) {
+      throw new NotFoundException(`Fee config for ${feeType} not found`);
+    }
+
+    const previousValue = feeConfig.baseFeeRate;
+    feeConfig.baseFeeRate = newRate;
+    const updated = await this.feeConfigRepo.save(feeConfig);
+
+    await this.recordFeeHistory({
+      feeType,
+      changeType: FeeChangeType.GLOBAL,
+      merchantId: null,
+      previousValue,
+      newValue: newRate,
+      actorId: adminId,
+      reason: reason ?? null,
+    });
+
+    return updated;
+  }
+
+  async recordFeeHistory(dto: {
+    feeType: string;
+    changeType: FeeChangeType;
+    merchantId: string | null;
+    previousValue: string;
+    newValue: string;
+    actorId: string;
+    reason: string | null;
+  }): Promise<FeeHistory> {
+    const entry = this.feeHistoryRepo.create(dto);
+    return this.feeHistoryRepo.save(entry);
   }
 }

--- a/backend/src/admin/cron-admin.controller.ts
+++ b/backend/src/admin/cron-admin.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, Get, Post, Param, Query, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiQuery } from '@nestjs/swagger';
+import { CronJobService } from '../../cron/cron-job.service';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { AdminRole } from '../entities/admin.entity';
+import { CronJobLog } from '../../cron/entities/cron-job-log.entity';
+
+@ApiTags('admin.crons')
+@UseGuards(RolesGuard)
+@Controller({ path: 'admin/crons', version: '1' })
+export class CronAdminController {
+  constructor(private cronService: CronJobService) {}
+
+  @Get()
+  @Roles(AdminRole.ADMIN, AdminRole.SUPERADMIN)
+  @ApiOperation({ summary: 'List cron jobs status' })
+  async listJobs() {
+    // Return registry + last run stats
+    return []; // TODO: implement
+  }
+
+  @Get(':jobName/history')
+  @Roles(AdminRole.ADMIN, AdminRole.SUPERADMIN)
+  @ApiOperation({ summary: 'Job history' })
+  async getHistory(
+    @Param('jobName') jobName: string,
+    @Query('page') page = 1,
+    @Query('limit') limit = 50,
+  ) {
+    return []; // TODO: paginated logs
+  }
+
+  @Post(':jobName/trigger')
+  @Roles(AdminRole.ADMIN, AdminRole.SUPERADMIN)
+  @ApiOperation({ summary: 'Manual trigger' })
+  async triggerJob(@Param('jobName') jobName: string) {
+    // Validate jobName in registry, then run
+    return { triggered: true };
+  }
+}
+

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -52,6 +52,7 @@ import { ApiVersionModule } from './api-version/api-version.module';
 import { DeprecationHeadersInterceptor } from './api-version/deprecation-headers.interceptor';
 import { CronModule } from './cron/cron.module';
 import { SentryModule } from './sentry/sentry.module';
+import { PrometheusModule } from './prometheus/prometheus.module';
 
 @Module({
   imports: [
@@ -96,6 +97,7 @@ import { SentryModule } from './sentry/sentry.module';
     }),
 
     HealthModule,
+    PrometheusModule,
     ApiVersionModule,
     SorobanModule,
     CronModule,

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,6 +1,7 @@
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 import { APP_INTERCEPTOR } from '@nestjs/core';
+import { APP_FILTER } from '@nestjs/core';
 import { ConfigType } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
 import { BullModule } from '@nestjs/bull';
@@ -20,6 +21,8 @@ import { LoggingModule } from './logging/logging.module';
 import { CorrelationIdMiddleware } from './logging/correlation-id.middleware';
 import { HttpLoggingInterceptor } from './logging/http-logging.interceptor';
 import { ResponseInterceptor } from './common/interceptors/response.interceptor';
+import { SentryInterceptor } from './common/interceptors/sentry.interceptor';
+import { SentryExceptionFilter } from './common/filters/sentry-exception.filter';
 import { WebhooksModule } from './webhooks/webhooks.module';
 import { RbacModule } from './rbac/rbac.module';
 import { MerchantsModule } from './merchants/merchants.module';
@@ -34,6 +37,7 @@ import { MaintenanceModeMiddleware } from './app-config/middleware/maintenance-m
 import { AdminModule } from './admin/admin.module';
 import { EarningsModule } from './earnings/earnings.module';
 import { SmsModule } from './sms/sms.module';
+import { OtpModule } from './otp/otp.module';
 import { PinModule } from './pin/pin.module';
 import { TransfersModule } from './transfers/transfers.module';
 import { WithdrawalsModule } from './withdrawals/withdrawals.module';
@@ -47,6 +51,7 @@ import { ReportsModule } from './reports/reports.module';
 import { ApiVersionModule } from './api-version/api-version.module';
 import { DeprecationHeadersInterceptor } from './api-version/deprecation-headers.interceptor';
 import { CronModule } from './cron/cron.module';
+import { SentryModule } from './sentry/sentry.module';
 
 @Module({
   imports: [
@@ -58,6 +63,9 @@ import { CronModule } from './cron/cron.module';
 
     // 1b. Logging — Winston + Nest bridge.
     LoggingModule,
+
+    // 1c. Sentry — error monitoring + performance tracing.
+    SentryModule,
 
     // 2. Database — owns the TypeORM root connection; see database.module.ts.
     DatabaseModule,
@@ -179,6 +187,14 @@ import { CronModule } from './cron/cron.module';
       provide: APP_INTERCEPTOR,
       useClass: HttpLoggingInterceptor,
     },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: SentryInterceptor,
+    },
+    {
+      provide: APP_FILTER,
+      useClass: SentryExceptionFilter,
+    },
   ],
 })
 export class AppModule implements NestModule {
@@ -187,3 +203,4 @@ export class AppModule implements NestModule {
     consumer.apply(MaintenanceModeMiddleware).forRoutes('*');
   }
 }
+

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -53,6 +53,7 @@ import { DeprecationHeadersInterceptor } from './api-version/deprecation-headers
 import { CronModule } from './cron/cron.module';
 import { SentryModule } from './sentry/sentry.module';
 import { PrometheusModule } from './prometheus/prometheus.module';
+import { HttpMetricsInterceptor } from './prometheus/http-metrics.interceptor';
 
 @Module({
   imports: [
@@ -184,6 +185,10 @@ import { PrometheusModule } from './prometheus/prometheus.module';
     {
       provide: APP_INTERCEPTOR,
       useClass: DeprecationHeadersInterceptor,
+    },
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: HttpMetricsInterceptor,
     },
     {
       provide: APP_INTERCEPTOR,

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -46,6 +46,7 @@ import { KycModule } from './kyc/kyc.module';
 import { ReportsModule } from './reports/reports.module';
 import { ApiVersionModule } from './api-version/api-version.module';
 import { DeprecationHeadersInterceptor } from './api-version/deprecation-headers.interceptor';
+import { CronModule } from './cron/cron.module';
 
 @Module({
   imports: [
@@ -89,6 +90,7 @@ import { DeprecationHeadersInterceptor } from './api-version/deprecation-headers
     HealthModule,
     ApiVersionModule,
     SorobanModule,
+    CronModule,
 
     // 6. Email — async transactional delivery via ZeptoMail + BullMQ.
     EmailModule,

--- a/backend/src/common/filters/sentry-exception.filter.ts
+++ b/backend/src/common/filters/sentry-exception.filter.ts
@@ -1,0 +1,103 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { HttpAdapterHost } from '@nestjs/core';
+import * as Sentry from '@sentry/nestjs';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Merchant } from '../../merchants/entities/merchant.entity';
+import type { User } from '../../users/entities/user.entity';
+import type { Admin } from '../../admin/entities/admin.entity';
+
+interface RequestWithUser {
+  user?: User | Admin;
+  url?: string;
+  method?: string;
+  headers?: Record<string, unknown>;
+}
+
+@Catch()
+export class SentryExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(SentryExceptionFilter.name);
+
+  constructor(
+    private readonly httpAdapterHost: HttpAdapterHost,
+    @InjectRepository(Merchant)
+    private readonly merchantRepo: Repository<Merchant>,
+  ) {}
+
+  async catch(exception: unknown, host: ArgumentsHost): Promise<void> {
+    const { httpAdapter } = this.httpAdapterHost;
+    const ctx = host.switchToHttp();
+    const request = ctx.getRequest<RequestWithUser>();
+    const response = ctx.getResponse();
+
+    const httpStatus =
+      exception instanceof HttpException
+        ? exception.getStatus()
+        : HttpStatus.INTERNAL_SERVER_ERROR;
+
+    // Only send 5xx errors to Sentry; 4xx are client errors
+    if (httpStatus >= 500) {
+      await this.captureException(exception, request);
+    }
+
+    const responseBody = {
+      statusCode: httpStatus,
+      message: exception instanceof HttpException ? exception.message : 'Internal server error',
+      timestamp: new Date().toISOString(),
+      path: request.url,
+    };
+
+    httpAdapter.reply(response, responseBody, httpStatus);
+  }
+
+  private async captureException(
+    exception: unknown,
+    request: RequestWithUser,
+  ): Promise<void> {
+    Sentry.withScope(async (scope) => {
+      const user = request.user;
+
+      if (user) {
+        const userContext: { id: string; email?: string; merchantId?: string } = {
+          id: user.id,
+        };
+
+        if ('email' in user) {
+          userContext.email = user.email;
+        }
+
+        // Enrich with merchantId if user is a merchant (only on error path)
+        if ('isMerchant' in user && user.isMerchant) {
+          try {
+            const merchant = await this.merchantRepo.findOne({
+              where: { userId: user.id },
+              select: ['id'],
+            });
+            if (merchant) {
+              userContext.merchantId = merchant.id;
+            }
+          } catch {
+            // Ignore merchant lookup failures during error reporting
+          }
+        }
+
+        scope.setUser(userContext);
+      }
+
+      scope.setContext('http_request', {
+        url: request.url,
+        method: request.method,
+      });
+
+      Sentry.captureException(exception);
+    });
+  }
+}
+

--- a/backend/src/common/interceptors/sentry.interceptor.ts
+++ b/backend/src/common/interceptors/sentry.interceptor.ts
@@ -1,0 +1,42 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import * as Sentry from '@sentry/nestjs';
+import type { User } from '../../users/entities/user.entity';
+import type { Admin } from '../../admin/entities/admin.entity';
+
+interface RequestWithUser {
+  user?: User | Admin;
+}
+
+@Injectable()
+export class SentryInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const request = context.switchToHttp().getRequest<RequestWithUser>();
+    const user = request.user;
+
+    Sentry.withScope((scope) => {
+      if (user) {
+        scope.setUser({
+          id: user.id,
+          email: 'email' in user ? user.email : undefined,
+        });
+        if ('isMerchant' in user && user.isMerchant) {
+          scope.setTag('user_type', 'merchant');
+        } else if ('isAdmin' in user && user.isAdmin) {
+          scope.setTag('user_type', 'admin');
+        } else {
+          scope.setTag('user_type', 'user');
+        }
+      }
+      scope.setTag('handler', `${context.getClass().name}.${context.getHandler().name}`);
+    });
+
+    return next.handle();
+  }
+}
+

--- a/backend/src/config/config.module.ts
+++ b/backend/src/config/config.module.ts
@@ -11,6 +11,7 @@ import { r2Config } from './r2.config';
 import { flutterwaveConfig } from './flutterwave.config';
 import { paystackConfig } from './paystack.config';
 import { firebaseConfig } from './firebase.config';
+import { sentryConfig } from './sentry.config';
 
 /**
  * Combined Joi validation schema for all environment variables.
@@ -86,13 +87,6 @@ const validationSchema = Joi.object({
     'any.required': 'STELLAR_ADMIN_SECRET_KEY is required',
     'string.min': 'STELLAR_ADMIN_SECRET_KEY must be at least 32 characters',
   }),
-  STELLAR_ADMIN_SECRET_KEY: Joi.string()
-    .min(32)
-    .required()
-    .messages({
-      'any.required': 'STELLAR_ADMIN_SECRET_KEY is required',
-      'string.min': 'STELLAR_ADMIN_SECRET_KEY must be at least 32 characters',
-    }),
   STELLAR_RECEIVE_ADDRESS: Joi.string()
     .length(56)
     .pattern(/^G[A-Z2-7]{55}$/)
@@ -146,6 +140,11 @@ const validationSchema = Joi.object({
     .required()
     .messages({ 'any.required': 'PAYSTACK_SECRET_KEY is required' }),
   PAYSTACK_BASE_URL: Joi.string().uri().default('https://api.paystack.co'),
+
+  // ── Sentry ─────────────────────────────────────────────────────────────────
+  SENTRY_DSN: Joi.string().uri().optional(),
+  SENTRY_TRACES_SAMPLE_RATE: Joi.number().min(0).max(1).default(0.1),
+  SENTRY_PROFILES_SAMPLE_RATE: Joi.number().min(0).max(1).default(0.05),
 });
 
 @Module({
@@ -163,6 +162,7 @@ const validationSchema = Joi.object({
         flutterwaveConfig,
         paystackConfig,
         firebaseConfig,
+        sentryConfig,
       ],
       validationSchema,
       validationOptions: { abortEarly: false },
@@ -170,3 +170,4 @@ const validationSchema = Joi.object({
   ],
 })
 export class AppConfigModule {}
+

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -13,3 +13,5 @@ export {
 export { paystackConfig, type PaystackConfig } from './paystack.config';
 export { smsConfig, smsConfigValidation } from './sms.config';
 export { firebaseConfig, firebaseConfigValidation } from './firebase.config';
+export { sentryConfig, type SentryConfig } from './sentry.config';
+

--- a/backend/src/config/sentry.config.ts
+++ b/backend/src/config/sentry.config.ts
@@ -1,0 +1,20 @@
+import { registerAs } from '@nestjs/config';
+
+export interface SentryConfig {
+  dsn: string;
+  tracesSampleRate: number;
+  profilesSampleRate: number;
+  environment: string;
+  enabled: boolean;
+}
+
+export const sentryConfig = registerAs(
+  'sentry',
+  (): SentryConfig => ({
+    dsn: process.env['SENTRY_DSN'] ?? '',
+    tracesSampleRate: parseFloat(process.env['SENTRY_TRACES_SAMPLE_RATE'] ?? '0.1'),
+    profilesSampleRate: parseFloat(process.env['SENTRY_PROFILES_SAMPLE_RATE'] ?? '0.05'),
+    environment: process.env['NODE_ENV'] ?? 'development',
+    enabled: !!process.env['SENTRY_DSN'] && process.env['NODE_ENV'] !== 'test',
+  }),
+);

--- a/backend/src/cron/TODO.md
+++ b/backend/src/cron/TODO.md
@@ -1,0 +1,22 @@
+# Cron Job Centralization TODO
+
+Completed:
+- [x] Checkout feat/cron-job-centralization
+- [x] 1. Create CronJobLog entity
+- [x] 2. CronJobService.run() wrapper
+- [x] 3. Registry + missed run processor
+- [x] 4. Admin endpoints stub
+- [x] 5. CronModule + integrate
+- [x] 6. Tests (run/timeout/fail)
+
+Remaining:
+1. Update existing jobs to use CronJobService.run()
+2. Full admin endpoints implementation
+3. DB migration for CronJobLog
+4. Schedule health check job
+5. PR
+
+**Next:** Update existing jobs (rates.processor.ts etc.).
+
+
+

--- a/backend/src/cron/cron-health.processor.ts
+++ b/backend/src/cron/cron-health.processor.ts
@@ -1,0 +1,71 @@
+import { Processor, Process } from '@nestjs/bull';
+import { Job } from 'bull';
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LessThanOrEqual, MoreThan, Repository, Between } from 'typeorm';
+import { CronJobLog, CronJobStatus } from './entities/cron-job-log.entity';
+import { CronJobService } from './cron-job.service';
+import { NotificationsService } from '../notifications/notifications.service';
+
+const CRON_QUEUE = 'cron';
+
+interface JobConfig {
+  name: string;
+  intervalMs: number; // e.g. 30000 for 30s
+}
+
+const JOB_REGISTRY: JobConfig[] = [
+  { name: 'fetch-exchange-rate', intervalMs: 30_000 },
+  { name: 'deposit-monitor', intervalMs: 30_000 },
+  { name: 'settlement-processor', intervalMs: 15 * 60_000 },
+  { name: 'yield-distributor', intervalMs: 24 * 60 * 60_000 },
+  { name: 'waitlist-leaderboard-broadcast', intervalMs: 60_000 },
+  { name: 'report-cleanup', intervalMs: 24 * 60 * 60_000 },
+  { name: 'token-cleanup', intervalMs: 7 * 24 * 60 * 60_000 },
+  { name: 'paylink-expiry', intervalMs: 5 * 60_000 },
+  { name: 'contract-event-listener', intervalMs: 60_000 },
+];
+
+@Injectable()
+@Processor(CRON_QUEUE)
+export class CronHealthProcessor {
+  private readonly logger = new Logger(CronHealthProcessor.name);
+
+  constructor(
+    @InjectRepository(CronJobLog)
+    private logRepo: Repository<CronJobLog>,
+    private cronService: CronJobService,
+    private notificationService: NotificationService,
+  ) {}
+
+  @Process('cron-health-check')
+  async checkHealth(job: Job) {
+    const now = new Date();
+    const cutoff = new Date(now.getTime() - 2 * 10 * 60 * 1000); // 20min ago for 10min check
+
+    for (const jobConfig of JOB_REGISTRY) {
+      const lastCompleted = await this.logRepo.findOne({
+        where: {
+          jobName: jobConfig.name,
+          status: CronJobStatus.COMPLETED,
+          completedAt: MoreThan(cutoff),
+        },
+        order: { completedAt: 'DESC' },
+      });
+
+      if (!lastCompleted) {
+        this.logger.warn(`Missed cron run: ${jobConfig.name}`);
+        // Alert admin
+        await this.notificationService.create({
+          title: 'Cron Job Missed',
+          body: `${jobConfig.name} has not completed in expected interval`,
+          type: 'CRITICAL',
+          recipientRole: 'admin',
+        }).catch(() => {});
+
+        // Could integrate Sentry here
+      }
+    }
+  }
+}
+

--- a/backend/src/cron/cron-job.service.spec.ts
+++ b/backend/src/cron/cron-job.service.spec.ts
@@ -1,0 +1,78 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CronJobService } from './cron-job.service';
+import { CronJobLog, CronJobStatus } from './entities/cron-job-log.entity';
+import { TimeoutException } from '@nestjs/common';
+
+describe('CronJobService', () => {
+  let service: CronJobService;
+  let mockRepo: jest.Mocked<any>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CronJobService,
+        {
+          provide: getRepositoryToken(CronJobLog),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<CronJobService>(CronJobService);
+    mockRepo = module.get(getRepositoryToken(CronJobLog));
+  });
+
+  it('should log start and complete successfully', async () => {
+    const mockFn = jest.fn().mockResolvedValue('result');
+    mockRepo.create.mockReturnValue({ id: 'log1' });
+    mockRepo.save.mockResolvedValue({ id: 'log1' } as any);
+
+    const result = await service.run('test-job', mockFn, 42);
+
+    expect(mockRepo.create).toHaveBeenCalledWith({
+      jobName: 'test-job',
+      status: CronJobStatus.STARTED,
+    });
+    expect(result).toBe('result');
+    expect(mockRepo.save).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      status: CronJobStatus.COMPLETED,
+      durationMs: expect.any(Number),
+      itemsProcessed: 42,
+    }));
+  });
+
+  it('should timeout after 5min', async () => {
+    jest.useFakeTimers();
+    const mockFn = jest.fn();
+    mockRepo.create.mockReturnValue({ id: 'log1' });
+    mockRepo.save.mockResolvedValue({} as any);
+
+    const promise = service.run('timeout-job', mockFn);
+    jest.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+    await expect(promise).rejects.toThrow(TimeoutException);
+    expect(mockRepo.save).toHaveBeenCalledWith(expect.objectContaining({
+      status: CronJobStatus.FAILED,
+    }));
+    jest.useRealTimers();
+  });
+
+  it('should log failure', async () => {
+    const error = new Error('test error');
+    const mockFn = jest.fn().mockRejectedValue(error);
+    mockRepo.create.mockReturnValue({ id: 'log1' });
+    mockRepo.save.mockResolvedValue({} as any);
+
+    await expect(service.run('fail-job', mockFn)).rejects.toThrow('test error');
+
+    expect(mockRepo.save).toHaveBeenCalledWith(expect.objectContaining({
+      status: CronJobStatus.FAILED,
+      errorMessage: 'test error',
+    }));
+  });
+});
+

--- a/backend/src/cron/cron-job.service.ts
+++ b/backend/src/cron/cron-job.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, Logger, TimeoutException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CronJobLog, CronJobStatus } from './entities/cron-job-log.entity';
+
+@Injectable()
+export class CronJobService {
+  private readonly logger = new Logger(CronJobService.name);
+
+  constructor(
+    @InjectRepository(CronJobLog)
+    private logRepo: Repository<CronJobLog>,
+  ) {}
+
+  async run<T>(jobName: string, fn: () => Promise<T>, expectedItems?: number): Promise<T> {
+    const log = this.logRepo.create({
+      jobName,
+      status: CronJobStatus.STARTED,
+    });
+    await this.logRepo.save(log);
+
+    const start = Date.now();
+
+    try {
+      // 5 min timeout
+      const result = await Promise.race([
+        fn(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new TimeoutException(`Cron job ${jobName} exceeded 5min`)), 5 * 60 * 1000),
+        ),
+      ]);
+
+      log.status = CronJobStatus.COMPLETED;
+      log.completedAt = new Date();
+      log.durationMs = Date.now() - start;
+      log.itemsProcessed = expectedItems;
+      await this.logRepo.save(log);
+
+      this.logger.log(`Cron ${jobName} completed in ${log.durationMs}ms, processed ${log.itemsProcessed || 'N/A'}`);
+      return result;
+    } catch (error) {
+      log.status = CronJobStatus.FAILED;
+      log.completedAt = new Date();
+      log.durationMs = Date.now() - start;
+      log.errorMessage = error instanceof Error ? error.message : String(error);
+      await this.logRepo.save(log);
+
+      this.logger.error(`Cron ${jobName} failed: ${log.errorMessage} (${log.durationMs}ms)`);
+      throw error;
+    }
+  }
+}
+

--- a/backend/src/cron/cron.module.ts
+++ b/backend/src/cron/cron.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { BullModule } from '@nestjs/bull';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { NotificationsModule } from '../../notifications/notifications.module';
+import { CronJobLog } from './entities/cron-job-log.entity';
+import { CronJobService } from './cron-job.service';
+import { CronHealthProcessor } from './cron-health.processor';
+
+const CRON_QUEUE = 'cron';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([CronJobLog]),
+    NotificationsModule,
+    BullModule.registerQueue({ name: CRON_QUEUE }),
+  ],
+  providers: [CronJobService, CronHealthProcessor],
+  exports: [CronJobService],
+})
+export class CronModule {}
+

--- a/backend/src/cron/entities/cron-job-log.entity.ts
+++ b/backend/src/cron/entities/cron-job-log.entity.ts
@@ -1,0 +1,42 @@
+import { Entity, Column, CreateDateColumn, PrimaryGeneratedColumn, Index } from 'typeorm';
+import { BaseEntity } from '../../../common/entities/base.entity';
+
+export enum CronJobStatus {
+  STARTED = 'started',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+  SKIPPED = 'skipped',
+}
+
+@Entity('cron_job_logs')
+@Index(['jobName', 'startedAt'])
+export class CronJobLog extends BaseEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column()
+  jobName!: string;
+
+  @Column({
+    type: 'enum',
+    enum: CronJobStatus,
+    default: CronJobStatus.STARTED,
+  })
+  status!: CronJobStatus;
+
+  @CreateDateColumn({ name: 'started_at' })
+  startedAt!: Date;
+
+  @Column({ name: 'completed_at', type: 'timestamp', nullable: true })
+  completedAt?: Date;
+
+  @Column({ name: 'duration_ms', type: 'int' })
+  durationMs!: number;
+
+  @Column({ name: 'error_message', length: 1000, nullable: true })
+  errorMessage?: string;
+
+  @Column({ name: 'items_processed', type: 'int', nullable: true })
+  itemsProcessed?: number;
+}
+

--- a/backend/src/deposits/deposits.module.ts
+++ b/backend/src/deposits/deposits.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Deposit } from './entities/deposit.entity';
 import { DepositsService } from './deposits.service';
 import { TransactionsModule } from '../transactions/transactions.module';
+import { PrometheusModule } from '../prometheus/prometheus.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Deposit]), TransactionsModule],
+  imports: [TypeOrmModule.forFeature([Deposit]), TransactionsModule, PrometheusModule],
   providers: [DepositsService],
   exports: [DepositsService],
 })

--- a/backend/src/deposits/deposits.service.ts
+++ b/backend/src/deposits/deposits.service.ts
@@ -8,6 +8,7 @@ import {
   TransactionStatus,
 } from '../transactions/entities/transaction.entity';
 import { VirtualAccount } from '../virtual-account/entities/virtual-account.entity';
+import { MetricsService } from '../prometheus/metrics.service';
 
 @Injectable()
 export class DepositsService {
@@ -18,6 +19,8 @@ export class DepositsService {
     private readonly depositRepo: Repository<Deposit>,
     @InjectRepository(Transaction)
     private readonly transactionRepo: Repository<Transaction>,
+
+    private readonly metricsService: MetricsService,
   ) {}
 
   async createDeposit(
@@ -59,6 +62,8 @@ export class DepositsService {
     this.logger.log(
       `Created deposit and transaction for user ${userId}: ${usdcAmount} USDC`,
     );
+
+    this.metricsService.incrementPaymentCreated('deposit');
 
     return savedDeposit;
   }

--- a/backend/src/fee-config/entities/fee-config.entity.ts
+++ b/backend/src/fee-config/entities/fee-config.entity.ts
@@ -5,6 +5,7 @@ export enum FeeType {
   TRANSFER = 'transfer',
   WITHDRAWAL = 'withdrawal',
   DEPOSIT = 'deposit',
+  MERCHANT_SETTLEMENT = 'merchant_settlement',
 }
 
 /**

--- a/backend/src/fee-config/entities/fee-history.entity.ts
+++ b/backend/src/fee-config/entities/fee-history.entity.ts
@@ -1,0 +1,75 @@
+import { Entity, Column, CreateDateColumn, Index } from 'typeorm';
+import { BaseEntity } from '../../common/entities/base.entity';
+
+export enum FeeChangeType {
+  GLOBAL = 'global',
+  MERCHANT_OVERRIDE = 'merchant_override',
+}
+
+@Entity('fee_histories')
+@Index(['feeType', 'createdAt'])
+@Index(['merchantId', 'createdAt'])
+@Index(['actorId', 'createdAt'])
+export class FeeHistory extends BaseEntity {
+  @Column({
+    name: 'fee_type',
+    type: 'varchar',
+    length: 50,
+  })
+  feeType!: string;
+
+  @Column({
+    name: 'change_type',
+    type: 'enum',
+    enum: FeeChangeType,
+  })
+  changeType!: FeeChangeType;
+
+  /** Merchant ID for per-merchant overrides; null for global changes */
+  @Column({
+    name: 'merchant_id',
+    type: 'varchar',
+    length: 255,
+    nullable: true,
+    default: null,
+  })
+  merchantId!: string | null;
+
+  @Column({
+    name: 'previous_value',
+    type: 'numeric',
+    precision: 7,
+    scale: 6,
+  })
+  previousValue!: string;
+
+  @Column({
+    name: 'new_value',
+    type: 'numeric',
+    precision: 7,
+    scale: 6,
+  })
+  newValue!: string;
+
+  /** Who performed the action (adminId) */
+  @Column({ name: 'actor_id', type: 'varchar', length: 255 })
+  actorId!: string;
+
+  @Column({
+    name: 'actor_type',
+    type: 'varchar',
+    length: 50,
+    default: 'admin',
+  })
+  actorType!: string;
+
+  @Column({
+    name: 'reason',
+    type: 'text',
+    nullable: true,
+    default: null,
+  })
+  reason!: string | null;
+
+}
+

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -10,6 +10,7 @@ import {
   DOCUMENTED_API_VERSIONS,
 } from './api-version/api-version.policy';
 import { filterOpenApiPathsForVersion } from './api-version/filter-openapi-for-version';
+import { SentryService } from './sentry/sentry.service';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { version } = require('../package.json') as { version: string };
 
@@ -19,6 +20,10 @@ async function bootstrap(): Promise<void> {
     logger: ['error', 'warn', 'log', 'debug', 'verbose'],
   });
   app.useLogger(app.get(WINSTON_MODULE_NEST_PROVIDER));
+
+  // Initialize Sentry before other middleware so it can capture bootstrap errors
+  const sentryService = app.get(SentryService);
+  sentryService.init();
 
   const config = app.get(ConfigService);
   const port = config.get<AppConfig['port']>('app.port')!;
@@ -74,3 +79,4 @@ async function bootstrap(): Promise<void> {
 }
 
 bootstrap();
+

--- a/backend/src/merchants/dto/register-merchant.dto.ts
+++ b/backend/src/merchants/dto/register-merchant.dto.ts
@@ -63,4 +63,14 @@ export class RegisterMerchantDto {
   @IsNumber()
   @Min(0)
   threshold?: number;
+
+  @ApiPropertyOptional({
+    description: 'Custom fee rate override (e.g. 0.015 = 1.5%). Null to use global default.',
+    minimum: 0,
+    maximum: 1,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  customFeeRate?: number;
 }

--- a/backend/src/merchants/dto/update-merchant.dto.ts
+++ b/backend/src/merchants/dto/update-merchant.dto.ts
@@ -62,4 +62,14 @@ export class UpdateMerchantDto {
   @IsNumber()
   @Min(0)
   threshold?: number;
+
+  @ApiPropertyOptional({
+    description: 'Custom fee rate override (e.g. 0.015 = 1.5%). Null to use global default.',
+    minimum: 0,
+    maximum: 1,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  customFeeRate?: number;
 }

--- a/backend/src/merchants/entities/merchant.entity.ts
+++ b/backend/src/merchants/entities/merchant.entity.ts
@@ -62,4 +62,15 @@ export class Merchant extends BaseEntity {
     },
   })
   settlementThresholdUsdc!: number;
+
+  /** Per-merchant custom fee rate override. Null means use global default. */
+  @Column({
+    name: 'custom_fee_rate',
+    type: 'numeric',
+    precision: 7,
+    scale: 6,
+    nullable: true,
+    default: null,
+  })
+  customFeeRate!: string | null;
 }

--- a/backend/src/merchants/merchants-admin.controller.ts
+++ b/backend/src/merchants/merchants-admin.controller.ts
@@ -4,6 +4,7 @@ import {
   Param,
   Patch,
   Req,
+  Body,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -34,5 +35,24 @@ export class MerchantsAdminController {
     }
 
     return this.merchantsService.verifyMerchant(id);
+  }
+
+  @Patch(':id/fee')
+  @ApiOperation({ summary: 'Set custom fee rate for a merchant' })
+  @ApiResponse({ status: 200, type: Merchant })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Admin only' })
+  @ApiResponse({ status: 404, description: 'Merchant not found' })
+  async setMerchantFee(
+    @Param('id') id: string,
+    @Body('customFeeRate') customFeeRate: number | null,
+    @Req() req: Request,
+  ): Promise<Merchant> {
+    const user = (req as Request & { user?: { isAdmin?: boolean } }).user;
+    if (!user?.isAdmin) {
+      throw new ForbiddenException('Admin only');
+    }
+
+    return this.merchantsService.updateMerchantFee(id, customFeeRate);
   }
 }

--- a/backend/src/merchants/merchants.service.ts
+++ b/backend/src/merchants/merchants.service.ts
@@ -33,30 +33,6 @@ export class MerchantsService {
       throw new ConflictException('Merchant profile already exists');
     }
 
-    const merchant = await this.dataSource.transaction(
-      async (trx: EntityManager) => {
-        const merchantEntity = trx.getRepository(Merchant).create({
-          userId: user.id,
-          businessName: dto.businessName,
-          businessType: dto.businessType,
-          logoKey: dto.logoKey ?? null,
-          description: dto.description ?? null,
-          settlementCurrency: dto.settlementCurrency,
-          autoSettleEnabled: dto.autoSettleEnabled ?? true,
-          settlementThresholdUsdc: dto.threshold ?? 10,
-        });
-
-        const savedMerchant = await trx
-          .getRepository(Merchant)
-          .save(merchantEntity);
-
-        user.isMerchant = true;
-        user.role = UserRole.MERCHANT;
-        await trx.getRepository(User).save(user);
-
-        return savedMerchant;
-      },
-    );
     const merchant = await this.dataSource.transaction(async (trx: EntityManager) => {
       const merchantEntity = trx.getRepository(Merchant).create({
         userId: user.id,
@@ -67,6 +43,7 @@ export class MerchantsService {
         settlementCurrency: dto.settlementCurrency,
         autoSettleEnabled: dto.autoSettleEnabled ?? true,
         settlementThresholdUsdc: dto.threshold ?? 10,
+        customFeeRate: dto.customFeeRate != null ? String(dto.customFeeRate) : null,
       });
 
       const savedMerchant = await trx.getRepository(Merchant).save(merchantEntity);
@@ -113,6 +90,9 @@ export class MerchantsService {
     }
     if (dto.threshold !== undefined) {
       merchant.settlementThresholdUsdc = dto.threshold;
+    }
+    if (dto.customFeeRate !== undefined) {
+      merchant.customFeeRate = dto.customFeeRate != null ? String(dto.customFeeRate) : null;
     }
 
     return this.merchantRepo.save(merchant);
@@ -167,5 +147,21 @@ export class MerchantsService {
     }
 
     return merchant;
+  }
+
+  async updateMerchantFee(
+    merchantId: string,
+    customFeeRate: number | null,
+  ): Promise<Merchant> {
+    const merchant = await this.merchantRepo.findOne({
+      where: { id: merchantId },
+    });
+    if (!merchant) {
+      throw new NotFoundException('Merchant not found');
+    }
+
+    merchant.customFeeRate =
+      customFeeRate != null ? String(customFeeRate) : null;
+    return this.merchantRepo.save(merchant);
   }
 }

--- a/backend/src/paylink/paylink.module.ts
+++ b/backend/src/paylink/paylink.module.ts
@@ -18,6 +18,7 @@ import {
 } from './paylink.processor';
 import { PayLinkService } from './paylink.service';
 import { PinModule } from '../pin/pin.module';
+import { PrometheusModule } from '../prometheus/prometheus.module';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { PinModule } from '../pin/pin.module';
     WsModule,
     EmailModule,
     NotificationsModule,
+    PrometheusModule,
   ],
   controllers: [PayLinkController],
   providers: [PayLinkService, PayLinkProcessor],

--- a/backend/src/paylink/paylink.service.ts
+++ b/backend/src/paylink/paylink.service.ts
@@ -24,6 +24,7 @@ import { CreatePayLinkDto } from './dto/create-pay-link.dto';
 import { ListPayLinksQueryDto } from './dto/list-pay-links-query.dto';
 import { PayLinkPublicDto } from './dto/pay-link-public.dto';
 import { PayLink, PayLinkStatus } from './entities/pay-link.entity';
+import { MetricsService } from '../prometheus/metrics.service';
 
 const DEFAULT_EXPIRES_HOURS = 72;
 const PAYLINK_TOKEN_SIZE = 10;
@@ -57,6 +58,8 @@ export class PayLinkService {
     private readonly gateway: CheeseGateway,
     private readonly emailService: EmailService,
     private readonly notificationService: NotificationService,
+
+    private readonly metricsService: MetricsService,
   ) {}
 
   async countActiveReceiveLinks(creatorUserId: string): Promise<number> {
@@ -223,6 +226,8 @@ export class PayLinkService {
       },
       creator.id,
     );
+
+    this.metricsService.incrementPaymentCreated('paylink');
 
     return saved;
   }

--- a/backend/src/prometheus/GRAFANA.md
+++ b/backend/src/prometheus/GRAFANA.md
@@ -1,0 +1,139 @@
+# Grafana Dashboard — HTTP Request Latency
+
+This document provides PromQL queries and a Grafana panel configuration for visualizing per-endpoint latency percentiles using the `http_request_duration_ms` histogram exported by the application.
+
+## Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `http_request_duration_ms` | Histogram | `method`, `route`, `status` | Request latency in milliseconds |
+| `http_requests_total` | Counter | `method`, `route`, `status` | Total number of HTTP requests |
+
+## PromQL Queries
+
+### p50 (median) latency per endpoint
+
+```promql
+histogram_quantile(0.50,
+  sum(rate(http_request_duration_ms_bucket{route=~"$route"}[5m])) by (le, route)
+)
+```
+
+### p95 latency per endpoint
+
+```promql
+histogram_quantile(0.95,
+  sum(rate(http_request_duration_ms_bucket{route=~"$route"}[5m])) by (le, route)
+)
+```
+
+### p99 latency per endpoint
+
+```promql
+histogram_quantile(0.99,
+  sum(rate(http_request_duration_ms_bucket{route=~"$route"}[5m])) by (le, route)
+)
+```
+
+### Request rate (RPS) per endpoint
+
+```promql
+sum(rate(http_requests_total{route=~"$route"}[5m])) by (route)
+```
+
+### Error rate per endpoint
+
+```promql
+sum(rate(http_requests_total{status=~"4..|5..",route=~"$route"}[5m])) by (route)
+/
+sum(rate(http_requests_total{route=~"$route"}[5m])) by (route)
+```
+
+## Grafana Panel JSON
+
+You can import the following panel JSON into a Grafana dashboard. It assumes:
+- Data source: Prometheus
+- Variable: `$route` — label_values(http_request_duration_ms, route)
+
+```json
+{
+  "id": null,
+  "title": "HTTP Latency per Endpoint",
+  "type": "timeseries",
+  "targets": [
+    {
+      "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_ms_bucket{route=~\"$route\"}[5m])) by (le, route))",
+      "legendFormat": "p50 {{ route }}",
+      "refId": "A"
+    },
+    {
+      "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_ms_bucket{route=~\"$route\"}[5m])) by (le, route))",
+      "legendFormat": "p95 {{ route }}",
+      "refId": "B"
+    },
+    {
+      "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_ms_bucket{route=~\"$route\"}[5m])) by (le, route))",
+      "legendFormat": "p99 {{ route }}",
+      "refId": "C"
+    }
+  ],
+  "fieldConfig": {
+    "defaults": {
+      "unit": "ms",
+      "custom": {
+        "drawStyle": "line",
+        "lineInterpolation": "linear",
+        "pointSize": 5,
+        "showPoints": "auto"
+      }
+    },
+    "overrides": []
+  },
+  "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+  "options": {
+    "tooltip": { "mode": "multi" },
+    "legend": { "displayMode": "table", "placement": "right" }
+  }
+}
+```
+
+## Additional Panels
+
+### Total Requests Counter
+
+```json
+{
+  "title": "Total Requests",
+  "type": "stat",
+  "targets": [
+    {
+      "expr": "sum(rate(http_requests_total[5m]))",
+      "refId": "A"
+    }
+  ],
+  "fieldConfig": {
+    "defaults": { "unit": "reqps" }
+  }
+}
+```
+
+### Slow Request Rate (>1s)
+
+Use the `_bucket` metric with the `le="+Inf"` and `le="1000"` buckets, or filter by log events `slow_http_request` if log-based metrics are available.
+
+```promql
+(
+  sum(rate(http_request_duration_ms_bucket{le="+Inf",route=~"$route"}[5m])) by (route)
+  -
+  sum(rate(http_request_duration_ms_bucket{le="1000",route=~"$route"}[5m])) by (route)
+)
+/
+sum(rate(http_request_duration_ms_bucket{le="+Inf",route=~"$route"}[5m])) by (route)
+```
+
+## Notes
+
+- Ensure `scrape_interval` in Prometheus is ≤ 15s for accurate rate calculations.
+- The histogram uses millisecond buckets (`[5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000]`), suitable for REST APIs.
+- Use `route` label (e.g., `/api/v1/users/:id`) rather than `originalUrl` to keep cardinality bounded.
+

--- a/backend/src/prometheus/http-metrics.interceptor.spec.ts
+++ b/backend/src/prometheus/http-metrics.interceptor.spec.ts
@@ -1,0 +1,235 @@
+import { CallHandler, ExecutionContext, Logger } from '@nestjs/common';
+import { of, throwError } from 'rxjs';
+import { lastValueFrom } from 'rxjs';
+import { HttpMetricsInterceptor } from './http-metrics.interceptor';
+import { MetricsService } from './metrics.service';
+
+describe('HttpMetricsInterceptor', () => {
+  let interceptor: HttpMetricsInterceptor;
+  let metricsService: jest.Mocked<MetricsService>;
+
+  beforeEach(() => {
+    metricsService = {
+      recordHttpRequest: jest.fn(),
+    } as unknown as jest.Mocked<MetricsService>;
+
+    interceptor = new HttpMetricsInterceptor(metricsService);
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function createContext(
+    req: Record<string, unknown>,
+    res: Record<string, unknown>,
+  ): ExecutionContext {
+    return {
+      switchToHttp: () => ({
+        getRequest: () => req,
+        getResponse: () => res,
+      }),
+    } as unknown as ExecutionContext;
+  }
+
+  it('should record metrics on successful request', async () => {
+    const req = {
+      method: 'GET',
+      originalUrl: '/api/v1/users',
+      route: { path: '/api/v1/users' },
+      correlationId: 'cid-1',
+    };
+    const res = { statusCode: 200 };
+
+    const ctx = createContext(req, res);
+    const next: CallHandler = { handle: () => of({ data: true }) };
+
+    await lastValueFrom(interceptor.intercept(ctx, next));
+
+    expect(metricsService.recordHttpRequest).toHaveBeenCalledTimes(1);
+    expect(metricsService.recordHttpRequest).toHaveBeenCalledWith(
+      'GET',
+      '/api/v1/users',
+      200,
+      expect.any(Number),
+    );
+  });
+
+  it('should record metrics on failed request with HttpException status', async () => {
+    const req = {
+      method: 'POST',
+      originalUrl: '/api/v1/payments',
+      route: { path: '/api/v1/payments' },
+      correlationId: 'cid-2',
+    };
+    const res = { statusCode: 400 };
+
+    const ctx = createContext(req, res);
+    const error = Object.assign(new Error('Bad Request'), { status: 400 });
+    const next: CallHandler = { handle: () => throwError(() => error) };
+
+    await expect(lastValueFrom(interceptor.intercept(ctx, next))).rejects.toThrow('Bad Request');
+
+    expect(metricsService.recordHttpRequest).toHaveBeenCalledTimes(1);
+    expect(metricsService.recordHttpRequest).toHaveBeenCalledWith(
+      'POST',
+      '/api/v1/payments',
+      400,
+      expect.any(Number),
+    );
+  });
+
+  it('should default error status to 500 when no status is present', async () => {
+    const req = {
+      method: 'GET',
+      originalUrl: '/api/v1/health',
+      route: { path: '/api/v1/health' },
+    };
+    const res = { statusCode: 200 };
+
+    const ctx = createContext(req, res);
+    const error = new Error('Internal failure');
+    const next: CallHandler = { handle: () => throwError(() => error) };
+
+    await expect(lastValueFrom(interceptor.intercept(ctx, next))).rejects.toThrow('Internal failure');
+
+    expect(metricsService.recordHttpRequest).toHaveBeenCalledWith(
+      'GET',
+      '/api/v1/health',
+      500,
+      expect.any(Number),
+    );
+  });
+
+  it('should fallback to originalUrl when route.path is missing', async () => {
+    const req = {
+      method: 'GET',
+      originalUrl: '/api/v1/custom-route',
+    };
+    const res = { statusCode: 200 };
+
+    const ctx = createContext(req, res);
+    const next: CallHandler = { handle: () => of('ok') };
+
+    await lastValueFrom(interceptor.intercept(ctx, next));
+
+    expect(metricsService.recordHttpRequest).toHaveBeenCalledWith(
+      'GET',
+      '/api/v1/custom-route',
+      200,
+      expect.any(Number),
+    );
+  });
+
+  it('should fallback to unknown when no route or url is present', async () => {
+    const req = { method: 'GET' };
+    const res = { statusCode: 200 };
+
+    const ctx = createContext(req, res);
+    const next: CallHandler = { handle: () => of('ok') };
+
+    await lastValueFrom(interceptor.intercept(ctx, next));
+
+    expect(metricsService.recordHttpRequest).toHaveBeenCalledWith(
+      'GET',
+      'unknown',
+      200,
+      expect.any(Number),
+    );
+  });
+
+  it('should log WARN for slow requests >1000ms on success', async () => {
+    const loggerWarn = jest.spyOn(Logger.prototype, 'warn');
+
+    const req = {
+      method: 'GET',
+      originalUrl: '/api/v1/slow',
+      route: { path: '/api/v1/slow' },
+      correlationId: 'cid-slow',
+    };
+    const res = { statusCode: 200 };
+
+    const ctx = createContext(req, res);
+    const next: CallHandler = {
+      handle: () =>
+        of('ok').pipe(
+          // simulate delay
+        ),
+    };
+
+    // Simulate slow execution by mocking Date.now
+    let callCount = 0;
+    const originalNow = Date.now;
+    jest.spyOn(Date, 'now').mockImplementation(() => {
+      callCount++;
+      return callCount === 1 ? 0 : 1500;
+    });
+
+    await lastValueFrom(interceptor.intercept(ctx, next));
+
+    expect(loggerWarn).toHaveBeenCalledWith('slow request detected', {
+      event: 'slow_http_request',
+      method: 'GET',
+      route: '/api/v1/slow',
+      status: 200,
+      durationMs: 1500,
+      correlationId: 'cid-slow',
+    });
+
+    jest.spyOn(Date, 'now').mockRestore();
+  });
+
+  it('should log WARN for slow requests >1000ms on error', async () => {
+    const loggerWarn = jest.spyOn(Logger.prototype, 'warn');
+
+    const req = {
+      method: 'POST',
+      originalUrl: '/api/v1/slow-error',
+      route: { path: '/api/v1/slow-error' },
+    };
+    const res = { statusCode: 500 };
+
+    const ctx = createContext(req, res);
+    const error = Object.assign(new Error('Timeout'), { status: 504 });
+    const next: CallHandler = { handle: () => throwError(() => error) };
+
+    let callCount = 0;
+    jest.spyOn(Date, 'now').mockImplementation(() => {
+      callCount++;
+      return callCount === 1 ? 0 : 2500;
+    });
+
+    await expect(lastValueFrom(interceptor.intercept(ctx, next))).rejects.toThrow('Timeout');
+
+    expect(loggerWarn).toHaveBeenCalledWith('slow request detected', {
+      event: 'slow_http_request',
+      method: 'POST',
+      route: '/api/v1/slow-error',
+      status: 504,
+      durationMs: 2500,
+      correlationId: null,
+    });
+
+    jest.spyOn(Date, 'now').mockRestore();
+  });
+
+  it('should not log WARN for fast requests', async () => {
+    const loggerWarn = jest.spyOn(Logger.prototype, 'warn');
+
+    const req = {
+      method: 'GET',
+      originalUrl: '/api/v1/fast',
+      route: { path: '/api/v1/fast' },
+    };
+    const res = { statusCode: 200 };
+
+    const ctx = createContext(req, res);
+    const next: CallHandler = { handle: () => of('ok') };
+
+    await lastValueFrom(interceptor.intercept(ctx, next));
+
+    expect(loggerWarn).not.toHaveBeenCalled();
+  });
+});
+

--- a/backend/src/prometheus/http-metrics.interceptor.ts
+++ b/backend/src/prometheus/http-metrics.interceptor.ts
@@ -1,0 +1,96 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable, catchError, tap, throwError } from 'rxjs';
+import { MetricsService } from './metrics.service';
+
+interface ExpressRequestWithRoute {
+  method?: string;
+  originalUrl?: string;
+  url?: string;
+  route?: { path?: string };
+  correlationId?: string;
+}
+
+interface ExpressResponseLike {
+  statusCode?: number;
+}
+
+function resolveRoute(req: ExpressRequestWithRoute): string {
+  const routePath = req.route?.path;
+  if (routePath && typeof routePath === 'string') {
+    return routePath;
+  }
+  return req.originalUrl ?? req.url ?? 'unknown';
+}
+
+function resolveStatusFromError(err: unknown): number {
+  if (err && typeof err === 'object') {
+    const e = err as Record<string, unknown>;
+    if (typeof e.status === 'number') return e.status;
+    if (typeof e.statusCode === 'number') return e.statusCode;
+  }
+  return 500;
+}
+
+const SLOW_REQUEST_THRESHOLD_MS = 1000;
+
+@Injectable()
+export class HttpMetricsInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(HttpMetricsInterceptor.name);
+
+  constructor(private readonly metricsService: MetricsService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const http = context.switchToHttp();
+    const req = http.getRequest<ExpressRequestWithRoute>();
+    const res = http.getResponse<ExpressResponseLike>();
+
+    const start = Date.now();
+    const method = req?.method ?? 'UNKNOWN';
+    const route = resolveRoute(req);
+    const correlationId = req?.correlationId;
+
+    return next.handle().pipe(
+      tap(() => {
+        const durationMs = Date.now() - start;
+        const status = res?.statusCode ?? 0;
+        this.metricsService.recordHttpRequest(method, route, status, durationMs);
+
+        if (durationMs > SLOW_REQUEST_THRESHOLD_MS) {
+          this.logger.warn('slow request detected', {
+            event: 'slow_http_request',
+            method,
+            route,
+            status,
+            durationMs,
+            correlationId: correlationId ?? null,
+          });
+        }
+      }),
+      catchError((err: unknown) => {
+        const durationMs = Date.now() - start;
+        const status = resolveStatusFromError(err);
+        this.metricsService.recordHttpRequest(method, route, status, durationMs);
+
+        if (durationMs > SLOW_REQUEST_THRESHOLD_MS) {
+          this.logger.warn('slow request detected', {
+            event: 'slow_http_request',
+            method,
+            route,
+            status,
+            durationMs,
+            correlationId: correlationId ?? null,
+          });
+        }
+
+        return throwError(() => err);
+      }),
+    );
+  }
+}
+

--- a/backend/src/prometheus/metrics.guard.spec.ts
+++ b/backend/src/prometheus/metrics.guard.spec.ts
@@ -1,0 +1,85 @@
+import { ExecutionContext } from '@nestjs/common';
+import { MetricsGuard } from './metrics.guard';
+
+describe('MetricsGuard', () => {
+  let guard: MetricsGuard;
+
+  beforeEach(() => {
+    guard = new MetricsGuard();
+  });
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  it('should allow requests from 127.0.0.1', () => {
+    const context = createMockContext('127.0.0.1');
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('should allow requests from ::1', () => {
+    const context = createMockContext('::1');
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('should allow requests from 10.0.0.5', () => {
+    const context = createMockContext('10.0.0.5');
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('should allow requests from 172.16.5.1', () => {
+    const context = createMockContext('172.16.5.1');
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('should allow requests from 192.168.1.100', () => {
+    const context = createMockContext('192.168.1.100');
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('should deny requests from public IP 8.8.8.8', () => {
+    const context = createMockContext('8.8.8.8');
+    expect(guard.canActivate(context)).toBe(false);
+  });
+
+  it('should deny requests from public IP 203.0.113.1', () => {
+    const context = createMockContext('203.0.113.1');
+    expect(guard.canActivate(context)).toBe(false);
+  });
+
+  it('should deny requests with no IP', () => {
+    const context = createMockContext('');
+    expect(guard.canActivate(context)).toBe(false);
+  });
+
+  it('should allow x-forwarded-for internal IP', () => {
+    const context = createMockContext('203.0.113.1', '192.168.1.50');
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('should deny x-forwarded-for public IP', () => {
+    const context = createMockContext('127.0.0.1', '8.8.8.8');
+    expect(guard.canActivate(context)).toBe(false);
+  });
+});
+
+function createMockContext(
+  remoteAddress: string,
+  forwardedFor?: string,
+): ExecutionContext {
+  const headers: Record<string, string> = {};
+  if (forwardedFor) {
+    headers['x-forwarded-for'] = forwardedFor;
+  }
+
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({
+        ip: remoteAddress,
+        headers,
+        connection: { remoteAddress },
+      }),
+    }),
+  } as unknown as ExecutionContext;
+}
+

--- a/backend/src/prometheus/metrics.guard.ts
+++ b/backend/src/prometheus/metrics.guard.ts
@@ -1,0 +1,96 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
+import type { Request } from 'express';
+
+@Injectable()
+export class MetricsGuard implements CanActivate {
+  private readonly logger = new Logger(MetricsGuard.name);
+  private readonly allowedIps: Set<string>;
+  private readonly allowedNetworks: { start: bigint; end: bigint }[];
+
+  constructor() {
+    const raw =
+      process.env['METRICS_ALLOWLIST_IPS'] ??
+      '127.0.0.1,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16';
+
+    this.allowedIps = new Set();
+    this.allowedNetworks = [];
+
+    for (const entry of raw.split(',').map((s) => s.trim())) {
+      if (!entry) continue;
+      if (entry.includes('/')) {
+        const network = this.parseCidr(entry);
+        if (network) this.allowedNetworks.push(network);
+      } else {
+        this.allowedIps.add(entry);
+      }
+    }
+  }
+
+  canActivate(context: ExecutionContext): boolean {
+    const req = context.switchToHttp().getRequest<Request>();
+    const ip = this.extractClientIp(req);
+
+    if (this.isAllowed(ip)) {
+      return true;
+    }
+
+    this.logger.warn(`Metrics access denied for IP: ${ip}`);
+    return false;
+  }
+
+  private extractClientIp(req: Request): string {
+    const forwarded = req.headers['x-forwarded-for'];
+    if (typeof forwarded === 'string' && forwarded.length > 0) {
+      return forwarded.split(',')[0].trim();
+    }
+    return req.socket?.remoteAddress ?? req.ip ?? 'unknown';
+  }
+
+  private isAllowed(ip: string): boolean {
+    if (this.allowedIps.has(ip)) return true;
+
+    const ipNum = this.ipToBigInt(ip);
+    if (ipNum === null) return false;
+
+    for (const net of this.allowedNetworks) {
+      if (ipNum >= net.start && ipNum <= net.end) return true;
+    }
+
+    return false;
+  }
+
+  private parseCidr(
+    cidr: string,
+  ): { start: bigint; end: bigint } | null {
+    const [ipPart, prefixPart] = cidr.split('/');
+    const prefix = parseInt(prefixPart ?? '', 10);
+    if (!Number.isFinite(prefix) || prefix < 0 || prefix > 32) return null;
+
+    const ipNum = this.ipToBigInt(ipPart ?? '');
+    if (ipNum === null) return null;
+
+    const mask = prefix === 0 ? 0n : (0xffffffffn << (32n - BigInt(prefix))) & 0xffffffffn;
+    const start = ipNum & mask;
+    const end = start | (~mask & 0xffffffffn);
+    return { start, end };
+  }
+
+  private ipToBigInt(ip: string): bigint | null {
+    const parts = ip.split('.');
+    if (parts.length !== 4) return null;
+
+    let result = 0n;
+    for (const part of parts) {
+      const num = parseInt(part, 10);
+      if (!Number.isFinite(num) || num < 0 || num > 255) return null;
+      result = (result << 8n) | BigInt(num);
+    }
+    return result;
+  }
+}
+

--- a/backend/src/prometheus/metrics.service.spec.ts
+++ b/backend/src/prometheus/metrics.service.spec.ts
@@ -1,0 +1,67 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MetricsService } from './metrics.service';
+
+describe('MetricsService', () => {
+  let service: MetricsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MetricsService],
+    }).compile();
+
+    service = module.get<MetricsService>(MetricsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('incrementPaymentCreated', () => {
+    it('should increment payment_created_total counter', () => {
+      const spy = jest.spyOn(service.paymentCreatedTotal, 'inc');
+      service.incrementPaymentCreated('deposit');
+      expect(spy).toHaveBeenCalledWith({ type: 'deposit' });
+    });
+
+    it('should support paylink type', () => {
+      const spy = jest.spyOn(service.paymentCreatedTotal, 'inc');
+      service.incrementPaymentCreated('paylink');
+      expect(spy).toHaveBeenCalledWith({ type: 'paylink' });
+    });
+
+    it('should support withdrawal type', () => {
+      const spy = jest.spyOn(service.paymentCreatedTotal, 'inc');
+      service.incrementPaymentCreated('withdrawal');
+      expect(spy).toHaveBeenCalledWith({ type: 'withdrawal' });
+    });
+  });
+
+  describe('incrementPaymentSettled', () => {
+    it('should increment payment_settled_total counter', () => {
+      const spy = jest.spyOn(service.paymentSettledTotal, 'inc');
+      service.incrementPaymentSettled('withdrawal');
+      expect(spy).toHaveBeenCalledWith({ type: 'withdrawal' });
+    });
+  });
+
+  describe('incrementSettlementFailed', () => {
+    it('should increment settlement_failed_total counter', () => {
+      const spy = jest.spyOn(service.settlementFailedTotal, 'inc');
+      service.incrementSettlementFailed('withdrawal');
+      expect(spy).toHaveBeenCalledWith({ type: 'withdrawal' });
+    });
+  });
+
+  describe('observeSettlementDuration', () => {
+    it('should observe settlement_duration_seconds histogram', () => {
+      const spy = jest.spyOn(service.settlementDurationSeconds, 'observe');
+      service.observeSettlementDuration('withdrawal', 1.5);
+      expect(spy).toHaveBeenCalledWith({ type: 'withdrawal' }, 1.5);
+    });
+  });
+});
+

--- a/backend/src/prometheus/metrics.service.spec.ts
+++ b/backend/src/prometheus/metrics.service.spec.ts
@@ -63,5 +63,51 @@ describe('MetricsService', () => {
       expect(spy).toHaveBeenCalledWith({ type: 'withdrawal' }, 1.5);
     });
   });
+
+  describe('recordHttpRequest', () => {
+    it('should increment http_requests_total counter with correct labels', () => {
+      const spy = jest.spyOn(service.httpRequestsTotal, 'inc');
+      service.recordHttpRequest('GET', '/api/v1/users', 200, 150);
+      expect(spy).toHaveBeenCalledWith({
+        method: 'GET',
+        route: '/api/v1/users',
+        status: '200',
+      });
+    });
+
+    it('should observe http_request_duration_ms histogram with correct labels', () => {
+      const spy = jest.spyOn(service.httpRequestDurationMs, 'observe');
+      service.recordHttpRequest('POST', '/api/v1/payments', 201, 350);
+      expect(spy).toHaveBeenCalledWith(
+        { method: 'POST', route: '/api/v1/payments', status: '201' },
+        350,
+      );
+    });
+
+    it('should handle error status codes', () => {
+      const counterSpy = jest.spyOn(service.httpRequestsTotal, 'inc');
+      const histogramSpy = jest.spyOn(service.httpRequestDurationMs, 'observe');
+
+      service.recordHttpRequest('DELETE', '/api/v1/items/:id', 404, 80);
+
+      expect(counterSpy).toHaveBeenCalledWith({
+        method: 'DELETE',
+        route: '/api/v1/items/:id',
+        status: '404',
+      });
+      expect(histogramSpy).toHaveBeenCalledWith(
+        { method: 'DELETE', route: '/api/v1/items/:id', status: '404' },
+        80,
+      );
+    });
+
+    it('should convert numeric status to string', () => {
+      const counterSpy = jest.spyOn(service.httpRequestsTotal, 'inc');
+      service.recordHttpRequest('PATCH', '/api/v1/config', 500, 1200);
+      expect(counterSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ status: '500' }),
+      );
+    });
+  });
 });
 

--- a/backend/src/prometheus/metrics.service.ts
+++ b/backend/src/prometheus/metrics.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { Counter, Histogram } from 'prom-client';
+
+@Injectable()
+export class MetricsService {
+  readonly paymentCreatedTotal: Counter<string>;
+  readonly paymentSettledTotal: Counter<string>;
+  readonly settlementFailedTotal: Counter<string>;
+  readonly settlementDurationSeconds: Histogram<string>;
+
+  constructor() {
+    this.paymentCreatedTotal = new Counter({
+      name: 'payment_created_total',
+      help: 'Total number of payments created',
+      labelNames: ['type'],
+    });
+
+    this.paymentSettledTotal = new Counter({
+      name: 'payment_settled_total',
+      help: 'Total number of payments successfully settled',
+      labelNames: ['type'],
+    });
+
+    this.settlementFailedTotal = new Counter({
+      name: 'settlement_failed_total',
+      help: 'Total number of settlement failures',
+      labelNames: ['type'],
+    });
+
+    this.settlementDurationSeconds = new Histogram({
+      name: 'settlement_duration_seconds',
+      help: 'Time spent processing settlements in seconds',
+      labelNames: ['type'],
+      buckets: [0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10, 30],
+    });
+  }
+
+  incrementPaymentCreated(type: string): void {
+    this.paymentCreatedTotal.inc({ type });
+  }
+
+  incrementPaymentSettled(type: string): void {
+    this.paymentSettledTotal.inc({ type });
+  }
+
+  incrementSettlementFailed(type: string): void {
+    this.settlementFailedTotal.inc({ type });
+  }
+
+  observeSettlementDuration(type: string, durationSeconds: number): void {
+    this.settlementDurationSeconds.observe({ type }, durationSeconds);
+  }
+}
+

--- a/backend/src/prometheus/metrics.service.ts
+++ b/backend/src/prometheus/metrics.service.ts
@@ -8,6 +8,9 @@ export class MetricsService {
   readonly settlementFailedTotal: Counter<string>;
   readonly settlementDurationSeconds: Histogram<string>;
 
+  readonly httpRequestsTotal: Counter<string>;
+  readonly httpRequestDurationMs: Histogram<string>;
+
   constructor() {
     this.paymentCreatedTotal = new Counter({
       name: 'payment_created_total',
@@ -33,6 +36,19 @@ export class MetricsService {
       labelNames: ['type'],
       buckets: [0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10, 30],
     });
+
+    this.httpRequestsTotal = new Counter({
+      name: 'http_requests_total',
+      help: 'Total number of HTTP requests',
+      labelNames: ['method', 'route', 'status'],
+    });
+
+    this.httpRequestDurationMs = new Histogram({
+      name: 'http_request_duration_ms',
+      help: 'HTTP request latency in milliseconds',
+      labelNames: ['method', 'route', 'status'],
+      buckets: [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000],
+    });
   }
 
   incrementPaymentCreated(type: string): void {
@@ -49,6 +65,17 @@ export class MetricsService {
 
   observeSettlementDuration(type: string, durationSeconds: number): void {
     this.settlementDurationSeconds.observe({ type }, durationSeconds);
+  }
+
+  recordHttpRequest(
+    method: string,
+    route: string,
+    status: number | string,
+    durationMs: number,
+  ): void {
+    const labels = { method, route, status: String(status) };
+    this.httpRequestsTotal.inc(labels);
+    this.httpRequestDurationMs.observe(labels, durationMs);
   }
 }
 

--- a/backend/src/prometheus/prometheus.controller.spec.ts
+++ b/backend/src/prometheus/prometheus.controller.spec.ts
@@ -1,0 +1,30 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrometheusMetricsController } from './prometheus.controller';
+import { register } from 'prom-client';
+
+describe('PrometheusMetricsController', () => {
+  let controller: PrometheusMetricsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PrometheusMetricsController],
+    }).compile();
+
+    controller = module.get<PrometheusMetricsController>(PrometheusMetricsController);
+  });
+
+  afterEach(() => {
+    register.clear();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should return Prometheus-formatted metrics', async () => {
+    const result = await controller.index();
+    expect(typeof result).toBe('string');
+    expect(result).toContain('# HELP');
+  });
+});
+

--- a/backend/src/prometheus/prometheus.controller.ts
+++ b/backend/src/prometheus/prometheus.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, UseGuards, VERSION_NEUTRAL } from '@nestjs/common';
+import { ApiExcludeEndpoint } from '@nestjs/swagger';
+import { SkipResponseWrap } from '../common/decorators/skip-response-wrap.decorator';
+import { MetricsGuard } from './metrics.guard';
+import { register } from 'prom-client';
+
+@Controller({ path: 'metrics', version: VERSION_NEUTRAL })
+@UseGuards(MetricsGuard)
+export class PrometheusMetricsController {
+  @Get()
+  @SkipResponseWrap()
+  @ApiExcludeEndpoint()
+  async index(): Promise<string> {
+    return register.metrics();
+  }
+}
+

--- a/backend/src/prometheus/prometheus.module.ts
+++ b/backend/src/prometheus/prometheus.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { PrometheusModule as WillsotoPrometheusModule } from '@willsoto/nestjs-prometheus';
+import { MetricsService } from './metrics.service';
+import { PrometheusMetricsController } from './prometheus.controller';
+
+@Module({
+  imports: [
+    WillsotoPrometheusModule.register({
+      defaultMetrics: {
+        enabled: true,
+      },
+    }),
+  ],
+  controllers: [PrometheusMetricsController],
+  providers: [MetricsService],
+  exports: [MetricsService],
+})
+export class PrometheusModule {}
+

--- a/backend/src/rates/rates.module.ts
+++ b/backend/src/rates/rates.module.ts
@@ -1,12 +1,20 @@
 import { Module } from '@nestjs/common';
+import { BullModule } from '@nestjs/bull';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CacheModule } from '../cache/cache.module';
+import { CronModule } from '../cron/cron.module';
 import { RateSnapshot } from './entities/rate-snapshot.entity';
 import { RatesService } from './rates.service';
+import { RatesProcessor } from './rates.processor';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([RateSnapshot]), CacheModule],
-  providers: [RatesService],
+  imports: [
+    TypeOrmModule.forFeature([RateSnapshot]),
+    CacheModule,
+    BullModule.registerQueue({ name: 'rates' }),
+    CronModule,
+  ],
+  providers: [RatesService, RatesProcessor],
   exports: [RatesService],
 })
 export class RatesModule {}

--- a/backend/src/rates/rates.processor.ts
+++ b/backend/src/rates/rates.processor.ts
@@ -2,6 +2,7 @@ import { Processor, Process, InjectQueue } from '@nestjs/bull';
 import { Logger, OnModuleInit } from '@nestjs/common';
 import { Job, Queue } from 'bull';
 import { RatesService } from './rates.service';
+import { CronJobService } from '../cron/cron-job.service';
 
 export const RATES_QUEUE = 'rates';
 export const FETCH_RATE_JOB = 'fetch-rate';
@@ -13,6 +14,7 @@ export class RatesProcessor implements OnModuleInit {
   constructor(
     private readonly ratesService: RatesService,
     @InjectQueue(RATES_QUEUE) private readonly ratesQueue: Queue,
+    private readonly cronJobService: CronJobService,
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -29,11 +31,14 @@ export class RatesProcessor implements OnModuleInit {
 
   @Process(FETCH_RATE_JOB)
   async handleFetchRate(_job: Job): Promise<void> {
-    try {
-      await this.ratesService.fetchAndCache();
-    } catch (err) {
-      // Log WARN only — do NOT evict Redis so last known rate stays alive
-      this.logger.warn(`fetch-rate failed: ${(err as Error).message}`);
-    }
+    await this.cronJobService.run('fetch-exchange-rate', async () => {
+      try {
+        await this.ratesService.fetchAndCache();
+      } catch (err) {
+        // Log WARN only — do NOT evict Redis so last known rate stays alive
+        this.logger.warn(`fetch-rate failed: ${(err as Error).message}`);
+      }
+    });
   }
 }
+

--- a/backend/src/sentry/sentry.service.spec.ts
+++ b/backend/src/sentry/sentry.service.spec.ts
@@ -1,0 +1,69 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { SentryService } from './sentry.service';
+
+describe('SentryService', () => {
+  let service: SentryService;
+  let configService: jest.Mocked<ConfigService>;
+
+  beforeEach(async () => {
+    configService = {
+      get: jest.fn(),
+    } as unknown as jest.Mocked<ConfigService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SentryService,
+        { provide: ConfigService, useValue: configService },
+      ],
+    }).compile();
+
+    service = module.get<SentryService>(SentryService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('init', () => {
+    it('should not initialize when SENTRY_DSN is not set', () => {
+      configService.get.mockReturnValue({
+        dsn: '',
+        tracesSampleRate: 0.1,
+        profilesSampleRate: 0.05,
+        environment: 'test',
+        enabled: false,
+      });
+
+      service.init();
+      expect(service.isInitialized()).toBe(false);
+    });
+
+    it('should not initialize in test environment', () => {
+      configService.get.mockReturnValue({
+        dsn: 'https://test@example.com/1',
+        tracesSampleRate: 1.0,
+        profilesSampleRate: 1.0,
+        environment: 'test',
+        enabled: false,
+      });
+
+      service.init();
+      expect(service.isInitialized()).toBe(false);
+    });
+
+    it('should initialize when DSN is set and not in test', () => {
+      configService.get.mockReturnValue({
+        dsn: 'https://test@example.com/1',
+        tracesSampleRate: 0.1,
+        profilesSampleRate: 0.05,
+        environment: 'production',
+        enabled: true,
+      });
+
+      service.init();
+      expect(service.isInitialized()).toBe(true);
+    });
+  });
+});
+

--- a/backend/src/sentry/sentry.service.ts
+++ b/backend/src/sentry/sentry.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as Sentry from '@sentry/nestjs';
+import type { SentryConfig } from '../config/sentry.config';
+
+@Injectable()
+export class SentryService {
+  private readonly logger = new Logger(SentryService.name);
+  private initialized = false;
+
+  constructor(private readonly configService: ConfigService) {}
+
+  init(): void {
+    const cfg = this.configService.get<SentryConfig>('sentry');
+    if (!cfg?.enabled || !cfg.dsn) {
+      this.logger.log('Sentry is disabled (no DSN or test environment)');
+      return;
+    }
+
+    Sentry.init({
+      dsn: cfg.dsn,
+      environment: cfg.environment,
+      tracesSampleRate: cfg.tracesSampleRate,
+      profilesSampleRate: cfg.profilesSampleRate,
+      integrations: [
+        Sentry.httpIntegration(),
+      ],
+      beforeSend: (event: Sentry.ErrorEvent) => {
+        // Sanitize sensitive fields from event
+        if (event.request?.headers) {
+          delete (event.request.headers as Record<string, unknown>)['authorization'];
+          delete (event.request.headers as Record<string, unknown>)['cookie'];
+        }
+        return event;
+      },
+    });
+
+    this.initialized = true;
+    this.logger.log(`Sentry initialized (env=${cfg.environment}, traces=${cfg.tracesSampleRate})`);
+  }
+
+  isInitialized(): boolean {
+    return this.initialized;
+  }
+}
+

--- a/backend/src/withdrawals/processors/withdrawal.processor.ts
+++ b/backend/src/withdrawals/processors/withdrawal.processor.ts
@@ -12,6 +12,7 @@ import { Withdrawal } from '../entities/withdrawal.entity';
 import { SorobanService } from '../../soroban/soroban.service';
 import { Transaction, TransactionType, TransactionStatus } from '../../transactions/entities/transaction.entity';
 import { NotificationsService } from '../../notifications/notifications.service';
+import { MetricsService } from '../../prometheus/metrics.service';
 
 export interface ProcessWithdrawalJobData {
   withdrawalId: string;
@@ -29,6 +30,8 @@ export class WithdrawalProcessor {
     private readonly transactionRepo: Repository<Transaction>,
 
     private readonly notificationsService: NotificationsService,
+
+    private readonly metricsService: MetricsService,
   ) {}
 
   @Process(PROCESS_WITHDRAWAL_JOB)
@@ -36,6 +39,7 @@ export class WithdrawalProcessor {
     const { withdrawalId } = job.data;
     this.logger.log(`Processing withdrawal job for ${withdrawalId}`);
 
+    const start = Date.now();
     const withdrawal = await this.withdrawalsService.markProcessing(withdrawalId);
 
     try {
@@ -63,6 +67,10 @@ export class WithdrawalProcessor {
 
       await this.notificationsService.notifyWithdrawalConfirmed(confirmed);
 
+      const duration = (Date.now() - start) / 1000;
+      this.metricsService.observeSettlementDuration('withdrawal', duration);
+      this.metricsService.incrementPaymentSettled('withdrawal');
+
       this.logger.log(`Withdrawal ${withdrawalId} confirmed. txHash=${txHash}`);
     } catch (error: unknown) {
       const reason = error instanceof Error ? error.message : String(error);
@@ -70,6 +78,10 @@ export class WithdrawalProcessor {
 
       await this.withdrawalsService.markFailed(withdrawalId, reason);
       await this.notificationsService.notifyWithdrawalFailed(withdrawal, reason);
+
+      const duration = (Date.now() - start) / 1000;
+      this.metricsService.observeSettlementDuration('withdrawal', duration);
+      this.metricsService.incrementSettlementFailed('withdrawal');
 
       throw error;
     }

--- a/backend/src/withdrawals/withdrawals.module.ts
+++ b/backend/src/withdrawals/withdrawals.module.ts
@@ -9,6 +9,7 @@ import { WithdrawalsController } from './withdrawals.controller';
 import { WithdrawalProcessor } from './processors/withdrawal.processor';
 import { SorobanModule } from '../soroban/soroban.module';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { PrometheusModule } from '../prometheus/prometheus.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
     BullModule.registerQueue({ name: WITHDRAWAL_QUEUE }),
     SorobanModule,
     NotificationsModule,
+    PrometheusModule,
   ],
   controllers: [WithdrawalsController],
   providers: [WithdrawalsService, WithdrawalProcessor],

--- a/backend/src/withdrawals/withdrawals.service.ts
+++ b/backend/src/withdrawals/withdrawals.service.ts
@@ -12,6 +12,7 @@ import { Withdrawal, WithdrawalStatus } from './entities/withdrawal.entity';
 import { CreateWithdrawalDto } from './dto/create-withdrawal.dto';
 import { WithdrawalQueryDto } from './dto/withdrawal-query.dto';
 import { FeeConfig, FeeType } from '../fee-config/entities/fee-config.entity';
+import { MetricsService } from '../prometheus/metrics.service';
 
 export const WITHDRAWAL_QUEUE = 'process-withdrawal';
 export const PROCESS_WITHDRAWAL_JOB = 'process-withdrawal';
@@ -29,6 +30,8 @@ export class WithdrawalsService {
 
     @InjectQueue(WITHDRAWAL_QUEUE)
     private readonly withdrawalQueue: Queue,
+
+    private readonly metricsService: MetricsService,
   ) {}
 
   async create(userId: string, dto: CreateWithdrawalDto): Promise<Withdrawal> {
@@ -65,6 +68,8 @@ export class WithdrawalsService {
       `Withdrawal ${saved.id} created for user ${userId}: ${dto.amount} USDC → net ${netAmount} USDC`,
     );
 
+    this.metricsService.incrementPaymentCreated('withdrawal');
+
     return saved;
   }
 
@@ -92,7 +97,7 @@ export class WithdrawalsService {
 
   async computeFee(grossAmount: string): Promise<{ fee: string; netAmount: string }> {
     const config = await this.feeConfigRepo.findOne({
-      where{ feeType: FeeType.WITHDRAWAL, isActive: true },
+      where: { feeType: FeeType.WITHDRAWAL, isActive: true },
     });
 
     const gross = parseFloat(grossAmount);

--- a/backend/test/prometheus.e2e-spec.ts
+++ b/backend/test/prometheus.e2e-spec.ts
@@ -1,0 +1,61 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { PrometheusModule } from '../src/prometheus/prometheus.module';
+import { MetricsService } from '../src/prometheus/metrics.service';
+import { register } from 'prom-client';
+
+describe('Prometheus /metrics (e2e)', () => {
+  let app: INestApplication<App>;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [PrometheusModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    register.clear();
+  });
+
+  it('GET /metrics should return 200 and Prometheus text format from internal IP', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/metrics')
+      .set('X-Forwarded-For', '127.0.0.1')
+      .expect(200);
+
+    expect(res.text).toContain('# HELP');
+    expect(res.headers['content-type']).toMatch(/text\/plain/);
+  });
+
+  it('GET /metrics should return 403 from public IP', async () => {
+    await request(app.getHttpServer())
+      .get('/metrics')
+      .set('X-Forwarded-For', '8.8.8.8')
+      .expect(403);
+  });
+
+  it('custom counters should be present in metrics output', async () => {
+    const metricsService = app.get(MetricsService);
+    metricsService.incrementPaymentCreated('deposit');
+    metricsService.incrementPaymentSettled('withdrawal');
+    metricsService.incrementSettlementFailed('withdrawal');
+    metricsService.observeSettlementDuration('withdrawal', 0.5);
+
+    const res = await request(app.getHttpServer())
+      .get('/metrics')
+      .set('X-Forwarded-For', '127.0.0.1')
+      .expect(200);
+
+    expect(res.text).toContain('payment_created_total');
+    expect(res.text).toContain('payment_settled_total');
+    expect(res.text).toContain('settlement_failed_total');
+    expect(res.text).toContain('settlement_duration_seconds');
+  });
+});
+

--- a/backend/test/prometheus.e2e-spec.ts
+++ b/backend/test/prometheus.e2e-spec.ts
@@ -57,5 +57,35 @@ describe('Prometheus /metrics (e2e)', () => {
     expect(res.text).toContain('settlement_failed_total');
     expect(res.text).toContain('settlement_duration_seconds');
   });
+
+  it('http_requests_total should be present and incremented after recordHttpRequest', async () => {
+    const metricsService = app.get(MetricsService);
+    metricsService.recordHttpRequest('GET', '/api/v1/users', 200, 120);
+
+    const res = await request(app.getHttpServer())
+      .get('/metrics')
+      .set('X-Forwarded-For', '127.0.0.1')
+      .expect(200);
+
+    expect(res.text).toContain('http_requests_total');
+    expect(res.text).toContain('method="GET"');
+    expect(res.text).toContain('route="/api/v1/users"');
+    expect(res.text).toContain('status="200"');
+  });
+
+  it('http_request_duration_ms should be present and contain observed buckets', async () => {
+    const metricsService = app.get(MetricsService);
+    metricsService.recordHttpRequest('POST', '/api/v1/payments', 201, 350);
+
+    const res = await request(app.getHttpServer())
+      .get('/metrics')
+      .set('X-Forwarded-For', '127.0.0.1')
+      .expect(200);
+
+    expect(res.text).toContain('http_request_duration_ms');
+    expect(res.text).toContain('method="POST"');
+    expect(res.text).toContain('route="/api/v1/payments"');
+    expect(res.text).toContain('status="201"');
+  });
 });
 


### PR DESCRIPTION
Closes #790

---

Add http_request_duration_ms histogram and http_requests_total counter with per-endpoint labels, global HttpMetricsInterceptor, slow-request WARN logging, tests, and Grafana docs.