### PR TITLE
feat(analytics): add compareWith=previous for period-over-period comparison

### DIFF
--- a/backend/src/analytics/analytics.controller.ts
+++ b/backend/src/analytics/analytics.controller.ts
@@ -13,14 +13,20 @@ export class AnalyticsController {
   @Get('volume')
   @ApiOperation({ summary: 'Get payment volume aggregation' })
   @ApiQuery({ name: 'period', enum: ['daily', 'monthly'], required: false })
-  async getVolume(@Request() req, @Query('period') period: 'daily' | 'monthly' = 'daily') {
-    return this.analyticsService.getVolume(req.user.merchantId, period);
+  @ApiQuery({ name: 'compareWith', enum: ['previous'], required: false })
+  async getVolume(
+    @Request() req,
+    @Query('period') period: 'daily' | 'monthly' = 'daily',
+    @Query('compareWith') compareWith?: 'previous',
+  ) {
+    return this.analyticsService.getVolume(req.user.merchantId, period, compareWith);
   }
 
   @Get('funnel')
   @ApiOperation({ summary: 'Get payment funnel metrics' })
-  async getFunnel(@Request() req) {
-    return this.analyticsService.getFunnel(req.user.merchantId);
+  @ApiQuery({ name: 'compareWith', enum: ['previous'], required: false })
+  async getFunnel(@Request() req, @Query('compareWith') compareWith?: 'previous') {
+    return this.analyticsService.getFunnel(req.user.merchantId, compareWith);
   }
 
   @Get('comparison')

--- a/backend/src/analytics/analytics.service.ts
+++ b/backend/src/analytics/analytics.service.ts
@@ -25,58 +25,113 @@ export class AnalyticsService {
     return { ...data, cacheHit: false };
   }
 
-  async getVolume(merchantId: string, period: 'daily' | 'monthly') {
-    const cacheKey = `volume:${merchantId}:${period}`;
+  private getPeriodBounds(period: 'daily' | 'monthly'): { currentStart: Date; currentEnd: Date; prevStart: Date; prevEnd: Date } {
+    const now = new Date();
+    if (period === 'daily') {
+      const currentStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+      const currentEnd = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+      return { currentStart, currentEnd, prevStart: new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1), prevEnd: currentStart };
+    }
+    const currentStart = new Date(now.getFullYear(), now.getMonth(), 1);
+    const currentEnd = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+    return { currentStart, currentEnd, prevStart: new Date(now.getFullYear(), now.getMonth() - 1, 1), prevEnd: currentStart };
+  }
+
+  private pctChange(current: number, previous: number): number | null {
+    if (previous === 0) return null;
+    return parseFloat((((current - previous) / previous) * 100).toFixed(2));
+  }
+
+  async getVolume(merchantId: string, period: 'daily' | 'monthly', compareWith?: 'previous') {
+    const cacheKey = `volume:${merchantId}:${period}:${compareWith ?? 'none'}`;
     return this.getCachedData(cacheKey, async () => {
       const dateFormat = period === 'daily' ? 'YYYY-MM-DD' : 'YYYY-MM';
-      
-      const results = await this.paymentsRepo
-        .createQueryBuilder('payment')
-        .select(`TO_CHAR(payment.createdAt, '${dateFormat}')`, 'date')
-        .addSelect('SUM(payment.amountUsd)', 'volume')
-        .addSelect('COUNT(*)', 'count')
-        .where('payment.merchantId = :merchantId', { merchantId })
-        .andWhere('payment.status = :status', { status: PaymentStatus.SETTLED })
-        .groupBy('date')
-        .orderBy('date', 'ASC')
-        .getRawMany();
 
-      return { results };
+      const fetchSeries = (start?: Date, end?: Date) => {
+        const qb = this.paymentsRepo
+          .createQueryBuilder('payment')
+          .select(`TO_CHAR(payment.createdAt, '${dateFormat}')`, 'date')
+          .addSelect('SUM(payment.amountUsd)', 'volume')
+          .addSelect('COUNT(*)', 'count')
+          .where('payment.merchantId = :merchantId', { merchantId })
+          .andWhere('payment.status = :status', { status: PaymentStatus.SETTLED });
+        if (start) qb.andWhere('payment.createdAt >= :start', { start });
+        if (end) qb.andWhere('payment.createdAt < :end', { end });
+        return qb.groupBy('date').orderBy('date', 'ASC').getRawMany();
+      };
+
+      if (compareWith !== 'previous') {
+        return { results: await fetchSeries() };
+      }
+
+      const { currentStart, currentEnd, prevStart, prevEnd } = this.getPeriodBounds(period);
+      const [current, previous] = await Promise.all([
+        fetchSeries(currentStart, currentEnd),
+        fetchSeries(prevStart, prevEnd),
+      ]);
+
+      const sumVolume = (rows: any[]) => rows.reduce((s, r) => s + parseFloat(r.volume || 0), 0);
+      const sumCount = (rows: any[]) => rows.reduce((s, r) => s + parseInt(r.count || 0), 0);
+
+      const currentVolume = sumVolume(current);
+      const prevVolume = sumVolume(previous);
+      const currentCount = sumCount(current);
+      const prevCount = sumCount(previous);
+
+      return {
+        current: { results: current, totalVolume: currentVolume, totalCount: currentCount },
+        previous: { results: previous, totalVolume: prevVolume, totalCount: prevCount },
+        changes: {
+          volume: this.pctChange(currentVolume, prevVolume),
+          count: this.pctChange(currentCount, prevCount),
+        },
+      };
     });
   }
 
-  async getFunnel(merchantId: string) {
-    const cacheKey = `funnel:${merchantId}`;
+  async getFunnel(merchantId: string, compareWith?: 'previous') {
+    const cacheKey = `funnel:${merchantId}:${compareWith ?? 'none'}`;
     return this.getCachedData(cacheKey, async () => {
-      const stats = await this.paymentsRepo
-        .createQueryBuilder('payment')
-        .select('payment.status', 'status')
-        .addSelect('COUNT(*)', 'count')
-        .where('payment.merchantId = :merchantId', { merchantId })
-        .groupBy('payment.status')
-        .getRawMany();
+      const fetchCounts = async (start?: Date, end?: Date) => {
+        const qb = this.paymentsRepo
+          .createQueryBuilder('payment')
+          .select('payment.status', 'status')
+          .addSelect('COUNT(*)', 'count')
+          .where('payment.merchantId = :merchantId', { merchantId });
+        if (start) qb.andWhere('payment.createdAt >= :start', { start });
+        if (end) qb.andWhere('payment.createdAt < :end', { end });
+        const stats = await qb.groupBy('payment.status').getRawMany();
 
-      const counts = {
-        total: 0,
-        pending: 0,
-        confirmed: 0,
-        settling: 0,
-        settled: 0,
-        failed: 0,
-        expired: 0,
+        const counts = { total: 0, pending: 0, confirmed: 0, settling: 0, settled: 0, failed: 0, expired: 0 };
+        stats.forEach((s) => { counts[s.status] = parseInt(s.count); counts.total += parseInt(s.count); });
+        return {
+          counts,
+          percentages: {
+            conversionRate: counts.total > 0 ? (counts.settled / counts.total) * 100 : 0,
+            abandonmentRate: counts.total > 0 ? ((counts.expired + counts.failed) / counts.total) * 100 : 0,
+          },
+        };
       };
 
-      stats.forEach((s) => {
-        counts[s.status] = parseInt(s.count);
-        counts.total += parseInt(s.count);
-      });
+      if (compareWith !== 'previous') {
+        return fetchCounts();
+      }
 
-      const percentages = {
-        conversionRate: counts.total > 0 ? (counts.settled / counts.total) * 100 : 0,
-        abandonmentRate: counts.total > 0 ? ((counts.expired + counts.failed) / counts.total) * 100 : 0,
+      const { currentStart, currentEnd, prevStart, prevEnd } = this.getPeriodBounds('daily');
+      const [current, previous] = await Promise.all([
+        fetchCounts(currentStart, currentEnd),
+        fetchCounts(prevStart, prevEnd),
+      ]);
+
+      return {
+        current,
+        previous,
+        changes: {
+          settled: this.pctChange(current.counts.settled, previous.counts.settled),
+          total: this.pctChange(current.counts.total, previous.counts.total),
+          conversionRate: this.pctChange(current.percentages.conversionRate, previous.percentages.conversionRate),
+        },
       };
-
-      return { counts, percentages };
     });
   }
 


### PR DESCRIPTION
Closes #717

---

## Summary
Adds `compareWith=previous` query param to analytics endpoints so callers can get current and previous period data side-by-side with % change per metric in a single response.

## Changes
- `GET /analytics/volume?compareWith=previous` — returns `{ current, previous, changes: { volume, count } }`
- `GET /analytics/funnel?compareWith=previous` — returns `{ current, previous, changes: { settled, total, conversionRate } }`
- `pctChange()` returns `null` when previous period is zero (no divide-by-zero)
- Cache keys scoped per `compareWith` value
- Swagger `@ApiQuery` decorators added for both endpoints
- Existing endpoints without `compareWith` are fully backward-compatible

## Acceptance Criteria
- [x] % change calculated correctly
- [x] Zero previous period returns `null` not divide-by-zero
- [x] Both periods returned in a single response object