### PR TITLE
feat(analytics): add GET /analytics/networks endpoint with per-network breakdown

### DIFF
--- a/backend/src/analytics/analytics.controller.ts
+++ b/backend/src/analytics/analytics.controller.ts
@@ -29,4 +29,16 @@ export class AnalyticsController {
   async getComparison(@Request() req, @Query('period') period: 'daily' | 'monthly' = 'daily') {
     return this.analyticsService.getComparison(req.user.merchantId, period);
   }
+
+  @Get('networks')
+  @ApiOperation({ summary: 'Get payment volume breakdown by blockchain network' })
+  @ApiQuery({ name: 'sortBy', enum: ['volume', 'count'], required: false })
+  @ApiQuery({ name: 'period', enum: ['daily', 'monthly'], required: false })
+  async getNetworkBreakdown(
+    @Request() req,
+    @Query('sortBy') sortBy: 'volume' | 'count' = 'volume',
+    @Query('period') period: 'daily' | 'monthly' = 'daily',
+  ) {
+    return this.analyticsService.getNetworkBreakdown(req.user.merchantId, sortBy, period);
+  }
 }

--- a/backend/src/analytics/analytics.service.ts
+++ b/backend/src/analytics/analytics.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { Payment, PaymentStatus } from '../payments/entities/payment.entity';
+import { Payment, PaymentNetwork, PaymentStatus } from '../payments/entities/payment.entity';
 
 @Injectable()
 export class AnalyticsService {
@@ -124,6 +124,62 @@ export class AnalyticsService {
       .getRawOne();
 
     return parseFloat(result?.total || 0);
+  }
+
+  async getNetworkBreakdown(merchantId: string, sortBy: 'volume' | 'count' = 'volume', period: 'daily' | 'monthly' = 'daily') {
+    const cacheKey = `networks:${merchantId}:${sortBy}:${period}`;
+    return this.getCachedData(cacheKey, async () => {
+      const dateFormat = period === 'daily' ? 'YYYY-MM-DD' : 'YYYY-MM';
+
+      const [rows, trendRows] = await Promise.all([
+        this.paymentsRepo
+          .createQueryBuilder('payment')
+          .select('payment.network', 'network')
+          .addSelect('COUNT(*)', 'count')
+          .addSelect('COALESCE(SUM(payment.amountUsd), 0)', 'volumeUsd')
+          .where('payment.merchantId = :merchantId', { merchantId })
+          .andWhere('payment.status = :status', { status: PaymentStatus.SETTLED })
+          .groupBy('payment.network')
+          .getRawMany(),
+        this.paymentsRepo
+          .createQueryBuilder('payment')
+          .select('payment.network', 'network')
+          .addSelect(`TO_CHAR(payment.createdAt, '${dateFormat}')`, 'date')
+          .addSelect('COUNT(*)', 'count')
+          .addSelect('COALESCE(SUM(payment.amountUsd), 0)', 'volumeUsd')
+          .where('payment.merchantId = :merchantId', { merchantId })
+          .andWhere('payment.status = :status', { status: PaymentStatus.SETTLED })
+          .groupBy('payment.network')
+          .addGroupBy('date')
+          .orderBy('date', 'ASC')
+          .getRawMany(),
+      ]);
+
+      const totals = rows.reduce((s, r) => ({ volume: s.volume + parseFloat(r.volumeUsd), count: s.count + parseInt(r.count) }), { volume: 0, count: 0 });
+
+      const byNetwork = new Map(rows.map((r) => [r.network, { count: parseInt(r.count), volumeUsd: parseFloat(r.volumeUsd) }]));
+
+      const trendByNetwork = new Map<string, { date: string; count: number; volumeUsd: number }[]>();
+      for (const r of trendRows) {
+        if (!trendByNetwork.has(r.network)) trendByNetwork.set(r.network, []);
+        trendByNetwork.get(r.network).push({ date: r.date, count: parseInt(r.count), volumeUsd: parseFloat(r.volumeUsd) });
+      }
+
+      const networks = Object.values(PaymentNetwork).map((network) => {
+        const data = byNetwork.get(network) ?? { count: 0, volumeUsd: 0 };
+        return {
+          network,
+          count: data.count,
+          volumeUsd: data.volumeUsd,
+          percentOfTotal: totals.volume > 0 ? parseFloat(((data.volumeUsd / totals.volume) * 100).toFixed(2)) : 0,
+          trend: trendByNetwork.get(network) ?? [],
+        };
+      });
+
+      networks.sort((a, b) => (sortBy === 'count' ? b.count - a.count : b.volumeUsd - a.volumeUsd));
+
+      return { networks, totals };
+    });
   }
 
   clearCache() {

--- a/backend/src/database/migrations/1772200000001-ExpandPaymentNetworkEnum.ts
+++ b/backend/src/database/migrations/1772200000001-ExpandPaymentNetworkEnum.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ExpandPaymentNetworkEnum1772200000001 implements MigrationInterface {
+  name = 'ExpandPaymentNetworkEnum1772200000001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TYPE "public"."payments_network_enum"
+        ADD VALUE IF NOT EXISTS 'polygon',
+        ADD VALUE IF NOT EXISTS 'base',
+        ADD VALUE IF NOT EXISTS 'celo',
+        ADD VALUE IF NOT EXISTS 'arbitrum',
+        ADD VALUE IF NOT EXISTS 'optimism',
+        ADD VALUE IF NOT EXISTS 'starknet',
+        ADD VALUE IF NOT EXISTS 'stacks'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // PostgreSQL does not support removing enum values; down is a no-op
+  }
+}

--- a/backend/src/payments/entities/payment.entity.ts
+++ b/backend/src/payments/entities/payment.entity.ts
@@ -22,6 +22,13 @@ export enum PaymentStatus {
 
 export enum PaymentNetwork {
   STELLAR = 'stellar',
+  POLYGON = 'polygon',
+  BASE = 'base',
+  CELO = 'celo',
+  ARBITRUM = 'arbitrum',
+  OPTIMISM = 'optimism',
+  STARKNET = 'starknet',
+  STACKS = 'stacks',
 }
 
 @Entity('payments')


### PR DESCRIPTION
Closes #720

---

## Summary
Breaks down payment volume by blockchain network for chain-specific insights.

## Changes
- **`PaymentNetwork` enum** expanded with all 8 supported networks: `stellar`, `polygon`, `base`, `celo`, `arbitrum`, `optimism`, `starknet`, `stacks`
- **`GET /analytics/networks`** — new endpoint returning per-network `count`, `volumeUsd`, `percentOfTotal`, and historical `trend` series
- **Zero-fill** — all networks always appear in the response even with no data
- **Sortable** via `?sortBy=volume|count` (default: `volume`)
- **Historical trend** per network via `?period=daily|monthly`
- **Migration** `1772200000001-ExpandPaymentNetworkEnum` — adds new enum values to the existing PostgreSQL type using `ADD VALUE IF NOT EXISTS`

## Acceptance Criteria
- [x] All supported networks shown even with zero volume
- [x] Percentage calculated correctly (sums to 100%)
- [x] Sortable by volume