### PR TITLE
implemeted Soft delete for merchants and payments

### DIFF
--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -9,7 +9,7 @@ import {
   Query,
   Req,
   UseGuards,
-  Header,
+  Headers,
   Res,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
@@ -160,9 +160,9 @@ export class AdminController {
   async getAuditLogs(
     @Query() query: any,
     @Query() pagination: PaginationDto,
-    @Query('export') exportType?: string,
-    @Header('Accept') accept?: string,
     @Res() res: Response,
+    @Query('export') exportType?: string,
+    @Headers('accept') accept?: string,
   ) {
     const exportCsv = exportType === 'csv' || accept === 'text/csv';
     const result = await this.adminService.getAuditLogs(query, pagination, exportCsv);
@@ -173,5 +173,28 @@ export class AdminController {
     } else {
       res.json(result);
     }
+  }
+
+  // ── Generic Soft/Hard Delete and Restore ───────────────────────────────────
+
+  @Post(':entity/:id/restore')
+  @ApiOperation({ summary: 'Restore a soft-deleted record' })
+  restoreRecord(
+    @Param('entity') entity: string,
+    @Param('id') id: string,
+  ) {
+    return this.adminService.restoreRecord(entity, id);
+  }
+
+  @Delete(':entity/:id')
+  @ApiOperation({ summary: 'Soft or hard delete a record' })
+  deleteRecord(
+    @Param('entity') entity: string,
+    @Param('id') id: string,
+    @Query('hard') hard: string,
+    @Req() req: Request & { user: { id: string; role: MerchantRole } },
+  ) {
+    const isHard = hard === 'true';
+    return this.adminService.deleteRecord(entity, id, isHard, req.user.role);
   }
 }

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -37,12 +37,13 @@ export class AdminService {
       skip: (page - 1) * limit,
       take: limit,
       order: { createdAt: 'DESC' },
+      withDeleted: true,
     });
     return { merchants: merchants.map(m => this.sanitize(m)), total };
   }
 
   async findOneMerchant(id: string) {
-    const merchant = await this.merchantsRepo.findOne({ where: { id } });
+    const merchant = await this.merchantsRepo.findOne({ where: { id }, withDeleted: true });
     if (!merchant) throw new NotFoundException('Merchant not found');
     return this.sanitize(merchant);
   }
@@ -361,4 +362,55 @@ export class AdminService {
     const t = Math.floor(Date.now() / 1000);
     return [-1, 0, 1].some(w => this.totpCode(secret, t + w * 30) === token);
   }
+
+  // ── Generic Record Management (#soft-delete) ───────────────────────────────
+
+  async restoreRecord(entity: string, id: string) {
+    if (entity === 'merchants') {
+      const record = await this.merchantsRepo.findOne({ where: { id }, withDeleted: true });
+      if (!record) throw new NotFoundException('Merchant not found');
+      if (!record.deletedAt) throw new BadRequestException('Merchant is not deleted');
+      await this.merchantsRepo.restore(id);
+      return { success: true, id };
+    } else if (entity === 'payments') {
+      const record = await this.paymentsRepo.findOne({ where: { id }, withDeleted: true });
+      if (!record) throw new NotFoundException('Payment not found');
+      if (!record.deletedAt) throw new BadRequestException('Payment is not deleted');
+      await this.paymentsRepo.restore(id);
+      return { success: true, id };
+    } else {
+      throw new BadRequestException('Invalid entity type');
+    }
+  }
+
+  async deleteRecord(entity: string, id: string, hard: boolean, actorRole: MerchantRole) {
+    if (hard && actorRole !== MerchantRole.SUPERADMIN) {
+      throw new ForbiddenException('Only SUPERADMIN can hard delete records');
+    }
+
+    if (entity === 'merchants') {
+      const record = await this.merchantsRepo.findOne({ where: { id }, withDeleted: true });
+      if (!record) throw new NotFoundException('Merchant not found');
+      
+      if (hard) {
+        await this.merchantsRepo.delete(id);
+      } else {
+        await this.merchantsRepo.softDelete(id);
+      }
+      return { success: true, id, hardDeleted: hard };
+    } else if (entity === 'payments') {
+      const record = await this.paymentsRepo.findOne({ where: { id }, withDeleted: true });
+      if (!record) throw new NotFoundException('Payment not found');
+      
+      if (hard) {
+        await this.paymentsRepo.delete(id);
+      } else {
+        await this.paymentsRepo.softDelete(id);
+      }
+      return { success: true, id, hardDeleted: hard };
+    } else {
+      throw new BadRequestException('Invalid entity type');
+    }
+  }
 }
+

--- a/backend/src/merchants/entities/merchant.entity.ts
+++ b/backend/src/merchants/entities/merchant.entity.ts
@@ -4,6 +4,7 @@ import {
   Column,
   CreateDateColumn,
   UpdateDateColumn,
+  DeleteDateColumn,
   OneToMany,
 } from 'typeorm';
 import { Exclude, Transform } from 'class-transformer';
@@ -113,4 +114,7 @@ export class Merchant {
 
   @UpdateDateColumn()
   updatedAt: Date;
+
+  @DeleteDateColumn()
+  deletedAt: Date;
 }

--- a/backend/src/payments/entities/payment.entity.ts
+++ b/backend/src/payments/entities/payment.entity.ts
@@ -4,6 +4,7 @@ import {
   Column,
   CreateDateColumn,
   UpdateDateColumn,
+  DeleteDateColumn,
   ManyToOne,
   JoinColumn,
 } from 'typeorm';
@@ -127,4 +128,7 @@ export class Payment {
 
   @UpdateDateColumn()
   updatedAt: Date;
+
+  @DeleteDateColumn()
+  deletedAt: Date;
 }


### PR DESCRIPTION
## What was done

Entity Updates for Soft Deletes:

Added TypeORM's @DeleteDateColumn() deletedAt: Date; to both the Merchant (merchant.entity.ts) and Payment (payment.entity.ts) entities.
This change automatically configures normal, merchant-facing queries to natively exclude any soft-deleted records.
Admin Queries Updated (admin.service.ts):

Added { withDeleted: true } parameter to admin methods specifically (findAllMerchants, findOneMerchant) so that admins can still query and view records regardless of their soft-deleted state.
Admin Restore & Delete Endpoints (admin.controller.ts & admin.service.ts):

Created a dynamic POST /admin/:entity/:id/restore route. This allows an admin to select a deleted entity (merchants or payments) and restore it seamlessly.
Created a corresponding DELETE /admin/:entity/:id?hard=true route that defaults to a soft delete but supports a hard delete override.
Tied a role requirement to the delete logic: if ?hard=true is requested, it ensures that the actor role is specifically a SUPERADMIN, restricting permanent removal functionality to them alone.
Lint Issues Reconciled:

Resolved parameters and header lint errors in admin.controller.ts ensuring clean code syntax.


Close #748 