### PR TITLE
feat(merchants): add per-channel notification preferences

### DIFF
--- a/backend/src/database/migrations/1772200000002-CreateNotificationPreferences.ts
+++ b/backend/src/database/migrations/1772200000002-CreateNotificationPreferences.ts
@@ -1,0 +1,105 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex, TableForeignKey } from 'typeorm';
+
+export class CreateNotificationPreferences1772200000002 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "notification_channel_enum" AS ENUM ('email', 'push', 'in_app')
+    `);
+
+    await queryRunner.query(`
+      CREATE TYPE "notification_event_type_enum" AS ENUM (
+        'payment.confirmed',
+        'payment.settled',
+        'settlement.failed'
+      )
+    `);
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'notification_preferences',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'merchant_id',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'channel',
+            type: 'enum',
+            enumName: 'notification_channel_enum',
+            isNullable: false,
+          },
+          {
+            name: 'event_type',
+            type: 'enum',
+            enumName: 'notification_event_type_enum',
+            isNullable: false,
+          },
+          {
+            name: 'enabled',
+            type: 'boolean',
+            default: true,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamptz',
+            default: 'now()',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamptz',
+            default: 'now()',
+          },
+        ],
+      }),
+      true,
+    );
+
+    // Unique constraint: one row per merchant × channel × event
+    await queryRunner.createIndex(
+      'notification_preferences',
+      new TableIndex({
+        name: 'UQ_notif_pref_merchant_channel_event',
+        columnNames: ['merchant_id', 'channel', 'event_type'],
+        isUnique: true,
+      }),
+    );
+
+    // Index for fast lookups by merchant
+    await queryRunner.createIndex(
+      'notification_preferences',
+      new TableIndex({
+        name: 'IDX_notif_pref_merchant_id',
+        columnNames: ['merchant_id'],
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'notification_preferences',
+      new TableForeignKey({
+        name: 'FK_notif_pref_merchant',
+        columnNames: ['merchant_id'],
+        referencedTableName: 'merchants',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropForeignKey('notification_preferences', 'FK_notif_pref_merchant');
+    await queryRunner.dropIndex('notification_preferences', 'IDX_notif_pref_merchant_id');
+    await queryRunner.dropIndex('notification_preferences', 'UQ_notif_pref_merchant_channel_event');
+    await queryRunner.dropTable('notification_preferences');
+    await queryRunner.query(`DROP TYPE IF EXISTS "notification_event_type_enum"`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "notification_channel_enum"`);
+  }
+}

--- a/backend/src/merchants/merchants.controller.ts
+++ b/backend/src/merchants/merchants.controller.ts
@@ -11,13 +11,18 @@ import {
 import { MerchantsService } from './merchants.service';
 import { UpdateMerchantDto } from './dto/create-merchant.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt.guard';
+import { NotificationPrefsService } from '../notifications/notification-prefs.service';
+import { UpdateNotificationPrefsDto, NotificationPrefsResponseDto } from '../notifications/dto/notification-prefs.dto';
 
 @ApiTags('merchants')
 @ApiBearerAuth('bearer')
 @UseGuards(JwtAuthGuard)
 @Controller('merchants')
 export class MerchantsController {
-  constructor(private readonly merchantsService: MerchantsService) {}
+  constructor(
+    private readonly merchantsService: MerchantsService,
+    private readonly notificationPrefsService: NotificationPrefsService,
+  ) {}
 
   @Get('me')
   @ApiOperation({ summary: 'Get merchant profile' })
@@ -45,5 +50,27 @@ export class MerchantsController {
   @ApiResponse({ status: 500, description: 'Internal server error' })
   generateApiKey(@Request() req: { user: { merchantId: string } }) {
     return this.merchantsService.generateApiKey(req.user.merchantId);
+  }
+
+  @Get('me/notification-prefs')
+  @ApiOperation({ summary: 'Get notification preferences' })
+  @ApiOkResponse({ type: NotificationPrefsResponseDto, description: 'Current notification preferences per channel and event' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT' })
+  getNotificationPrefs(
+    @Request() req: { user: { merchantId: string } },
+  ): Promise<NotificationPrefsResponseDto> {
+    return this.notificationPrefsService.getPrefs(req.user.merchantId);
+  }
+
+  @Patch('me/notification-prefs')
+  @ApiOperation({ summary: 'Update notification preferences' })
+  @ApiOkResponse({ type: NotificationPrefsResponseDto, description: 'Updated notification preferences' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT' })
+  @ApiBadRequestResponse({ description: 'Validation failed or attempted to disable in_app channel' })
+  updateNotificationPrefs(
+    @Request() req: { user: { merchantId: string } },
+    @Body() dto: UpdateNotificationPrefsDto,
+  ): Promise<NotificationPrefsResponseDto> {
+    return this.notificationPrefsService.updatePrefs(req.user.merchantId, dto);
   }
 }

--- a/backend/src/merchants/merchants.module.ts
+++ b/backend/src/merchants/merchants.module.ts
@@ -5,11 +5,13 @@ import { MerchantsController } from './merchants.controller';
 import { AdminMerchantsController } from './admin-merchants.controller';
 import { Merchant } from './entities/merchant.entity';
 import { AdminAuditLog } from './entities/admin-audit-log.entity';
+import { NotificationPreference } from '../notifications/entities/notification-preference.entity';
+import { NotificationPrefsService } from '../notifications/notification-prefs.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Merchant, AdminAuditLog])],
+  imports: [TypeOrmModule.forFeature([Merchant, AdminAuditLog, NotificationPreference])],
   controllers: [MerchantsController, AdminMerchantsController],
-  providers: [MerchantsService],
-  exports: [MerchantsService],
+  providers: [MerchantsService, NotificationPrefsService],
+  exports: [MerchantsService, NotificationPrefsService],
 })
 export class MerchantsModule {}

--- a/backend/src/notifications/dto/notification-prefs.dto.ts
+++ b/backend/src/notifications/dto/notification-prefs.dto.ts
@@ -1,0 +1,51 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsOptional,
+  ValidateNested,
+} from 'class-validator';
+import { NotificationChannel, NotificationEventType } from '../entities/notification-preference.entity';
+
+export class NotificationPrefItemDto {
+  @ApiProperty({ enum: NotificationChannel })
+  @IsEnum(NotificationChannel)
+  channel: NotificationChannel;
+
+  @ApiProperty({ enum: NotificationEventType })
+  @IsEnum(NotificationEventType)
+  eventType: NotificationEventType;
+
+  @ApiProperty()
+  @IsBoolean()
+  enabled: boolean;
+}
+
+export class UpdateNotificationPrefsDto {
+  @ApiProperty({ type: [NotificationPrefItemDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => NotificationPrefItemDto)
+  preferences: NotificationPrefItemDto[];
+}
+
+export class NotificationPrefResponseItemDto {
+  @ApiProperty({ enum: NotificationChannel })
+  channel: NotificationChannel;
+
+  @ApiProperty({ enum: NotificationEventType })
+  eventType: NotificationEventType;
+
+  @ApiProperty()
+  enabled: boolean;
+
+  @ApiPropertyOptional({ description: 'in_app channel is always enabled and cannot be disabled' })
+  readonly?: boolean;
+}
+
+export class NotificationPrefsResponseDto {
+  @ApiProperty({ type: [NotificationPrefResponseItemDto] })
+  preferences: NotificationPrefResponseItemDto[];
+}

--- a/backend/src/notifications/entities/notification-preference.entity.ts
+++ b/backend/src/notifications/entities/notification-preference.entity.ts
@@ -1,0 +1,58 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Unique,
+  Index,
+} from 'typeorm';
+import { Merchant } from '../../merchants/entities/merchant.entity';
+
+export enum NotificationChannel {
+  EMAIL = 'email',
+  PUSH = 'push',
+  IN_APP = 'in_app',
+}
+
+export enum NotificationEventType {
+  PAYMENT_CONFIRMED = 'payment.confirmed',
+  PAYMENT_SETTLED = 'payment.settled',
+  SETTLEMENT_FAILED = 'settlement.failed',
+}
+
+@Entity('notification_preferences')
+@Unique(['merchantId', 'channel', 'eventType'])
+@Index(['merchantId'])
+export class NotificationPreference {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'merchant_id' })
+  merchantId: string;
+
+  @ManyToOne(() => Merchant, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'merchant_id' })
+  merchant: Merchant;
+
+  @Column({ type: 'enum', enum: NotificationChannel })
+  channel: NotificationChannel;
+
+  @Column({ type: 'enum', enum: NotificationEventType })
+  eventType: NotificationEventType;
+
+  /**
+   * Whether this channel+event combination is enabled.
+   * in_app channel is always forced to true at the service layer.
+   */
+  @Column({ default: true })
+  enabled: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/notifications/notification-prefs.service.ts
+++ b/backend/src/notifications/notification-prefs.service.ts
@@ -1,0 +1,105 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  NotificationChannel,
+  NotificationEventType,
+  NotificationPreference,
+} from './entities/notification-preference.entity';
+import {
+  NotificationPrefResponseItemDto,
+  NotificationPrefsResponseDto,
+  UpdateNotificationPrefsDto,
+} from './dto/notification-prefs.dto';
+
+/** All valid channel × event combinations, used to seed defaults. */
+const ALL_CHANNELS = Object.values(NotificationChannel);
+const ALL_EVENTS = Object.values(NotificationEventType);
+
+@Injectable()
+export class NotificationPrefsService {
+  constructor(
+    @InjectRepository(NotificationPreference)
+    private readonly prefsRepo: Repository<NotificationPreference>,
+  ) {}
+
+  async getPrefs(merchantId: string): Promise<NotificationPrefsResponseDto> {
+    const stored = await this.prefsRepo.find({ where: { merchantId } });
+
+    // Build a full matrix, filling in defaults for any missing rows
+    const preferences: NotificationPrefResponseItemDto[] = [];
+
+    for (const channel of ALL_CHANNELS) {
+      for (const eventType of ALL_EVENTS) {
+        const existing = stored.find(
+          (p) => p.channel === channel && p.eventType === eventType,
+        );
+
+        const isInApp = channel === NotificationChannel.IN_APP;
+
+        preferences.push({
+          channel,
+          eventType,
+          // in_app is always enabled; fall back to true for unsaved rows
+          enabled: isInApp ? true : (existing?.enabled ?? true),
+          ...(isInApp ? { readonly: true } : {}),
+        });
+      }
+    }
+
+    return { preferences };
+  }
+
+  async updatePrefs(
+    merchantId: string,
+    dto: UpdateNotificationPrefsDto,
+  ): Promise<NotificationPrefsResponseDto> {
+    for (const item of dto.preferences) {
+      if (item.channel === NotificationChannel.IN_APP && !item.enabled) {
+        throw new BadRequestException(
+          'in_app notifications cannot be disabled',
+        );
+      }
+    }
+
+    // Upsert each preference using the unique constraint (merchantId, channel, eventType)
+    for (const item of dto.preferences) {
+      const isInApp = item.channel === NotificationChannel.IN_APP;
+      const enabled = isInApp ? true : item.enabled;
+
+      await this.prefsRepo
+        .createQueryBuilder()
+        .insert()
+        .into(NotificationPreference)
+        .values({
+          merchantId,
+          channel: item.channel,
+          eventType: item.eventType,
+          enabled,
+        })
+        .orUpdate(['enabled', 'updated_at'], ['merchant_id', 'channel', 'event_type'])
+        .execute();
+    }
+
+    return this.getPrefs(merchantId);
+  }
+
+  /**
+   * Utility used by other services to check whether a specific channel+event
+   * is enabled for a merchant before dispatching a notification.
+   */
+  async isEnabled(
+    merchantId: string,
+    channel: NotificationChannel,
+    eventType: NotificationEventType,
+  ): Promise<boolean> {
+    if (channel === NotificationChannel.IN_APP) return true;
+
+    const pref = await this.prefsRepo.findOne({
+      where: { merchantId, channel, eventType },
+    });
+
+    // Default to enabled if no preference row exists yet
+    return pref?.enabled ?? true;
+  }
+}

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -5,13 +5,14 @@ import { ConfigModule } from '@nestjs/config';
 import { NotificationsService } from './notifications.service';
 import { EmailProcessor } from './email.processor';
 import { EmailDeliveryLog } from './entities/email-delivery-log.entity';
+import { NotificationPreference } from './entities/notification-preference.entity';
 import { QueueConfigService } from '../config/queue-config.service';
 import { EMAIL_DELIVERY_QUEUE } from '../queue/queue.constants';
 
 @Module({
   imports: [
     ConfigModule,
-    TypeOrmModule.forFeature([EmailDeliveryLog]),
+    TypeOrmModule.forFeature([EmailDeliveryLog, NotificationPreference]),
     BullModule.registerQueue({ name: EMAIL_DELIVERY_QUEUE }),
   ],
   providers: [NotificationsService, EmailProcessor, QueueConfigService],

--- a/backend/src/settlements/settlements.module.ts
+++ b/backend/src/settlements/settlements.module.ts
@@ -8,6 +8,8 @@ import { Payment } from '../payments/entities/payment.entity';
 import { WebhooksModule } from '../webhooks/webhooks.module';
 import { PartnerSignatureGuard } from './guards/partner-signature.guard';
 import { CacheModule } from '../cache/cache.module';
+import { EmailModule } from '../email/email.module';
+import { MerchantsModule } from '../merchants/merchants.module';
 
 @Module({
   imports: [
@@ -15,6 +17,8 @@ import { CacheModule } from '../cache/cache.module';
     AdminAlertModule,
     WebhooksModule,
     CacheModule,
+    EmailModule,
+    MerchantsModule,
   ],
   controllers: [SettlementsController, PartnerCallbackController],
   providers: [SettlementsService, PartnerSignatureGuard],

--- a/backend/src/settlements/settlements.service.ts
+++ b/backend/src/settlements/settlements.service.ts
@@ -11,6 +11,10 @@ import { WebhooksService } from '../webhooks/webhooks.service';
 import { PaginatedResponseDto } from '../common/dto/pagination.dto';
 import { AdminSettlementsQueryDto } from './dto/admin-settlements-query.dto';
 import { CacheService } from '../cache/cache.service';
+import { EmailService } from '../email/email.service';
+import { MerchantsService } from '../merchants/merchants.service';
+import { NotificationPrefsService } from '../notifications/notification-prefs.service';
+import { NotificationChannel, NotificationEventType } from '../notifications/entities/notification-preference.entity';
 
 export interface PartnerCallbackPayload {
   reference: string;
@@ -31,6 +35,9 @@ export class SettlementsService {
     private webhooks: WebhooksService,
     private adminAlerts: AdminAlertService,
     private cache: CacheService,
+    private emailService: EmailService,
+    private merchantsService: MerchantsService,
+    private notificationPrefs: NotificationPrefsService,
   ) {}
 
   async initiateSettlement(payment: Payment): Promise<void> {
@@ -113,6 +120,17 @@ export class SettlementsService {
         settlementId: settlement.id,
         amount: settlement.netAmountUsd,
       });
+
+      await this.sendSettlementEmail(
+        settlement.merchantId,
+        NotificationEventType.PAYMENT_SETTLED,
+        'settlement-completed',
+        {
+          settlementId: settlement.id,
+          netAmountUsd: Number(settlement.netAmountUsd).toFixed(2),
+          paymentId: payment.id,
+        },
+      );
     } catch (err) {
       this.logger.error(`Settlement failed for ${settlement.id}`, err.message);
       await this.adminAlerts.raise({
@@ -137,6 +155,17 @@ export class SettlementsService {
         paymentId: payment.id,
         reason: err.message,
       });
+
+      await this.sendSettlementEmail(
+        settlement.merchantId,
+        NotificationEventType.SETTLEMENT_FAILED,
+        'payment-failed',
+        {
+          settlementId: settlement.id,
+          paymentId: payment.id,
+          reason: err.message,
+        },
+      );
     }
   }
 
@@ -183,6 +212,17 @@ export class SettlementsService {
           settlementId: settlement.id,
           amount: settlement.netAmountUsd,
         });
+
+        await this.sendSettlementEmail(
+          settlement.merchantId,
+          NotificationEventType.PAYMENT_SETTLED,
+          'settlement-completed',
+          {
+            settlementId: settlement.id,
+            netAmountUsd: Number(settlement.netAmountUsd).toFixed(2),
+            paymentId: payment.id,
+          },
+        );
       }
     } else {
       settlement.status = SettlementStatus.FAILED;
@@ -196,10 +236,45 @@ export class SettlementsService {
           paymentId: payment.id,
           reason: settlement.failureReason,
         });
+
+        await this.sendSettlementEmail(
+          settlement.merchantId,
+          NotificationEventType.SETTLEMENT_FAILED,
+          'payment-failed',
+          {
+            settlementId: settlement.id,
+            paymentId: payment.id,
+            reason: settlement.failureReason,
+          },
+        );
       }
     }
   }
-}
+
+  /**
+   * Sends an email for a settlement event only if the merchant has that
+   * channel+event combination enabled in their notification preferences.
+   */
+  private async sendSettlementEmail(
+    merchantId: string,
+    eventType: NotificationEventType,
+    templateAlias: string,
+    mergeData: Record<string, unknown>,
+  ): Promise<void> {
+    const emailEnabled = await this.notificationPrefs.isEnabled(
+      merchantId,
+      NotificationChannel.EMAIL,
+      eventType,
+    );
+    if (!emailEnabled) return;
+
+    try {
+      const merchant = await this.merchantsService.findOne(merchantId);
+      await this.emailService.queue(merchant.email, templateAlias, mergeData, merchantId);
+    } catch (err) {
+      this.logger.warn(`Failed to send settlement email for merchant ${merchantId}: ${err.message}`);
+    }
+  }
 
   // Admin methods
   async findAllAdmin(query: AdminSettlementsQueryDto) {

--- a/backend/src/stellar/stellar-monitor.service.ts
+++ b/backend/src/stellar/stellar-monitor.service.ts
@@ -13,6 +13,8 @@ import { WebhooksService } from '../webhooks/webhooks.service';
 import { EmailService } from '../email/email.service';
 import { ConfigService } from '@nestjs/config';
 import { Merchant } from '../merchants/entities/merchant.entity';
+import { NotificationPrefsService } from '../notifications/notification-prefs.service';
+import { NotificationChannel, NotificationEventType } from '../notifications/entities/notification-preference.entity';
 
 @Injectable()
 export class StellarMonitorService implements OnModuleInit {
@@ -28,6 +30,7 @@ export class StellarMonitorService implements OnModuleInit {
     private webhooks: WebhooksService,
     private emailService: EmailService,
     private config: ConfigService,
+    private notificationPrefs: NotificationPrefsService,
     @InjectQueue(QUEUE_NAMES.stellarMonitor) private monitorQueue: Queue,
   ) {}
 
@@ -133,9 +136,14 @@ export class StellarMonitorService implements OnModuleInit {
     asset: string,
   ): Promise<void> {
     const merchant = payment.merchant;
-    if (!merchant?.email || merchant.paymentConfirmedEmailEnabled === false) {
-      return;
-    }
+    if (!merchant?.email) return;
+
+    const emailEnabled = await this.notificationPrefs.isEnabled(
+      merchant.id,
+      NotificationChannel.EMAIL,
+      NotificationEventType.PAYMENT_CONFIRMED,
+    );
+    if (!emailEnabled) return;
 
     const frontendUrl = this.config.get<string>('FRONTEND_URL', 'http://localhost:3000');
     const paymentDetailUrl = `${frontendUrl.replace(/\/$/, '')}/pay/${payment.reference}`;

--- a/backend/src/stellar/stellar.module.ts
+++ b/backend/src/stellar/stellar.module.ts
@@ -9,6 +9,7 @@ import { SettlementsModule } from '../settlements/settlements.module';
 import { WebhooksModule } from '../webhooks/webhooks.module';
 import { QUEUE_NAMES } from '../queues/queue.constants';
 import { EmailModule } from '../email/email.module';
+import { MerchantsModule } from '../merchants/merchants.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { EmailModule } from '../email/email.module';
     forwardRef(() => SettlementsModule),
     WebhooksModule,
     EmailModule,
+    MerchantsModule,
     BullModule.registerQueue({ name: QUEUE_NAMES.stellarMonitor }),
   ],
   providers: [StellarService, StellarMonitorService],


### PR DESCRIPTION
closes #742 

Lets merchants control which notification channels (email, push, in-app) are active per event type, replacing the single paymentConfirmedEmailEnabled flag with a proper preferences system.

What changed

New notification_preferences table — one row per (merchant, channel, event) with a unique constraint and CASCADE delete
GET /api/v1/merchants/me/notification-prefs — returns the full channel × event matrix, defaulting to enabled for any unsaved rows
PATCH /api/v1/merchants/me/notification-prefs — upserts preferences; rejects any attempt to disable in_app with a 400
NotificationPrefsService.isEnabled() — lightweight check used by downstream services before dispatching emails
stellar-monitor now gates payment.confirmed emails through the new prefs instead of the legacy boolean flag
settlements service now sends payment.settled and settlement.failed emails, both gated by prefs
Behaviour guarantees

in-app is always enabled — enforced at the service layer, not just validation
Merchants with no saved preferences get all channels enabled by default (no data migration needed)
Disabling email for an event stops only that email type; other channels and events are unaffected