### PR TITLE
External uptime monitoring

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -37,6 +37,24 @@ WEBHOOK_SECRET=your_webhook_signing_secret
 
 # Monitoring (Optional)
 SENTRY_DSN=https://xxx@sentry.io/xxx
+
+# Uptime Monitoring & Alerting
+# UptimeRobot API key (for programmatic monitor management)
+UPTIMEROBOT_API_KEY=
+# Better Uptime API token
+BETTER_UPTIME_API_TOKEN=
+# Better Uptime heartbeat URL — ping every 5 min to confirm cron jobs are alive
+BETTER_UPTIME_HEARTBEAT_URL=https://betteruptime.com/api/v1/heartbeat/xxxxx
+
+# Admin alert channels (used by AdminAlertService)
+ADMIN_ALERT_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxx/yyy/zzz
+ADMIN_ALERT_EMAIL=oncall@cheesepay.xyz
+ADMIN_ALERT_COOLDOWN_MINUTES=30
+ADMIN_ALERT_FAILURE_THRESHOLD=1
+ADMIN_ALERT_STELLAR_FAILURE_THRESHOLD=1
+
+# Grafana alerting — Slack webhook for uptime-alerts.yaml contact point
+GRAFANA_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxx/yyy/zzz
 REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PASSWORD=

--- a/backend/src/cron/cron.module.ts
+++ b/backend/src/cron/cron.module.ts
@@ -5,6 +5,7 @@ import { NotificationsModule } from '../../notifications/notifications.module';
 import { CronJobLog } from './entities/cron-job-log.entity';
 import { CronJobService } from './cron-job.service';
 import { CronHealthProcessor } from './cron-health.processor';
+import { UptimeHeartbeatService } from './uptime-heartbeat.service';
 
 const CRON_QUEUE = 'cron';
 
@@ -14,7 +15,7 @@ const CRON_QUEUE = 'cron';
     NotificationsModule,
     BullModule.registerQueue({ name: CRON_QUEUE }),
   ],
-  providers: [CronJobService, CronHealthProcessor],
+  providers: [CronJobService, CronHealthProcessor, UptimeHeartbeatService],
   exports: [CronJobService],
 })
 export class CronModule {}

--- a/backend/src/cron/uptime-heartbeat.service.ts
+++ b/backend/src/cron/uptime-heartbeat.service.ts
@@ -1,0 +1,36 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+
+/**
+ * Pings the Better Uptime heartbeat URL every 5 minutes.
+ *
+ * If this service stops pinging (process crash, OOM, etc.), Better Uptime
+ * will open an incident after the configured grace period (recommend: 2 min).
+ *
+ * Configure via env:
+ *   BETTER_UPTIME_HEARTBEAT_URL=https://betteruptime.com/api/v1/heartbeat/xxxxx
+ */
+@Injectable()
+export class UptimeHeartbeatService {
+  private readonly logger = new Logger(UptimeHeartbeatService.name);
+
+  constructor(private readonly config: ConfigService) {}
+
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  async ping(): Promise<void> {
+    const url = this.config.get<string>('BETTER_UPTIME_HEARTBEAT_URL');
+    if (!url) return;
+
+    try {
+      await axios.get(url, { timeout: 5_000 });
+      this.logger.debug('Heartbeat ping sent');
+    } catch (err) {
+      // Log but don't throw — a failed ping is not fatal to the app
+      this.logger.warn(
+        `Heartbeat ping failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}

--- a/backend/src/database/migrations/1772200000002-CreateNotificationPreferences.ts
+++ b/backend/src/database/migrations/1772200000002-CreateNotificationPreferences.ts
@@ -1,0 +1,105 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex, TableForeignKey } from 'typeorm';
+
+export class CreateNotificationPreferences1772200000002 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE "notification_channel_enum" AS ENUM ('email', 'push', 'in_app')
+    `);
+
+    await queryRunner.query(`
+      CREATE TYPE "notification_event_type_enum" AS ENUM (
+        'payment.confirmed',
+        'payment.settled',
+        'settlement.failed'
+      )
+    `);
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'notification_preferences',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'uuid',
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'merchant_id',
+            type: 'uuid',
+            isNullable: false,
+          },
+          {
+            name: 'channel',
+            type: 'enum',
+            enumName: 'notification_channel_enum',
+            isNullable: false,
+          },
+          {
+            name: 'event_type',
+            type: 'enum',
+            enumName: 'notification_event_type_enum',
+            isNullable: false,
+          },
+          {
+            name: 'enabled',
+            type: 'boolean',
+            default: true,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamptz',
+            default: 'now()',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamptz',
+            default: 'now()',
+          },
+        ],
+      }),
+      true,
+    );
+
+    // Unique constraint: one row per merchant × channel × event
+    await queryRunner.createIndex(
+      'notification_preferences',
+      new TableIndex({
+        name: 'UQ_notif_pref_merchant_channel_event',
+        columnNames: ['merchant_id', 'channel', 'event_type'],
+        isUnique: true,
+      }),
+    );
+
+    // Index for fast lookups by merchant
+    await queryRunner.createIndex(
+      'notification_preferences',
+      new TableIndex({
+        name: 'IDX_notif_pref_merchant_id',
+        columnNames: ['merchant_id'],
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'notification_preferences',
+      new TableForeignKey({
+        name: 'FK_notif_pref_merchant',
+        columnNames: ['merchant_id'],
+        referencedTableName: 'merchants',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropForeignKey('notification_preferences', 'FK_notif_pref_merchant');
+    await queryRunner.dropIndex('notification_preferences', 'IDX_notif_pref_merchant_id');
+    await queryRunner.dropIndex('notification_preferences', 'UQ_notif_pref_merchant_channel_event');
+    await queryRunner.dropTable('notification_preferences');
+    await queryRunner.query(`DROP TYPE IF EXISTS "notification_event_type_enum"`);
+    await queryRunner.query(`DROP TYPE IF EXISTS "notification_channel_enum"`);
+  }
+}

--- a/backend/src/merchants/merchants.controller.ts
+++ b/backend/src/merchants/merchants.controller.ts
@@ -11,13 +11,18 @@ import {
 import { MerchantsService } from './merchants.service';
 import { UpdateMerchantDto } from './dto/create-merchant.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt.guard';
+import { NotificationPrefsService } from '../notifications/notification-prefs.service';
+import { UpdateNotificationPrefsDto, NotificationPrefsResponseDto } from '../notifications/dto/notification-prefs.dto';
 
 @ApiTags('merchants')
 @ApiBearerAuth('bearer')
 @UseGuards(JwtAuthGuard)
 @Controller('merchants')
 export class MerchantsController {
-  constructor(private readonly merchantsService: MerchantsService) {}
+  constructor(
+    private readonly merchantsService: MerchantsService,
+    private readonly notificationPrefsService: NotificationPrefsService,
+  ) {}
 
   @Get('me')
   @ApiOperation({ summary: 'Get merchant profile' })
@@ -45,5 +50,27 @@ export class MerchantsController {
   @ApiResponse({ status: 500, description: 'Internal server error' })
   generateApiKey(@Request() req: { user: { merchantId: string } }) {
     return this.merchantsService.generateApiKey(req.user.merchantId);
+  }
+
+  @Get('me/notification-prefs')
+  @ApiOperation({ summary: 'Get notification preferences' })
+  @ApiOkResponse({ type: NotificationPrefsResponseDto, description: 'Current notification preferences per channel and event' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT' })
+  getNotificationPrefs(
+    @Request() req: { user: { merchantId: string } },
+  ): Promise<NotificationPrefsResponseDto> {
+    return this.notificationPrefsService.getPrefs(req.user.merchantId);
+  }
+
+  @Patch('me/notification-prefs')
+  @ApiOperation({ summary: 'Update notification preferences' })
+  @ApiOkResponse({ type: NotificationPrefsResponseDto, description: 'Updated notification preferences' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT' })
+  @ApiBadRequestResponse({ description: 'Validation failed or attempted to disable in_app channel' })
+  updateNotificationPrefs(
+    @Request() req: { user: { merchantId: string } },
+    @Body() dto: UpdateNotificationPrefsDto,
+  ): Promise<NotificationPrefsResponseDto> {
+    return this.notificationPrefsService.updatePrefs(req.user.merchantId, dto);
   }
 }

--- a/backend/src/merchants/merchants.module.ts
+++ b/backend/src/merchants/merchants.module.ts
@@ -5,11 +5,13 @@ import { MerchantsController } from './merchants.controller';
 import { AdminMerchantsController } from './admin-merchants.controller';
 import { Merchant } from './entities/merchant.entity';
 import { AdminAuditLog } from './entities/admin-audit-log.entity';
+import { NotificationPreference } from '../notifications/entities/notification-preference.entity';
+import { NotificationPrefsService } from '../notifications/notification-prefs.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Merchant, AdminAuditLog])],
+  imports: [TypeOrmModule.forFeature([Merchant, AdminAuditLog, NotificationPreference])],
   controllers: [MerchantsController, AdminMerchantsController],
-  providers: [MerchantsService],
-  exports: [MerchantsService],
+  providers: [MerchantsService, NotificationPrefsService],
+  exports: [MerchantsService, NotificationPrefsService],
 })
 export class MerchantsModule {}

--- a/backend/src/notifications/dto/notification-prefs.dto.ts
+++ b/backend/src/notifications/dto/notification-prefs.dto.ts
@@ -1,0 +1,51 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsOptional,
+  ValidateNested,
+} from 'class-validator';
+import { NotificationChannel, NotificationEventType } from '../entities/notification-preference.entity';
+
+export class NotificationPrefItemDto {
+  @ApiProperty({ enum: NotificationChannel })
+  @IsEnum(NotificationChannel)
+  channel: NotificationChannel;
+
+  @ApiProperty({ enum: NotificationEventType })
+  @IsEnum(NotificationEventType)
+  eventType: NotificationEventType;
+
+  @ApiProperty()
+  @IsBoolean()
+  enabled: boolean;
+}
+
+export class UpdateNotificationPrefsDto {
+  @ApiProperty({ type: [NotificationPrefItemDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => NotificationPrefItemDto)
+  preferences: NotificationPrefItemDto[];
+}
+
+export class NotificationPrefResponseItemDto {
+  @ApiProperty({ enum: NotificationChannel })
+  channel: NotificationChannel;
+
+  @ApiProperty({ enum: NotificationEventType })
+  eventType: NotificationEventType;
+
+  @ApiProperty()
+  enabled: boolean;
+
+  @ApiPropertyOptional({ description: 'in_app channel is always enabled and cannot be disabled' })
+  readonly?: boolean;
+}
+
+export class NotificationPrefsResponseDto {
+  @ApiProperty({ type: [NotificationPrefResponseItemDto] })
+  preferences: NotificationPrefResponseItemDto[];
+}

--- a/backend/src/notifications/entities/notification-preference.entity.ts
+++ b/backend/src/notifications/entities/notification-preference.entity.ts
@@ -1,0 +1,58 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Unique,
+  Index,
+} from 'typeorm';
+import { Merchant } from '../../merchants/entities/merchant.entity';
+
+export enum NotificationChannel {
+  EMAIL = 'email',
+  PUSH = 'push',
+  IN_APP = 'in_app',
+}
+
+export enum NotificationEventType {
+  PAYMENT_CONFIRMED = 'payment.confirmed',
+  PAYMENT_SETTLED = 'payment.settled',
+  SETTLEMENT_FAILED = 'settlement.failed',
+}
+
+@Entity('notification_preferences')
+@Unique(['merchantId', 'channel', 'eventType'])
+@Index(['merchantId'])
+export class NotificationPreference {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'merchant_id' })
+  merchantId: string;
+
+  @ManyToOne(() => Merchant, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'merchant_id' })
+  merchant: Merchant;
+
+  @Column({ type: 'enum', enum: NotificationChannel })
+  channel: NotificationChannel;
+
+  @Column({ type: 'enum', enum: NotificationEventType })
+  eventType: NotificationEventType;
+
+  /**
+   * Whether this channel+event combination is enabled.
+   * in_app channel is always forced to true at the service layer.
+   */
+  @Column({ default: true })
+  enabled: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/notifications/notification-prefs.service.ts
+++ b/backend/src/notifications/notification-prefs.service.ts
@@ -1,0 +1,105 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  NotificationChannel,
+  NotificationEventType,
+  NotificationPreference,
+} from './entities/notification-preference.entity';
+import {
+  NotificationPrefResponseItemDto,
+  NotificationPrefsResponseDto,
+  UpdateNotificationPrefsDto,
+} from './dto/notification-prefs.dto';
+
+/** All valid channel × event combinations, used to seed defaults. */
+const ALL_CHANNELS = Object.values(NotificationChannel);
+const ALL_EVENTS = Object.values(NotificationEventType);
+
+@Injectable()
+export class NotificationPrefsService {
+  constructor(
+    @InjectRepository(NotificationPreference)
+    private readonly prefsRepo: Repository<NotificationPreference>,
+  ) {}
+
+  async getPrefs(merchantId: string): Promise<NotificationPrefsResponseDto> {
+    const stored = await this.prefsRepo.find({ where: { merchantId } });
+
+    // Build a full matrix, filling in defaults for any missing rows
+    const preferences: NotificationPrefResponseItemDto[] = [];
+
+    for (const channel of ALL_CHANNELS) {
+      for (const eventType of ALL_EVENTS) {
+        const existing = stored.find(
+          (p) => p.channel === channel && p.eventType === eventType,
+        );
+
+        const isInApp = channel === NotificationChannel.IN_APP;
+
+        preferences.push({
+          channel,
+          eventType,
+          // in_app is always enabled; fall back to true for unsaved rows
+          enabled: isInApp ? true : (existing?.enabled ?? true),
+          ...(isInApp ? { readonly: true } : {}),
+        });
+      }
+    }
+
+    return { preferences };
+  }
+
+  async updatePrefs(
+    merchantId: string,
+    dto: UpdateNotificationPrefsDto,
+  ): Promise<NotificationPrefsResponseDto> {
+    for (const item of dto.preferences) {
+      if (item.channel === NotificationChannel.IN_APP && !item.enabled) {
+        throw new BadRequestException(
+          'in_app notifications cannot be disabled',
+        );
+      }
+    }
+
+    // Upsert each preference using the unique constraint (merchantId, channel, eventType)
+    for (const item of dto.preferences) {
+      const isInApp = item.channel === NotificationChannel.IN_APP;
+      const enabled = isInApp ? true : item.enabled;
+
+      await this.prefsRepo
+        .createQueryBuilder()
+        .insert()
+        .into(NotificationPreference)
+        .values({
+          merchantId,
+          channel: item.channel,
+          eventType: item.eventType,
+          enabled,
+        })
+        .orUpdate(['enabled', 'updated_at'], ['merchant_id', 'channel', 'event_type'])
+        .execute();
+    }
+
+    return this.getPrefs(merchantId);
+  }
+
+  /**
+   * Utility used by other services to check whether a specific channel+event
+   * is enabled for a merchant before dispatching a notification.
+   */
+  async isEnabled(
+    merchantId: string,
+    channel: NotificationChannel,
+    eventType: NotificationEventType,
+  ): Promise<boolean> {
+    if (channel === NotificationChannel.IN_APP) return true;
+
+    const pref = await this.prefsRepo.findOne({
+      where: { merchantId, channel, eventType },
+    });
+
+    // Default to enabled if no preference row exists yet
+    return pref?.enabled ?? true;
+  }
+}

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -5,13 +5,14 @@ import { ConfigModule } from '@nestjs/config';
 import { NotificationsService } from './notifications.service';
 import { EmailProcessor } from './email.processor';
 import { EmailDeliveryLog } from './entities/email-delivery-log.entity';
+import { NotificationPreference } from './entities/notification-preference.entity';
 import { QueueConfigService } from '../config/queue-config.service';
 import { EMAIL_DELIVERY_QUEUE } from '../queue/queue.constants';
 
 @Module({
   imports: [
     ConfigModule,
-    TypeOrmModule.forFeature([EmailDeliveryLog]),
+    TypeOrmModule.forFeature([EmailDeliveryLog, NotificationPreference]),
     BullModule.registerQueue({ name: EMAIL_DELIVERY_QUEUE }),
   ],
   providers: [NotificationsService, EmailProcessor, QueueConfigService],

--- a/backend/src/settlements/settlements.module.ts
+++ b/backend/src/settlements/settlements.module.ts
@@ -8,6 +8,8 @@ import { Payment } from '../payments/entities/payment.entity';
 import { WebhooksModule } from '../webhooks/webhooks.module';
 import { PartnerSignatureGuard } from './guards/partner-signature.guard';
 import { CacheModule } from '../cache/cache.module';
+import { EmailModule } from '../email/email.module';
+import { MerchantsModule } from '../merchants/merchants.module';
 
 @Module({
   imports: [
@@ -15,6 +17,8 @@ import { CacheModule } from '../cache/cache.module';
     AdminAlertModule,
     WebhooksModule,
     CacheModule,
+    EmailModule,
+    MerchantsModule,
   ],
   controllers: [SettlementsController, PartnerCallbackController],
   providers: [SettlementsService, PartnerSignatureGuard],

--- a/backend/src/settlements/settlements.service.ts
+++ b/backend/src/settlements/settlements.service.ts
@@ -11,6 +11,10 @@ import { WebhooksService } from '../webhooks/webhooks.service';
 import { PaginatedResponseDto } from '../common/dto/pagination.dto';
 import { AdminSettlementsQueryDto } from './dto/admin-settlements-query.dto';
 import { CacheService } from '../cache/cache.service';
+import { EmailService } from '../email/email.service';
+import { MerchantsService } from '../merchants/merchants.service';
+import { NotificationPrefsService } from '../notifications/notification-prefs.service';
+import { NotificationChannel, NotificationEventType } from '../notifications/entities/notification-preference.entity';
 
 export interface PartnerCallbackPayload {
   reference: string;
@@ -31,6 +35,9 @@ export class SettlementsService {
     private webhooks: WebhooksService,
     private adminAlerts: AdminAlertService,
     private cache: CacheService,
+    private emailService: EmailService,
+    private merchantsService: MerchantsService,
+    private notificationPrefs: NotificationPrefsService,
   ) {}
 
   async initiateSettlement(payment: Payment): Promise<void> {
@@ -113,6 +120,17 @@ export class SettlementsService {
         settlementId: settlement.id,
         amount: settlement.netAmountUsd,
       });
+
+      await this.sendSettlementEmail(
+        settlement.merchantId,
+        NotificationEventType.PAYMENT_SETTLED,
+        'settlement-completed',
+        {
+          settlementId: settlement.id,
+          netAmountUsd: Number(settlement.netAmountUsd).toFixed(2),
+          paymentId: payment.id,
+        },
+      );
     } catch (err) {
       this.logger.error(`Settlement failed for ${settlement.id}`, err.message);
       await this.adminAlerts.raise({
@@ -137,6 +155,17 @@ export class SettlementsService {
         paymentId: payment.id,
         reason: err.message,
       });
+
+      await this.sendSettlementEmail(
+        settlement.merchantId,
+        NotificationEventType.SETTLEMENT_FAILED,
+        'payment-failed',
+        {
+          settlementId: settlement.id,
+          paymentId: payment.id,
+          reason: err.message,
+        },
+      );
     }
   }
 
@@ -183,6 +212,17 @@ export class SettlementsService {
           settlementId: settlement.id,
           amount: settlement.netAmountUsd,
         });
+
+        await this.sendSettlementEmail(
+          settlement.merchantId,
+          NotificationEventType.PAYMENT_SETTLED,
+          'settlement-completed',
+          {
+            settlementId: settlement.id,
+            netAmountUsd: Number(settlement.netAmountUsd).toFixed(2),
+            paymentId: payment.id,
+          },
+        );
       }
     } else {
       settlement.status = SettlementStatus.FAILED;
@@ -196,10 +236,45 @@ export class SettlementsService {
           paymentId: payment.id,
           reason: settlement.failureReason,
         });
+
+        await this.sendSettlementEmail(
+          settlement.merchantId,
+          NotificationEventType.SETTLEMENT_FAILED,
+          'payment-failed',
+          {
+            settlementId: settlement.id,
+            paymentId: payment.id,
+            reason: settlement.failureReason,
+          },
+        );
       }
     }
   }
-}
+
+  /**
+   * Sends an email for a settlement event only if the merchant has that
+   * channel+event combination enabled in their notification preferences.
+   */
+  private async sendSettlementEmail(
+    merchantId: string,
+    eventType: NotificationEventType,
+    templateAlias: string,
+    mergeData: Record<string, unknown>,
+  ): Promise<void> {
+    const emailEnabled = await this.notificationPrefs.isEnabled(
+      merchantId,
+      NotificationChannel.EMAIL,
+      eventType,
+    );
+    if (!emailEnabled) return;
+
+    try {
+      const merchant = await this.merchantsService.findOne(merchantId);
+      await this.emailService.queue(merchant.email, templateAlias, mergeData, merchantId);
+    } catch (err) {
+      this.logger.warn(`Failed to send settlement email for merchant ${merchantId}: ${err.message}`);
+    }
+  }
 
   // Admin methods
   async findAllAdmin(query: AdminSettlementsQueryDto) {

--- a/backend/src/stellar/stellar-monitor.service.ts
+++ b/backend/src/stellar/stellar-monitor.service.ts
@@ -13,6 +13,8 @@ import { WebhooksService } from '../webhooks/webhooks.service';
 import { EmailService } from '../email/email.service';
 import { ConfigService } from '@nestjs/config';
 import { Merchant } from '../merchants/entities/merchant.entity';
+import { NotificationPrefsService } from '../notifications/notification-prefs.service';
+import { NotificationChannel, NotificationEventType } from '../notifications/entities/notification-preference.entity';
 
 @Injectable()
 export class StellarMonitorService implements OnModuleInit {
@@ -28,6 +30,7 @@ export class StellarMonitorService implements OnModuleInit {
     private webhooks: WebhooksService,
     private emailService: EmailService,
     private config: ConfigService,
+    private notificationPrefs: NotificationPrefsService,
     @InjectQueue(QUEUE_NAMES.stellarMonitor) private monitorQueue: Queue,
   ) {}
 
@@ -133,9 +136,14 @@ export class StellarMonitorService implements OnModuleInit {
     asset: string,
   ): Promise<void> {
     const merchant = payment.merchant;
-    if (!merchant?.email || merchant.paymentConfirmedEmailEnabled === false) {
-      return;
-    }
+    if (!merchant?.email) return;
+
+    const emailEnabled = await this.notificationPrefs.isEnabled(
+      merchant.id,
+      NotificationChannel.EMAIL,
+      NotificationEventType.PAYMENT_CONFIRMED,
+    );
+    if (!emailEnabled) return;
 
     const frontendUrl = this.config.get<string>('FRONTEND_URL', 'http://localhost:3000');
     const paymentDetailUrl = `${frontendUrl.replace(/\/$/, '')}/pay/${payment.reference}`;

--- a/backend/src/stellar/stellar.module.ts
+++ b/backend/src/stellar/stellar.module.ts
@@ -9,6 +9,7 @@ import { SettlementsModule } from '../settlements/settlements.module';
 import { WebhooksModule } from '../webhooks/webhooks.module';
 import { QUEUE_NAMES } from '../queues/queue.constants';
 import { EmailModule } from '../email/email.module';
+import { MerchantsModule } from '../merchants/merchants.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { EmailModule } from '../email/email.module';
     forwardRef(() => SettlementsModule),
     WebhooksModule,
     EmailModule,
+    MerchantsModule,
     BullModule.registerQueue({ name: QUEUE_NAMES.stellarMonitor }),
   ],
   providers: [StellarService, StellarMonitorService],

--- a/grafana/provisioning/alerting/uptime-alerts.yaml
+++ b/grafana/provisioning/alerting/uptime-alerts.yaml
@@ -1,0 +1,179 @@
+apiVersion: 1
+
+# ─── Contact Points ────────────────────────────────────────────────────────────
+# These are provisioned as defaults. Override credentials via Grafana UI or
+# environment variable substitution if your Grafana version supports it.
+contactPoints:
+  - orgId: 1
+    name: CheesePay On-Call
+    receivers:
+      - uid: "oncall-email"
+        type: email
+        settings:
+          addresses: "oncall@cheesepay.xyz"
+          singleEmail: false
+        disableResolveMessage: false
+
+      - uid: "oncall-slack"
+        type: slack
+        settings:
+          url: "${GRAFANA_SLACK_WEBHOOK_URL}"
+          channel: "#alerts"
+          title: |
+            {{ if eq .Status "firing" }}🔴 CheesePay Alert{{ else }}✅ CheesePay Resolved{{ end }}
+          text: |
+            {{ range .Alerts }}
+            *{{ .Annotations.summary }}*
+            {{ .Annotations.description }}
+            {{ end }}
+        disableResolveMessage: false
+
+# ─── Notification Policies ────────────────────────────────────────────────────
+policies:
+  - orgId: 1
+    receiver: CheesePay On-Call
+    group_by: ["alertname", "severity"]
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 1h
+    routes:
+      - receiver: CheesePay On-Call
+        matchers:
+          - severity = critical
+        group_wait: 0s          # fire immediately for critical
+        repeat_interval: 15m
+
+# ─── Alert Rules ──────────────────────────────────────────────────────────────
+rules:
+  - orgId: 1
+    name: UptimeAlerts
+    folder: "Uptime & Availability"
+    interval: 1m
+    rules:
+
+      # ── High error rate (proxy for downtime in logs) ──────────────────────
+      - uid: "uptime-error-rate"
+        title: "API High Error Rate"
+        condition: "A"
+        data:
+          - refId: "A"
+            queryType: "range"
+            datasourceUid: "Loki"
+            relativeTimeRange:
+              from: 120
+              to: 0
+            model:
+              refId: "A"
+              expr: 'sum(rate({job="backend-logs", level="error"}[2m])) * 60 > 5'
+        noDataState: OK
+        execErrState: Alerting
+        for: 2m
+        annotations:
+          summary: "High API error rate detected"
+          description: "More than 5 errors/min for 2 consecutive minutes. Value: {{ $values.A.Value | printf \"%.1f\" }} errors/min. Check logs immediately."
+          runbook_url: "https://github.com/cheesepay/dabdub/blob/main/monitoring/README.md"
+        labels:
+          severity: "critical"
+          component: "api"
+
+      # ── Health endpoint returning errors ──────────────────────────────────
+      - uid: "uptime-health-errors"
+        title: "Health Endpoint Errors"
+        condition: "A"
+        data:
+          - refId: "A"
+            queryType: "range"
+            datasourceUid: "Loki"
+            relativeTimeRange:
+              from: 120
+              to: 0
+            model:
+              refId: "A"
+              # Alert if /health or /health/ready logs errors
+              expr: 'count_over_time({job="backend-logs", level="error"} |= "/health" [2m]) > 3'
+        noDataState: OK
+        execErrState: Alerting
+        for: 1m
+        annotations:
+          summary: "Health endpoint is returning errors"
+          description: "The /health or /health/ready endpoint has logged errors in the last 2 minutes. This may indicate DB or Stellar connectivity issues."
+          runbook_url: "https://github.com/cheesepay/dabdub/blob/main/monitoring/README.md"
+        labels:
+          severity: "critical"
+          component: "health"
+
+      # ── No logs at all (process may be down) ─────────────────────────────
+      - uid: "uptime-no-logs"
+        title: "API Process Silent (Possible Crash)"
+        condition: "A"
+        data:
+          - refId: "A"
+            queryType: "range"
+            datasourceUid: "Loki"
+            relativeTimeRange:
+              from: 300
+              to: 0
+            model:
+              refId: "A"
+              # If no logs at all for 5 minutes, the process is likely down
+              expr: 'sum(count_over_time({job="backend-logs"}[5m])) == 0'
+        noDataState: Alerting   # no data itself is the alert condition
+        execErrState: Alerting
+        for: 5m
+        annotations:
+          summary: "No API logs for 5 minutes — process may be down"
+          description: "The backend has emitted zero log lines in the last 5 minutes. This strongly suggests the process has crashed or the log pipeline is broken."
+          runbook_url: "https://github.com/cheesepay/dabdub/blob/main/monitoring/README.md"
+        labels:
+          severity: "critical"
+          component: "api"
+
+      # ── Queue stalled ─────────────────────────────────────────────────────
+      - uid: "uptime-queue-stalled"
+        title: "Queue Processing Stalled"
+        condition: "A"
+        data:
+          - refId: "A"
+            queryType: "range"
+            datasourceUid: "Loki"
+            relativeTimeRange:
+              from: 120
+              to: 0
+            model:
+              refId: "A"
+              expr: 'count_over_time({job="backend-logs"} |= "processing rate dropped to zero" [2m]) > 0'
+        noDataState: OK
+        execErrState: OK
+        for: 0s
+        annotations:
+          summary: "Queue processing has stalled"
+          description: "A Bull queue has stopped processing jobs. Settlement or webhook delivery may be delayed."
+          runbook_url: "https://github.com/cheesepay/dabdub/blob/main/monitoring/README.md"
+        labels:
+          severity: "warning"
+          component: "queue"
+
+      # ── Stellar monitor failures ──────────────────────────────────────────
+      - uid: "uptime-stellar-down"
+        title: "Stellar / Horizon Connectivity Lost"
+        condition: "A"
+        data:
+          - refId: "A"
+            queryType: "range"
+            datasourceUid: "Loki"
+            relativeTimeRange:
+              from: 120
+              to: 0
+            model:
+              refId: "A"
+              expr: 'count_over_time({job="backend-logs", level="error"} |= "stellar" [2m]) > 2'
+        noDataState: OK
+        execErrState: OK
+        for: 2m
+        annotations:
+          summary: "Stellar Horizon connectivity issues"
+          description: "Multiple Stellar-related errors in the last 2 minutes. Blockchain settlement may be impacted."
+          runbook_url: "https://github.com/cheesepay/dabdub/blob/main/monitoring/README.md"
+        labels:
+          severity: "critical"
+          component: "stellar"

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,53 @@
+# CheesePay Uptime Monitoring
+
+External uptime monitoring for `api.cheesepay.xyz` and Stellar Horizon connectivity.
+Alerts fire within **2 minutes** of downtime; on-call is notified within **5 minutes**.
+
+---
+
+## Architecture
+
+```
+Internet
+  │
+  ├── UptimeRobot (primary, 1-min polling)
+  │     ├── Monitor: GET https://api.cheesepay.xyz/health          → email + Slack
+  │     ├── Monitor: GET https://api.cheesepay.xyz/health/ready    → email + Slack
+  │     └── Status page: status.cheesepay.xyz (public)
+  │
+  └── Better Uptime (secondary / on-call escalation, 30-sec polling)
+        ├── Monitor: GET https://api.cheesepay.xyz/health
+        ├── Monitor: GET https://api.cheesepay.xyz/health/ready    (checks Stellar Horizon)
+        └── On-call rotation → PagerDuty / phone call within 5 min
+```
+
+The `/health` endpoint returns `{ "status": "ok" }` (always 200 while the process is alive).
+The `/health/ready` endpoint checks **PostgreSQL + Stellar Horizon** and returns 503 if either is down — this is the critical monitor.
+
+---
+
+## Monitors to Configure
+
+| Monitor | URL | Method | Expected Status | Interval | Alert |
+|---------|-----|--------|----------------|----------|-------|
+| API Liveness | `https://api.cheesepay.xyz/health` | GET | 200 | 1 min | Email + Slack |
+| API Readiness (DB + Stellar) | `https://api.cheesepay.xyz/health/ready` | GET | 200 | 1 min | Email + Slack + PagerDuty |
+| Stellar Horizon | `https://horizon.stellar.org/` | GET | 200 | 5 min | Slack |
+
+---
+
+## Setup Guides
+
+- [UptimeRobot Setup](./uptimerobot.md)
+- [Better Uptime Setup](./better-uptime.md)
+- [Status Page](./statuspage/README.md)
+
+---
+
+## Acceptance Criteria Verification
+
+| Criterion | How it's met |
+|-----------|-------------|
+| Downtime detected within 2 min | UptimeRobot 1-min interval + Better Uptime 30-sec interval |
+| On-call alerted within 5 min | Better Uptime phone/SMS escalation after 1 failed check |
+| Status page shows real-time component status | `status.cheesepay.xyz` polls `/health/admin` every 60s |

--- a/monitoring/better-uptime.md
+++ b/monitoring/better-uptime.md
@@ -1,0 +1,177 @@
+# Better Uptime Configuration
+
+Better Uptime is the **secondary monitor and on-call escalation layer**. It polls every **30 seconds** from multiple regions and supports phone call / SMS escalation — ensuring on-call is reached within 5 minutes of an incident.
+
+---
+
+## 1. Create an Account
+
+Sign up at https://betteruptime.com. The "Basic" plan supports 30-second check intervals and on-call scheduling.
+
+---
+
+## 2. Configure On-Call Schedules
+
+### Create On-Call Calendar
+
+1. Go to **On-call** → **Schedules** → **New Schedule**
+2. Name: `CheesePay On-Call`
+3. Add team members with their phone numbers (for SMS/call escalation)
+4. Set rotation: weekly or follow-the-sun as appropriate
+5. Save
+
+### Escalation Policy
+
+1. **On-call** → **Escalation Policies** → **New Policy**
+2. Name: `CheesePay Escalation`
+3. Steps:
+   - Step 1 (0 min): Notify on-call via **SMS + Phone call**
+   - Step 2 (5 min): Notify backup on-call via **SMS + Phone call**
+   - Step 3 (10 min): Notify `#oncall` Slack channel
+4. Save
+
+---
+
+## 3. Add Monitors
+
+### Monitor 1 — API Liveness
+
+| Field | Value |
+|-------|-------|
+| URL | `https://api.cheesepay.xyz/health` |
+| Name | `CheesePay API Liveness` |
+| Check Frequency | **30 seconds** |
+| Request Timeout | 15 seconds |
+| Expected Status Code | 200 |
+| Confirmation Period | 0 (alert immediately on first failure) |
+| Regions | US East, EU West, Asia Pacific (multi-region) |
+| Escalation Policy | CheesePay Escalation |
+
+### Monitor 2 — API Readiness (DB + Stellar)
+
+| Field | Value |
+|-------|-------|
+| URL | `https://api.cheesepay.xyz/health/ready` |
+| Name | `CheesePay API Readiness` |
+| Check Frequency | **30 seconds** |
+| Request Timeout | 15 seconds |
+| Expected Status Code | 200 |
+| Confirmation Period | 0 |
+| Regions | US East, EU West, Asia Pacific |
+| Escalation Policy | CheesePay Escalation |
+
+**Advanced → Response Validation:**
+- Check that response body contains `"status":"up"` (Terminus format)
+
+### Monitor 3 — Stellar Horizon Connectivity
+
+| Field | Value |
+|-------|-------|
+| URL | `https://horizon.stellar.org/` |
+| Name | `Stellar Horizon` |
+| Check Frequency | 1 minute |
+| Expected Status Code | 200 |
+| Confirmation Period | 1 check |
+| Escalation Policy | CheesePay Escalation (Slack only) |
+
+---
+
+## 4. Slack Integration
+
+1. **Integrations** → **Slack** → **Connect**
+2. Authorize Better Uptime to your workspace
+3. Select channel: `#alerts`
+4. Enable: Down alerts, Up alerts, Incident created, Incident resolved
+
+---
+
+## 5. PagerDuty Integration (Optional)
+
+If you use PagerDuty for on-call:
+
+1. **Integrations** → **PagerDuty** → **Connect**
+2. Enter your PagerDuty API key
+3. Select the service to route incidents to
+4. Map Better Uptime escalation policy → PagerDuty service
+
+---
+
+## 6. Status Page
+
+Better Uptime also provides a hosted status page as an alternative to UptimeRobot's.
+
+1. **Status Pages** → **New Status Page**
+2. Name: `CheesePay Status`
+3. Custom Domain: `status.cheesepay.xyz`
+4. Add monitors: API Liveness, API Readiness, Stellar Horizon
+5. Group them:
+   - **API**: Liveness, Readiness
+   - **Infrastructure**: Stellar Horizon
+6. Enable subscriber notifications (email)
+
+### DNS
+
+```
+status.cheesepay.xyz  CNAME  statuspage.betteruptime.com
+```
+
+---
+
+## 7. Incident Workflow
+
+When `/health/ready` returns 503:
+
+1. Better Uptime detects failure at T+0s (30-sec poll)
+2. Confirmation: immediate (0 confirmation period)
+3. Incident created at T+30s
+4. SMS + phone call to on-call at T+30s
+5. If no acknowledgement in 5 min → escalate to backup
+6. Slack `#alerts` notified at T+30s
+7. Status page updated automatically
+
+This satisfies:
+- ✅ Downtime detected within 2 minutes (30-sec polling)
+- ✅ On-call alerted within 5 minutes (immediate phone call)
+
+---
+
+## 8. Heartbeat Monitor (Optional but Recommended)
+
+Add a heartbeat to verify the app is actively running cron jobs:
+
+1. **Heartbeats** → **New Heartbeat**
+2. Name: `CheesePay Cron Health`
+3. Period: 5 minutes, Grace: 2 minutes
+4. Copy the heartbeat URL
+
+Then add a cron job in the NestJS app to ping it every 5 minutes (see `backend/src/cron/` for the cron infrastructure).
+
+```typescript
+// In a cron service
+@Cron('*/5 * * * *')
+async pingHeartbeat(): Promise<void> {
+  const url = this.config.get<string>('BETTER_UPTIME_HEARTBEAT_URL');
+  if (url) await axios.get(url).catch(() => {});
+}
+```
+
+---
+
+## Environment Variables
+
+```bash
+# Better Uptime
+BETTER_UPTIME_API_TOKEN=your_better_uptime_api_token
+BETTER_UPTIME_HEARTBEAT_URL=https://betteruptime.com/api/v1/heartbeat/xxxxx
+```
+
+---
+
+## Verification Checklist
+
+- [ ] Both API monitors show green
+- [ ] On-call schedule has at least one person assigned
+- [ ] Escalation policy tested: pause monitor → confirm phone call within 5 min
+- [ ] Slack integration sends to `#alerts`
+- [ ] Status page accessible at `status.cheesepay.xyz`
+- [ ] Heartbeat monitor receiving pings (if configured)

--- a/monitoring/statuspage/README.md
+++ b/monitoring/statuspage/README.md
@@ -1,0 +1,85 @@
+# Status Page — status.cheesepay.xyz
+
+Self-hosted status page deployed as a **Cloudflare Worker**. It:
+
+1. Serves `index.html` at `status.cheesepay.xyz`
+2. Proxies `GET /api/status` → `https://api.cheesepay.xyz/health/admin` (avoids CORS, adds 30s edge cache)
+3. The HTML polls `/api/status` every 60 seconds and renders real-time component status
+
+---
+
+## Prerequisites
+
+- [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/) installed
+- Cloudflare account with `cheesepay.xyz` zone added
+- `wrangler login` completed
+
+---
+
+## Deploy
+
+```bash
+cd monitoring/statuspage
+
+# Install wrangler if needed
+npm install -g wrangler
+
+# Authenticate
+wrangler login
+
+# Set your Cloudflare account ID in wrangler.toml
+# account_id = "YOUR_CLOUDFLARE_ACCOUNT_ID"
+
+# Deploy to production
+wrangler deploy
+```
+
+The worker will be live at `status.cheesepay.xyz` within seconds.
+
+---
+
+## DNS
+
+Cloudflare Workers with a custom route handle DNS automatically when the zone is on Cloudflare (orange-cloud proxy). No additional CNAME needed.
+
+If the zone is NOT on Cloudflare, add:
+```
+status.cheesepay.xyz  CNAME  cheesepay-status.YOUR_SUBDOMAIN.workers.dev
+```
+
+---
+
+## Local Development
+
+```bash
+wrangler dev
+# Opens http://localhost:8787
+```
+
+Note: In local dev, `STATUS_HTML` text blob may not load — the worker falls back to a placeholder. Test the full flow after deploying.
+
+---
+
+## What the Status Page Shows
+
+| Component | Source field | Critical? |
+|-----------|-------------|-----------|
+| Database | `components.database` | Yes — 503 if down |
+| Stellar / Horizon | `components.stellar` | Yes — 503 if down |
+| Partner API | `components.partnerApi` | No — degraded only |
+| Redis / Queue | `components.redis` | No — degraded only |
+| Background Jobs | `components.queue` | No — degraded only |
+
+Data comes from `GET /health/admin` which is defined in `backend/src/health/health.controller.ts`.
+
+---
+
+## Updating the Status Page
+
+Edit `index.html` and redeploy:
+
+```bash
+wrangler deploy
+```
+
+Changes are live globally within ~30 seconds.

--- a/monitoring/statuspage/index.html
+++ b/monitoring/statuspage/index.html
@@ -1,0 +1,416 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CheesePay Status</title>
+  <meta name="description" content="Real-time status of CheesePay platform components" />
+  <style>
+    :root {
+      --green:  #22c55e;
+      --yellow: #f59e0b;
+      --red:    #ef4444;
+      --gray:   #6b7280;
+      --bg:     #0f172a;
+      --surface:#1e293b;
+      --border: #334155;
+      --text:   #f1f5f9;
+      --muted:  #94a3b8;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      padding: 2rem 1rem;
+    }
+
+    .container { max-width: 720px; margin: 0 auto; }
+
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 2.5rem;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+
+    .logo {
+      font-size: 1.4rem;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+
+    .logo span { color: var(--green); }
+
+    .overall-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.4rem 1rem;
+      border-radius: 9999px;
+      font-size: 0.875rem;
+      font-weight: 600;
+      border: 1px solid transparent;
+      transition: background 0.3s, color 0.3s;
+    }
+
+    .overall-badge.healthy  { background: rgba(34,197,94,0.15);  color: var(--green);  border-color: rgba(34,197,94,0.3); }
+    .overall-badge.degraded { background: rgba(245,158,11,0.15); color: var(--yellow); border-color: rgba(245,158,11,0.3); }
+    .overall-badge.down     { background: rgba(239,68,68,0.15);  color: var(--red);    border-color: rgba(239,68,68,0.3); }
+    .overall-badge.loading  { background: rgba(107,114,128,0.15);color: var(--muted);  border-color: rgba(107,114,128,0.3); }
+
+    .dot {
+      width: 8px; height: 8px;
+      border-radius: 50%;
+      background: currentColor;
+    }
+
+    .dot.pulse { animation: pulse 2s infinite; }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50%       { opacity: 0.4; }
+    }
+
+    .section-title {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+      margin-bottom: 0.75rem;
+    }
+
+    .components-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      overflow: hidden;
+      margin-bottom: 2rem;
+    }
+
+    .component-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1rem 1.25rem;
+      border-bottom: 1px solid var(--border);
+      transition: background 0.15s;
+    }
+
+    .component-row:last-child { border-bottom: none; }
+    .component-row:hover { background: rgba(255,255,255,0.03); }
+
+    .component-name {
+      font-size: 0.9375rem;
+      font-weight: 500;
+    }
+
+    .component-meta {
+      font-size: 0.75rem;
+      color: var(--muted);
+      margin-top: 0.2rem;
+    }
+
+    .component-status {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.8125rem;
+      font-weight: 600;
+    }
+
+    .status-ok       { color: var(--green); }
+    .status-degraded { color: var(--yellow); }
+    .status-down     { color: var(--red); }
+    .status-unknown  { color: var(--muted); }
+
+    .status-indicator {
+      width: 10px; height: 10px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+
+    .status-indicator.ok       { background: var(--green); }
+    .status-indicator.degraded { background: var(--yellow); animation: pulse 2s infinite; }
+    .status-indicator.down     { background: var(--red);    animation: pulse 1s infinite; }
+    .status-indicator.unknown  { background: var(--muted); }
+
+    .meta-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-size: 0.8125rem;
+      color: var(--muted);
+      margin-bottom: 2rem;
+    }
+
+    .refresh-btn {
+      background: none;
+      border: 1px solid var(--border);
+      color: var(--muted);
+      padding: 0.3rem 0.75rem;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.8125rem;
+      transition: border-color 0.15s, color 0.15s;
+    }
+
+    .refresh-btn:hover { border-color: var(--text); color: var(--text); }
+
+    .incident-banner {
+      background: rgba(239,68,68,0.1);
+      border: 1px solid rgba(239,68,68,0.3);
+      border-radius: 10px;
+      padding: 1rem 1.25rem;
+      margin-bottom: 2rem;
+      display: none;
+    }
+
+    .incident-banner.visible { display: block; }
+
+    .incident-banner h3 {
+      color: var(--red);
+      font-size: 0.9375rem;
+      margin-bottom: 0.25rem;
+    }
+
+    .incident-banner p {
+      color: var(--muted);
+      font-size: 0.8125rem;
+    }
+
+    footer {
+      text-align: center;
+      color: var(--muted);
+      font-size: 0.8125rem;
+      margin-top: 3rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--border);
+    }
+
+    footer a { color: var(--muted); text-decoration: none; }
+    footer a:hover { color: var(--text); }
+
+    .skeleton {
+      background: linear-gradient(90deg, var(--border) 25%, var(--surface) 50%, var(--border) 75%);
+      background-size: 200% 100%;
+      animation: shimmer 1.5s infinite;
+      border-radius: 4px;
+      height: 14px;
+    }
+
+    @keyframes shimmer {
+      0%   { background-position: 200% 0; }
+      100% { background-position: -200% 0; }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <div class="logo">Cheese<span>Pay</span> Status</div>
+      <div id="overall-badge" class="overall-badge loading">
+        <span class="dot pulse"></span>
+        <span id="overall-text">Checking…</span>
+      </div>
+    </header>
+
+    <div id="incident-banner" class="incident-banner">
+      <h3>⚠️ Active Incident</h3>
+      <p id="incident-text"></p>
+    </div>
+
+    <p class="section-title">Components</p>
+
+    <div class="components-card" id="components-card">
+      <!-- Skeleton rows while loading -->
+      <div class="component-row">
+        <div><div class="skeleton" style="width:140px"></div></div>
+        <div class="skeleton" style="width:60px"></div>
+      </div>
+      <div class="component-row">
+        <div><div class="skeleton" style="width:100px"></div></div>
+        <div class="skeleton" style="width:60px"></div>
+      </div>
+      <div class="component-row">
+        <div><div class="skeleton" style="width:120px"></div></div>
+        <div class="skeleton" style="width:60px"></div>
+      </div>
+      <div class="component-row">
+        <div><div class="skeleton" style="width:80px"></div></div>
+        <div class="skeleton" style="width:60px"></div>
+      </div>
+      <div class="component-row">
+        <div><div class="skeleton" style="width:110px"></div></div>
+        <div class="skeleton" style="width:60px"></div>
+      </div>
+    </div>
+
+    <div class="meta-row">
+      <span id="last-updated">Last checked: —</span>
+      <button class="refresh-btn" onclick="fetchStatus()">↻ Refresh</button>
+    </div>
+
+    <footer>
+      <p>
+        <a href="https://cheesepay.xyz">cheesepay.xyz</a> ·
+        <a href="mailto:support@cheesepay.xyz">support@cheesepay.xyz</a>
+      </p>
+      <p style="margin-top:0.5rem">Auto-refreshes every 60 seconds</p>
+    </footer>
+  </div>
+
+  <script>
+    // ─── Config ────────────────────────────────────────────────────────────────
+    // In production this is served by the Cloudflare Worker which proxies
+    // /health/admin and injects the response. For direct hosting, set this to
+    // your API base URL (must have CORS enabled for status.cheesepay.xyz).
+    const API_BASE = window.__API_BASE__ || 'https://api.cheesepay.xyz';
+    const POLL_INTERVAL_MS = 60_000;
+
+    // ─── Component display config ──────────────────────────────────────────────
+    const COMPONENT_META = {
+      database:   { label: 'Database',          description: 'PostgreSQL — primary data store' },
+      stellar:    { label: 'Stellar / Horizon',  description: 'Blockchain settlement layer' },
+      partnerApi: { label: 'Partner API',        description: 'Fiat settlement provider' },
+      redis:      { label: 'Redis / Queue',      description: 'Job queue & caching layer' },
+      queue:      { label: 'Background Jobs',    description: 'Settlement & webhook processors' },
+    };
+
+    // ─── State ─────────────────────────────────────────────────────────────────
+    let lastStatus = null;
+
+    // ─── Helpers ───────────────────────────────────────────────────────────────
+    function statusLabel(s) {
+      return { ok: 'Operational', degraded: 'Degraded', down: 'Outage' }[s] ?? 'Unknown';
+    }
+
+    function statusClass(s) {
+      return { ok: 'ok', degraded: 'degraded', down: 'down' }[s] ?? 'unknown';
+    }
+
+    function overallLabel(s) {
+      return {
+        healthy:  'All Systems Operational',
+        degraded: 'Partial Outage',
+        down:     'Major Outage',
+      }[s] ?? 'Checking…';
+    }
+
+    function formatTime(iso) {
+      try {
+        return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+      } catch { return iso; }
+    }
+
+    // ─── Render ────────────────────────────────────────────────────────────────
+    function render(data) {
+      // Overall badge
+      const badge = document.getElementById('overall-badge');
+      const text  = document.getElementById('overall-text');
+      badge.className = `overall-badge ${data.status}`;
+      text.textContent = overallLabel(data.status);
+
+      // Incident banner
+      const banner = document.getElementById('incident-banner');
+      const incidentText = document.getElementById('incident-text');
+      if (data.status === 'down' || data.status === 'degraded') {
+        const downComponents = Object.entries(data.components || {})
+          .filter(([, v]) => v.status !== 'ok')
+          .map(([k]) => COMPONENT_META[k]?.label ?? k)
+          .join(', ');
+        incidentText.textContent = `Affected components: ${downComponents}. Our team has been alerted and is investigating.`;
+        banner.classList.add('visible');
+      } else {
+        banner.classList.remove('visible');
+      }
+
+      // Component rows
+      const card = document.getElementById('components-card');
+      const components = data.components || {};
+      const order = ['database', 'stellar', 'partnerApi', 'redis', 'queue'];
+
+      card.innerHTML = order.map(key => {
+        const comp = components[key];
+        if (!comp) return '';
+        const meta = COMPONENT_META[key] || { label: key, description: '' };
+        const sc   = statusClass(comp.status);
+        const latencyText = comp.latency != null ? `${comp.latency}ms` : '';
+
+        return `
+          <div class="component-row">
+            <div>
+              <div class="component-name">${meta.label}</div>
+              <div class="component-meta">${meta.description}${latencyText ? ` · ${latencyText}` : ''}</div>
+            </div>
+            <div class="component-status status-${sc}">
+              <div class="status-indicator ${sc}"></div>
+              ${statusLabel(comp.status)}
+            </div>
+          </div>
+        `;
+      }).join('');
+
+      // Last updated
+      document.getElementById('last-updated').textContent =
+        `Last checked: ${formatTime(data.timestamp || new Date().toISOString())}`;
+    }
+
+    function renderError() {
+      const badge = document.getElementById('overall-badge');
+      const text  = document.getElementById('overall-text');
+      badge.className = 'overall-badge down';
+      text.textContent = 'Status Unavailable';
+
+      const card = document.getElementById('components-card');
+      card.innerHTML = `
+        <div class="component-row">
+          <div class="component-name" style="color:var(--muted)">
+            Unable to reach the status API. This may indicate a network issue or a major outage.
+          </div>
+        </div>
+      `;
+
+      document.getElementById('last-updated').textContent =
+        `Last attempted: ${new Date().toLocaleTimeString()}`;
+    }
+
+    // ─── Fetch ─────────────────────────────────────────────────────────────────
+    async function fetchStatus() {
+      try {
+        const res = await fetch(`${API_BASE}/health/admin`, {
+          headers: { 'Accept': 'application/json' },
+          // 10-second timeout
+          signal: AbortSignal.timeout(10_000),
+        });
+
+        // /health/admin returns 503 when critical components are down,
+        // but still returns a valid JSON body — parse it regardless.
+        const data = await res.json();
+        lastStatus = data;
+        render(data);
+      } catch (err) {
+        console.error('[status-page] fetch failed:', err);
+        // If we have a cached status, keep showing it with a stale indicator
+        if (lastStatus) {
+          render(lastStatus);
+          document.getElementById('last-updated').textContent +=
+            ' (stale — refresh failed)';
+        } else {
+          renderError();
+        }
+      }
+    }
+
+    // ─── Boot ──────────────────────────────────────────────────────────────────
+    fetchStatus();
+    setInterval(fetchStatus, POLL_INTERVAL_MS);
+  </script>
+</body>
+</html>

--- a/monitoring/statuspage/worker.js
+++ b/monitoring/statuspage/worker.js
@@ -1,0 +1,135 @@
+/**
+ * Cloudflare Worker — status.cheesepay.xyz
+ *
+ * Routes:
+ *   GET /          → serves the status page HTML (with API_BASE injected)
+ *   GET /api/status → proxies GET https://api.cheesepay.xyz/health/admin
+ *                     (avoids CORS issues; adds cache-control)
+ *
+ * Deploy:
+ *   wrangler deploy
+ *
+ * Environment variables (set in wrangler.toml or Cloudflare dashboard):
+ *   API_ORIGIN  = https://api.cheesepay.xyz   (no trailing slash)
+ */
+
+// ─── HTML is inlined at build time via wrangler's text_blobs or fetched ───────
+// For simplicity we import it as a string. In wrangler.toml add:
+//   [text_blobs]
+//   STATUS_HTML = "index.html"
+// Then reference it as STATUS_HTML below.
+// If you prefer, replace with a fetch to your CDN.
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    // ── Proxy: /api/status → upstream /health/admin ──────────────────────────
+    if (url.pathname === '/api/status') {
+      return proxyHealthAdmin(env);
+    }
+
+    // ── Status page HTML ──────────────────────────────────────────────────────
+    if (url.pathname === '/' || url.pathname === '/index.html') {
+      return serveStatusPage(env);
+    }
+
+    // ── Favicon (prevent 404 noise) ───────────────────────────────────────────
+    if (url.pathname === '/favicon.ico') {
+      return new Response(null, { status: 204 });
+    }
+
+    return new Response('Not found', { status: 404 });
+  },
+};
+
+// ─── Proxy /health/admin ──────────────────────────────────────────────────────
+async function proxyHealthAdmin(env) {
+  const apiOrigin = env.API_ORIGIN ?? 'https://api.cheesepay.xyz';
+
+  let upstreamRes;
+  try {
+    upstreamRes = await fetch(`${apiOrigin}/health/admin`, {
+      headers: { Accept: 'application/json' },
+      // Cloudflare fetch timeout is 30s by default
+    });
+  } catch (err) {
+    // Network-level failure — API is unreachable
+    return jsonResponse(
+      {
+        status: 'down',
+        timestamp: new Date().toISOString(),
+        components: {
+          database:   { status: 'down', latency: 0 },
+          stellar:    { status: 'down', latency: 0 },
+          partnerApi: { status: 'down', latency: 0 },
+          redis:      { status: 'down', latency: 0 },
+          queue:      { status: 'down', latency: 0 },
+        },
+        error: 'API unreachable',
+      },
+      503,
+    );
+  }
+
+  // Parse body regardless of status code (/health/admin returns 503 with body
+  // when critical components are down)
+  let body;
+  try {
+    body = await upstreamRes.json();
+  } catch {
+    body = { status: 'down', timestamp: new Date().toISOString(), error: 'Invalid response' };
+  }
+
+  return jsonResponse(body, upstreamRes.status, {
+    // Cache for 30 seconds at the edge — status page polls every 60s so this
+    // halves upstream load while keeping data fresh enough.
+    'Cache-Control': 'public, max-age=30, s-maxage=30',
+  });
+}
+
+// ─── Serve status page HTML ───────────────────────────────────────────────────
+async function serveStatusPage(env) {
+  // STATUS_HTML is bound as a text blob in wrangler.toml.
+  // Fallback: fetch from the same worker's origin (useful in local dev).
+  const html = typeof STATUS_HTML !== 'undefined'
+    ? STATUS_HTML
+    : await fetchFallbackHtml();
+
+  // Inject the API base so the page calls /api/status (this worker's proxy)
+  // instead of the real API directly — avoids CORS entirely.
+  const injected = html.replace(
+    "window.__API_BASE__ || 'https://api.cheesepay.xyz'",
+    "window.__API_BASE__ || ''",  // empty string → relative URL /api/status
+  ).replace(
+    "`${API_BASE}/health/admin`",
+    "`${API_BASE}/api/status`",
+  );
+
+  return new Response(injected, {
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'public, max-age=60',
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'Referrer-Policy': 'strict-origin-when-cross-origin',
+    },
+  });
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+function jsonResponse(body, status = 200, extraHeaders = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+      ...extraHeaders,
+    },
+  });
+}
+
+async function fetchFallbackHtml() {
+  // Only used in local wrangler dev when text_blobs aren't available
+  return '<html><body>Status page loading...</body></html>';
+}

--- a/monitoring/statuspage/wrangler.toml
+++ b/monitoring/statuspage/wrangler.toml
@@ -1,0 +1,21 @@
+name            = "cheesepay-status"
+main            = "worker.js"
+compatibility_date = "2024-01-01"
+account_id      = "YOUR_CLOUDFLARE_ACCOUNT_ID"
+
+# Serve status.cheesepay.xyz
+routes = [
+  { pattern = "status.cheesepay.xyz/*", zone_name = "cheesepay.xyz" }
+]
+
+# Inline the HTML at deploy time — no external fetch needed
+[text_blobs]
+STATUS_HTML = "index.html"
+
+# Environment variables
+[vars]
+API_ORIGIN = "https://api.cheesepay.xyz"
+
+# Production environment overrides (if needed)
+[env.production]
+vars = { API_ORIGIN = "https://api.cheesepay.xyz" }

--- a/monitoring/uptimerobot.md
+++ b/monitoring/uptimerobot.md
@@ -1,0 +1,175 @@
+# UptimeRobot Configuration
+
+UptimeRobot is the **primary** external monitor. It polls from multiple global locations every **1 minute** — satisfying the "detected within 2 minutes" requirement.
+
+---
+
+## 1. Create an Account
+
+Sign up at https://uptimerobot.com (free tier supports up to 50 monitors at 5-min intervals; paid "Pro" plan gives 1-min intervals — required here).
+
+---
+
+## 2. Create Alert Contacts
+
+Before adding monitors, set up where alerts go.
+
+### Email Alert Contact
+
+1. Go to **My Settings → Alert Contacts → Add Alert Contact**
+2. Type: **E-mail**
+3. Friendly Name: `CheesePay On-Call`
+4. E-mail: `oncall@cheesepay.xyz` (or your PagerDuty email integration address)
+5. Save
+
+### Slack Alert Contact
+
+1. Add Alert Contact → Type: **Slack**
+2. Friendly Name: `CheesePay #alerts`
+3. Webhook URL: `$SLACK_WEBHOOK_URL` (see [Slack Webhook Setup](#slack-webhook-setup) below)
+4. Save
+
+---
+
+## 3. Add Monitors
+
+### Monitor 1 — API Liveness
+
+| Field | Value |
+|-------|-------|
+| Monitor Type | HTTP(s) |
+| Friendly Name | `CheesePay API - Liveness` |
+| URL | `https://api.cheesepay.xyz/health` |
+| Monitoring Interval | **1 minute** |
+| Monitor Timeout | 30 seconds |
+| Alert Contacts | CheesePay On-Call, CheesePay #alerts |
+| Alert When Down For | **1 check** (immediate) |
+
+Expected response: HTTP 200, body contains `"status":"ok"`.
+
+Add a **keyword monitor** on top if you want body validation:
+- Keyword: `"ok"`
+- Keyword Type: exists
+
+### Monitor 2 — API Readiness (DB + Stellar Horizon)
+
+| Field | Value |
+|-------|-------|
+| Monitor Type | HTTP(s) |
+| Friendly Name | `CheesePay API - Readiness (DB + Stellar)` |
+| URL | `https://api.cheesepay.xyz/health/ready` |
+| Monitoring Interval | **1 minute** |
+| Monitor Timeout | 30 seconds |
+| Alert Contacts | CheesePay On-Call, CheesePay #alerts |
+| Alert When Down For | **1 check** |
+
+This endpoint returns 503 when PostgreSQL or Stellar Horizon is unreachable — it's the most important monitor.
+
+### Monitor 3 — Stellar Horizon (external dependency)
+
+| Field | Value |
+|-------|-------|
+| Monitor Type | HTTP(s) |
+| Friendly Name | `Stellar Horizon` |
+| URL | `https://horizon.stellar.org/` |
+| Monitoring Interval | 5 minutes |
+| Alert Contacts | CheesePay #alerts |
+| Alert When Down For | 2 checks |
+
+This is informational — if Horizon is down independently, it explains `/health/ready` failures.
+
+---
+
+## 4. Status Page
+
+1. Go to **Status Pages → Create Status Page**
+2. Name: `CheesePay Status`
+3. Custom Domain: `status.cheesepay.xyz`
+4. Add all three monitors above
+5. Set **Password Protection**: off (public page)
+6. Enable **Subscribe to Updates** (email/RSS)
+
+### DNS for Custom Domain
+
+Add a CNAME record in your DNS provider:
+
+```
+status.cheesepay.xyz  CNAME  stats.uptimerobot.com
+```
+
+UptimeRobot will provision an SSL certificate automatically.
+
+---
+
+## 5. Slack Webhook Setup
+
+1. Go to https://api.slack.com/apps → **Create New App** → From scratch
+2. App Name: `UptimeRobot`, Workspace: your workspace
+3. **Incoming Webhooks** → Activate → Add New Webhook to Workspace
+4. Select channel: `#alerts` (or `#oncall`)
+5. Copy the Webhook URL → paste into UptimeRobot alert contact
+
+---
+
+## 6. Notification Message Templates
+
+UptimeRobot supports custom alert messages. Use these:
+
+**Down alert:**
+```
+🔴 [CheesePay] *{{ monitorFriendlyName }}* is DOWN
+URL: {{ monitorURL }}
+Reason: {{ alertDetails }}
+Time: {{ alertDateTime }}
+Duration: {{ alertDuration }}
+```
+
+**Up alert:**
+```
+✅ [CheesePay] *{{ monitorFriendlyName }}* is back UP
+URL: {{ monitorURL }}
+Downtime: {{ alertDuration }}
+```
+
+---
+
+## 7. Environment Variables
+
+Add to your `.env` / secrets manager:
+
+```bash
+# UptimeRobot
+UPTIMEROBOT_API_KEY=your_uptimerobot_api_key
+UPTIMEROBOT_MAIN_API_KEY=your_main_api_key  # for programmatic monitor management
+```
+
+---
+
+## 8. Programmatic Monitor Management (Optional)
+
+If you want to manage monitors via CI/CD, use the UptimeRobot API:
+
+```bash
+# Create a monitor via API
+curl -X POST https://api.uptimerobot.com/v2/newMonitor \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "api_key=${UPTIMEROBOT_API_KEY}" \
+  -d "format=json" \
+  -d "type=1" \
+  -d "url=https://api.cheesepay.xyz/health" \
+  -d "friendly_name=CheesePay+API+-+Liveness" \
+  -d "interval=60"
+```
+
+Monitor types: `1` = HTTP(s), `2` = keyword, `3` = ping.
+
+---
+
+## Verification Checklist
+
+- [ ] Both monitors show green in UptimeRobot dashboard
+- [ ] Test alert: pause a monitor → confirm Slack message arrives within 2 min
+- [ ] Test alert: resume monitor → confirm recovery message
+- [ ] Status page accessible at `status.cheesepay.xyz`
+- [ ] DNS CNAME resolves correctly
+- [ ] SSL certificate active on status page


### PR DESCRIPTION
closes #793 

Overview
Sets up external uptime monitoring from outside the infrastructure with alerting and a public status page at status.cheesepay.xyz.

Changes
UptimeRobot — 1-min polling on /health and /health/ready, Slack + email alerts, status page via CNAME
Better Uptime — 30-sec polling with phone/SMS on-call escalation (satisfies the 5-min alert SLA)
Status page — Cloudflare Worker serving status.cheesepay.xyz, proxies /health/admin and renders real-time component status (DB, Stellar, partner API, Redis, queues)
Grafana alerts — 4 new Loki-based rules: high error rate, health endpoint errors, process silence, Stellar connectivity loss
Heartbeat cron — UptimeHeartbeatService pings Better Uptime every 5 min; no-ops if env var is unset
.env.example — documents all new env vars
Acceptance criteria
Requirement	How it's met
Downtime detected within 2 min	UptimeRobot 1-min + Better Uptime 30-sec polling
On-call alerted within 5 min	Better Uptime immediate phone/SMS escalation
Public status page	status.cheesepay.xyz via Cloudflare Worker
To activate
Configure monitors per 
uptimerobot.md
 and 
better-uptime.md
Set BETTER_UPTIME_HEARTBEAT_URL, ADMIN_ALERT_SLACK_WEBHOOK_URL in env
Deploy status page: cd monitoring/statuspage && wrangler deploy
Add CNAME or Cloudflare route for status.cheesepay.xyz