### PR TITLE
feat: #745 #750 #753 #757 DB migrations, materialized view analytics,…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,28 @@ jobs:
       - name: Migration rollback check
         run: pnpm migration:rollback:check
 
+  backend-migration-uncommitted:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.2
+
+      - name: Install backend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check for uncommitted migration files
+        run: pnpm migration:uncommitted:check
+
   backend-sql-injection-check:
     runs-on: ubuntu-latest
     defaults:

--- a/backend/common/entities/base.entity.ts
+++ b/backend/common/entities/base.entity.ts
@@ -1,0 +1,1 @@
+export class BaseEntity {}

--- a/backend/ormconfig.ts
+++ b/backend/ormconfig.ts
@@ -1,0 +1,21 @@
+import 'reflect-metadata';
+import { ConnectionOptions } from 'typeorm';
+import * as path from 'path';
+
+const config: ConnectionOptions = {
+  type: 'postgres',
+  host: process.env.DB_HOST || 'localhost',
+  port: parseInt(process.env.DB_PORT || '5432', 10),
+  username: process.env.DB_USER || 'postgres',
+  password: process.env.DB_PASSWORD || process.env.DB_PASS || '',
+  database: process.env.DB_NAME || 'cheesepay',
+  entities: [path.join(__dirname, 'src/**/*.entity{.ts,.js}')],
+  migrations: [path.join(__dirname, 'src/database/migrations/*{.ts,.js}')],
+  migrationsTableName: 'typeorm_migrations',
+  synchronize: false,
+  cli: {
+    migrationsDir: 'src/database/migrations',
+  },
+};
+
+export = config;

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,11 +18,13 @@
     "test:cov": "jest --coverage",
     "test:integration": "jest --testRegex=\"\\.integration-spec\\.ts$\"",
     "test:e2e": "jest --testPathPattern=e2e-spec",
-    "migration:generate": "typeorm migration:generate",
-    "migration:run": "typeorm migration:run",
-    "migration:revert": "typeorm migration:revert",
+    "migration:generate": "ts-node --transpile-only node_modules/.bin/typeorm migration:generate -f ormconfig",
+    "migration:run": "ts-node --transpile-only node_modules/.bin/typeorm migration:run -f ormconfig",
+    "migration:revert": "ts-node --transpile-only node_modules/.bin/typeorm migration:revert -f ormconfig",
+    "migration:show": "ts-node --transpile-only node_modules/.bin/typeorm migration:show -f ormconfig",
     "migration:check": "ts-node --transpile-only scripts/migration-check.ts",
-    "migration:rollback:check": "ts-node --transpile-only scripts/migration-rollback-check.ts"
+    "migration:rollback:check": "ts-node --transpile-only scripts/migration-rollback-check.ts",
+    "migration:uncommitted:check": "ts-node --transpile-only scripts/migration-uncommitted-check.ts"
   },
   "dependencies": {
     "@nestjs/axios": "^4.0.1",

--- a/backend/scripts/migration-uncommitted-check.ts
+++ b/backend/scripts/migration-uncommitted-check.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env ts-node
+/**
+ * CI check: fails if there are uncommitted migration files.
+ * Ensures generated migrations are always committed before merging.
+ */
+import { execSync } from 'child_process';
+
+const output = execSync('git status --porcelain src/database/migrations/', { encoding: 'utf8' });
+
+if (output.trim().length > 0) {
+  console.error('ERROR: Uncommitted migration files detected:');
+  console.error(output);
+  console.error('Run `git add src/database/migrations/` and commit before pushing.');
+  process.exit(1);
+}
+
+console.log('Migration check passed: no uncommitted migration files.');

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -16,6 +16,7 @@ import { ApiTags, ApiBearerAuth, ApiOperation, ApiParam } from '@nestjs/swagger'
 import { QueryAdminPaymentsDto } from './dto/query-admin-payments.dto';
 import { Request, Response } from 'express';
 import { AdminService } from './admin.service';
+import { RatesService } from '../rates/rates.service';
 import { MerchantStatus, MerchantRole } from '../merchants/entities/merchant.entity';
 import { JwtAuthGuard } from '../auth/guards/jwt.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -28,7 +29,10 @@ import { PaginationDto } from '../common/dto/pagination.dto';
 @Roles(MerchantRole.ADMIN)
 @Controller('admin')
 export class AdminController {
-  constructor(private readonly adminService: AdminService) {}
+  constructor(
+    private readonly adminService: AdminService,
+    private readonly ratesService: RatesService,
+  ) {}
 
   @Get('merchants')
   @ApiOperation({ summary: 'List all merchants' })
@@ -78,6 +82,15 @@ export class AdminController {
       req.user.id,
       dto.reason,
     );
+  }
+
+  // ── Cache Management ──────────────────────────────────────────────────────
+
+  @Post('cache/rates/refresh')
+  @ApiOperation({ summary: 'Force-refresh the XLM/USD exchange rate cache' })
+  async refreshRateCache() {
+    const rate = await this.ratesService.fetchAndCache();
+    return { rate };
   }
 
   // ── Geographic Distribution Analytics (#714) ───────────────────────────────

--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -9,9 +9,10 @@ import { FeeConfig } from '../fee-config/entities/fee-config.entity';
 import { FeeHistory } from '../fee-config/entities/fee-history.entity';
 import { CronModule } from '../cron/cron.module';
 import { AuditLog } from './entities/audit-log.entity';
+import { RatesModule } from '../rates/rates.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Merchant, Payment, FeeConfig, FeeHistory, AuditLog]), CronModule],
+  imports: [TypeOrmModule.forFeature([Merchant, Payment, FeeConfig, FeeHistory, AuditLog]), CronModule, RatesModule],
   controllers: [AdminController, CronAdminController],
   providers: [AdminService],
   exports: [AdminService],

--- a/backend/src/analytics/analytics-refresh.service.spec.ts
+++ b/backend/src/analytics/analytics-refresh.service.spec.ts
@@ -1,0 +1,38 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AnalyticsRefreshService } from './analytics-refresh.service';
+import { DailyPaymentVolume } from './entities/daily-payment-volume.view';
+import { CronJobService } from '../cron/cron-job.service';
+
+const mockViewRepo = { query: jest.fn() };
+const mockCronJobService = {
+  run: jest.fn((name: string, fn: () => Promise<void>) => fn()),
+};
+
+describe('AnalyticsRefreshService', () => {
+  let service: AnalyticsRefreshService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnalyticsRefreshService,
+        { provide: getRepositoryToken(DailyPaymentVolume), useValue: mockViewRepo },
+        { provide: CronJobService, useValue: mockCronJobService },
+      ],
+    }).compile();
+    service = module.get(AnalyticsRefreshService);
+  });
+
+  it('issues REFRESH MATERIALIZED VIEW CONCURRENTLY via cron job service', async () => {
+    mockViewRepo.query.mockResolvedValue(undefined);
+    await service.refreshMaterializedViews();
+    expect(mockCronJobService.run).toHaveBeenCalledWith(
+      'refresh-mv-daily-payment-volume',
+      expect.any(Function),
+    );
+    expect(mockViewRepo.query).toHaveBeenCalledWith(
+      'REFRESH MATERIALIZED VIEW CONCURRENTLY mv_daily_payment_volume',
+    );
+  });
+});

--- a/backend/src/analytics/analytics-refresh.service.ts
+++ b/backend/src/analytics/analytics-refresh.service.ts
@@ -1,0 +1,27 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CronJobService } from '../cron/cron-job.service';
+import { DailyPaymentVolume } from './entities/daily-payment-volume.view';
+
+@Injectable()
+export class AnalyticsRefreshService {
+  private readonly logger = new Logger(AnalyticsRefreshService.name);
+
+  constructor(
+    @InjectRepository(DailyPaymentVolume)
+    private readonly viewRepo: Repository<DailyPaymentVolume>,
+    private readonly cronJobService: CronJobService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async refreshMaterializedViews(): Promise<void> {
+    await this.cronJobService.run('refresh-mv-daily-payment-volume', async () => {
+      await this.viewRepo.query(
+        'REFRESH MATERIALIZED VIEW CONCURRENTLY mv_daily_payment_volume',
+      );
+      this.logger.log('Refreshed mv_daily_payment_volume');
+    });
+  }
+}

--- a/backend/src/analytics/analytics.module.ts
+++ b/backend/src/analytics/analytics.module.ts
@@ -15,16 +15,20 @@ import { AnalyticsExportService, ANALYTICS_EXPORT_QUEUE } from './analytics-expo
 import { AnalyticsExport } from './entities/analytics-export.entity';
 import { AnalyticsExportProcessor } from './analytics-export.processor';
 import { EmailModule } from '../email/email.module';
+import { DailyPaymentVolume } from './entities/daily-payment-volume.view';
+import { AnalyticsRefreshService } from './analytics-refresh.service';
+import { CronModule } from '../cron/cron.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Payment, Settlement, Merchant, AnalyticsExport]),
+    TypeOrmModule.forFeature([Payment, Settlement, Merchant, AnalyticsExport, DailyPaymentVolume]),
     BullModule.registerQueue({ name: ANALYTICS_EXPORT_QUEUE }),
     EmailModule,
     CacheModule,
+    CronModule,
   ],
   controllers: [AnalyticsController, AnalyticsExportController, AnalyticsExportDownloadController],
-  providers: [AnalyticsService, AnalyticsExportService, AnalyticsExportProcessor],
+  providers: [AnalyticsService, AnalyticsExportService, AnalyticsExportProcessor, AnalyticsRefreshService],
   exports: [AnalyticsService],
 })
 export class AnalyticsModule {}

--- a/backend/src/analytics/analytics.service.ts
+++ b/backend/src/analytics/analytics.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { Payment, PaymentNetwork, PaymentStatus } from '../payments/entities/payment.entity';
 import { Settlement, SettlementStatus } from '../settlements/entities/settlement.entity';
 import { CacheService } from '../cache/cache.service';
+import { DailyPaymentVolume } from './entities/daily-payment-volume.view';
 
 type AnalyticsPeriod = 'daily' | 'monthly';
 type VolumeScope = 'merchant' | 'admin';
@@ -59,6 +60,8 @@ export class AnalyticsService {
     private paymentsRepo: Repository<Payment>,
     @InjectRepository(Settlement)
     private settlementsRepo: Repository<Settlement>,
+    @InjectRepository(DailyPaymentVolume)
+    private dailyVolumeRepo: Repository<DailyPaymentVolume>,
     private cache: CacheService,
   ) {}
 
@@ -347,24 +350,34 @@ export class AnalyticsService {
     start: Date,
     end: Date,
   ): Promise<VolumeBreakdownRow[]> {
-    const bucketExpression =
-      period === 'daily'
-        ? `DATE_TRUNC('day', payment."createdAt")`
-        : `DATE_TRUNC('month', payment."createdAt")`;
-    const labelFormat = period === 'daily' ? 'YYYY-MM-DD' : 'YYYY-MM';
+    // Daily queries read from the materialized view for sub-200ms performance.
+    if (period === 'daily') {
+      const qb = this.dailyVolumeRepo
+        .createQueryBuilder('mv')
+        .select("TO_CHAR(mv.day, 'YYYY-MM-DD')", 'bucket')
+        .addSelect('SUM(mv.paymentCount)', 'count')
+        .addSelect('COALESCE(SUM(mv.volumeUsd), 0)::numeric(18,6)::text', 'volumeUsd')
+        .where('mv.day >= :start', { start })
+        .andWhere('mv.day < :end', { end });
+      if (merchantId) {
+        qb.andWhere('mv.merchantId = :merchantId', { merchantId });
+      }
+      return qb.groupBy('mv.day').orderBy('mv.day', 'ASC').getRawMany();
+    }
+
+    // Monthly queries still hit the payments table directly.
+    const bucketExpression = `DATE_TRUNC('month', payment."createdAt")`;
     const query = this.paymentsRepo
       .createQueryBuilder('payment')
-      .select(`TO_CHAR(${bucketExpression}, '${labelFormat}')`, 'bucket')
+      .select(`TO_CHAR(${bucketExpression}, 'YYYY-MM')`, 'bucket')
       .addSelect('COUNT(*)', 'count')
       .addSelect('COALESCE(SUM(payment."amountUsd"), 0)::numeric(18,6)::text', 'volumeUsd')
       .where('payment.status = :status', { status: PaymentStatus.SETTLED })
       .andWhere('payment."createdAt" >= :start', { start })
       .andWhere('payment."createdAt" < :end', { end });
-
     if (merchantId) {
       query.andWhere('payment."merchantId" = :merchantId', { merchantId });
     }
-
     return query
       .groupBy(bucketExpression)
       .orderBy(bucketExpression, 'ASC')

--- a/backend/src/analytics/entities/daily-payment-volume.view.ts
+++ b/backend/src/analytics/entities/daily-payment-volume.view.ts
@@ -1,0 +1,16 @@
+import { ViewEntity, ViewColumn } from 'typeorm';
+
+@ViewEntity({ name: 'mv_daily_payment_volume', synchronize: false })
+export class DailyPaymentVolume {
+  @ViewColumn()
+  day: Date;
+
+  @ViewColumn()
+  merchantId: string;
+
+  @ViewColumn({ name: 'payment_count' })
+  paymentCount: string;
+
+  @ViewColumn({ name: 'volume_usd' })
+  volumeUsd: string;
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -77,7 +77,7 @@ import { CorrelationIdMiddleware } from './common/middleware/correlation-id.midd
         password: config.get('DB_PASSWORD'),
         database: config.get('DB_NAME', 'cheesepay'),
         entities: [__dirname + '/**/*.entity{.ts,.js}'],
-        synchronize: config.get('NODE_ENV') !== 'production',
+        synchronize: false,
         logging: config.get('NODE_ENV') === 'development',
       }),
       inject: [ConfigService],

--- a/backend/src/audit/entities/audit.entity.ts
+++ b/backend/src/audit/entities/audit.entity.ts
@@ -1,0 +1,19 @@
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn } from 'typeorm';
+
+@Entity('audit_logs')
+export class Audit {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ name: 'admin_id' })
+  adminId!: string;
+
+  @Column()
+  action!: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  detail: any;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+}

--- a/backend/src/cache/cache.service.spec.ts
+++ b/backend/src/cache/cache.service.spec.ts
@@ -1,0 +1,116 @@
+import { CacheService, CACHE_INVALIDATION_CHANNEL } from './cache.service';
+
+function makeMockRedis() {
+  return {
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+    scan: jest.fn(),
+    publish: jest.fn(),
+    subscribe: jest.fn().mockResolvedValue(undefined),
+    on: jest.fn(),
+    quit: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('CacheService', () => {
+  let service: CacheService;
+  let redis: ReturnType<typeof makeMockRedis>;
+  let subscriber: ReturnType<typeof makeMockRedis>;
+
+  beforeEach(async () => {
+    redis = makeMockRedis();
+    subscriber = makeMockRedis();
+    service = new CacheService(redis as any, subscriber as any);
+    await service.onModuleInit();
+  });
+
+  afterEach(async () => {
+    await service.onModuleDestroy();
+  });
+
+  const env = process.env.NODE_ENV ?? 'development';
+  const ns = `${env}:cache:`;
+
+  describe('key namespacing', () => {
+    it('prefixes get with {env}:cache:', async () => {
+      redis.get.mockResolvedValue(null);
+      await service.get('mykey');
+      expect(redis.get).toHaveBeenCalledWith(`${ns}mykey`);
+    });
+
+    it('prefixes set with {env}:cache:', async () => {
+      redis.set.mockResolvedValue('OK');
+      await service.set('mykey', 42, { ttlSeconds: 10 });
+      expect(redis.set).toHaveBeenCalledWith(`${ns}mykey`, expect.any(String), 'EX', 10);
+    });
+
+    it('ns property matches NODE_ENV', () => {
+      expect(service.ns).toBe(`${env}:cache:`);
+    });
+  });
+
+  describe('del', () => {
+    it('deletes namespaced key and publishes bare key to invalidation channel', async () => {
+      redis.del.mockResolvedValue(1);
+      redis.publish.mockResolvedValue(1);
+      await service.del('somekey');
+      expect(redis.del).toHaveBeenCalledWith(`${ns}somekey`);
+      expect(redis.publish).toHaveBeenCalledWith(CACHE_INVALIDATION_CHANNEL, 'somekey');
+    });
+  });
+
+  describe('delPattern', () => {
+    it('scans with namespaced pattern, deletes, and broadcasts stripped keys', async () => {
+      redis.scan.mockResolvedValueOnce(['0', [`${ns}analytics:m1`, `${ns}analytics:m2`]]);
+      redis.del.mockResolvedValue(2);
+      redis.publish.mockResolvedValue(1);
+
+      const count = await service.delPattern('analytics:*');
+
+      expect(redis.scan).toHaveBeenCalledWith('0', 'MATCH', `${ns}analytics:*`, 'COUNT', 250);
+      expect(redis.del).toHaveBeenCalledWith(`${ns}analytics:m1`, `${ns}analytics:m2`);
+      expect(redis.publish).toHaveBeenCalledWith(
+        CACHE_INVALIDATION_CHANNEL,
+        JSON.stringify(['analytics:m1', 'analytics:m2']),
+      );
+      expect(count).toBe(2);
+    });
+
+    it('does not publish when no keys matched', async () => {
+      redis.scan.mockResolvedValueOnce(['0', []]);
+      await service.delPattern('nothing:*');
+      expect(redis.publish).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getOrSet', () => {
+    it('returns cached value on hit without calling fetchFn', async () => {
+      const encoded = JSON.stringify({ v: 1, encoding: 'json', payload: JSON.stringify(99) });
+      redis.get.mockResolvedValue(encoded);
+      const fetchFn = jest.fn();
+      const result = await service.getOrSet('k', fetchFn, { ttlSeconds: 30 });
+      expect(result).toEqual({ value: 99, cacheHit: true });
+      expect(fetchFn).not.toHaveBeenCalled();
+    });
+
+    it('calls fetchFn and stores result on miss', async () => {
+      redis.get.mockResolvedValue(null);
+      redis.set.mockResolvedValue('OK');
+      const fetchFn = jest.fn().mockResolvedValue('fresh');
+      const result = await service.getOrSet('k', fetchFn, { ttlSeconds: 30 });
+      expect(result).toEqual({ value: 'fresh', cacheHit: false });
+      expect(redis.set).toHaveBeenCalledWith(`${ns}k`, expect.any(String), 'EX', 30);
+    });
+  });
+
+  describe('pub/sub', () => {
+    it('subscribes to invalidation channel on init', () => {
+      expect(subscriber.subscribe).toHaveBeenCalledWith(CACHE_INVALIDATION_CHANNEL);
+    });
+
+    it('registers a message handler on the subscriber', () => {
+      expect(subscriber.on).toHaveBeenCalledWith('message', expect.any(Function));
+    });
+  });
+});

--- a/backend/src/cache/cache.service.ts
+++ b/backend/src/cache/cache.service.ts
@@ -1,93 +1,88 @@
-import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import Redis from 'ioredis';
 import { gzipSync, gunzipSync } from 'node:zlib';
-
-interface CacheEntry<T> {
-  value: T;
-  expiresAt: number;
-}
 
 type CacheEnvelope =
   | { v: 1; encoding: 'json'; payload: string }
   | { v: 1; encoding: 'gzip+base64'; payload: string };
 
+/** Channel on which key-invalidation events are broadcast to all instances. */
+export const CACHE_INVALIDATION_CHANNEL = 'cache:invalidate';
+
+const compressThresholdBytes = 8 * 1024;
+
+function buildRedisClient(): Redis {
+  const url = process.env.REDIS_URL;
+  if (url) return new Redis(url as any);
+  return new Redis({
+    host: process.env.REDIS_HOST ?? '127.0.0.1',
+    port: process.env.REDIS_PORT ? Number(process.env.REDIS_PORT) : 6379,
+    password: process.env.REDIS_PASSWORD || undefined,
+    maxRetriesPerRequest: 3,
+    enableOfflineQueue: true,
+  } as any);
+}
+
 @Injectable()
-export class CacheService implements OnModuleDestroy {
+export class CacheService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(CacheService.name);
-  private readonly store = new Map<string, CacheEntry<unknown>>();
-  private readonly redis?: Redis;
 
-  // Only compress "large" payloads (bytes of JSON string).
-  private readonly compressThresholdBytes = 8 * 1024;
+  /** Shared connection used for reads/writes. */
+  private readonly redis: Redis;
+  /** Dedicated subscriber connection (ioredis subscriber mode blocks the connection). */
+  private readonly subscriber: Redis;
 
-  constructor() {
-    const redisUrl = process.env.REDIS_URL;
-    const host = process.env.REDIS_HOST;
-    const port = process.env.REDIS_PORT ? Number(process.env.REDIS_PORT) : undefined;
+  /** Namespace prefix: "{env}:cache:" */
+  readonly ns: string;
 
-    if (redisUrl) {
-      this.redis = new Redis(redisUrl, { lazyConnect: true, maxRetriesPerRequest: 1 });
-    } else if (host || port) {
-      this.redis = new Redis({
-        host: host ?? '127.0.0.1',
-        port: port ?? 6379,
-        password: process.env.REDIS_PASSWORD || undefined,
-        lazyConnect: true,
-        maxRetriesPerRequest: 1,
-      });
-    }
+  constructor(redis?: Redis, subscriber?: Redis) {
+    const env = process.env.NODE_ENV ?? 'development';
+    this.ns = `${env}:cache:`;
+    this.redis = redis ?? buildRedisClient();
+    this.subscriber = subscriber ?? buildRedisClient();
+  }
+
+  async onModuleInit(): Promise<void> {
+    await this.subscriber.subscribe(CACHE_INVALIDATION_CHANNEL);
+    this.subscriber.on('message', (_channel: string, message: string) => {
+      // No local in-process store to clear — log for observability only.
+      this.logger.debug(`Cache invalidation broadcast received: ${message}`);
+    });
   }
 
   async onModuleDestroy(): Promise<void> {
-    if (this.redis) {
-      try {
-        await this.redis.quit();
-      } catch {
-        // ignore shutdown issues
-      }
-    }
+    await Promise.allSettled([this.redis.quit(), this.subscriber.quit()]);
   }
 
-  private async ensureRedisConnected(): Promise<Redis | undefined> {
-    if (!this.redis) return undefined;
-    if (this.redis.status === 'ready') return this.redis;
-    try {
-      await this.redis.connect();
-      return this.redis;
-    } catch (err) {
-      this.logger.warn(`Redis unavailable, falling back to in-memory cache: ${String(err?.message ?? err)}`);
-      return undefined;
-    }
+  // ── Key helpers ────────────────────────────────────────────────────────────
+
+  private k(key: string): string {
+    return `${this.ns}${key}`;
   }
+
+  private stripNs(nsKey: string): string {
+    return nsKey.startsWith(this.ns) ? nsKey.slice(this.ns.length) : nsKey;
+  }
+
+  // ── Encoding ───────────────────────────────────────────────────────────────
 
   private encode(value: unknown): string {
     const json = JSON.stringify(value);
     const bytes = Buffer.byteLength(json, 'utf8');
     const envelope: CacheEnvelope =
-      bytes >= this.compressThresholdBytes
-        ? {
-            v: 1,
-            encoding: 'gzip+base64',
-            payload: gzipSync(Buffer.from(json, 'utf8')).toString('base64'),
-          }
+      bytes >= compressThresholdBytes
+        ? { v: 1, encoding: 'gzip+base64', payload: gzipSync(Buffer.from(json, 'utf8')).toString('base64') }
         : { v: 1, encoding: 'json', payload: json };
     return JSON.stringify(envelope);
   }
 
   private decode<T>(raw: string): T | undefined {
     try {
-      const parsed = JSON.parse(raw) as CacheEnvelope | unknown;
-      if (!parsed || typeof parsed !== 'object') return undefined;
-      const envelope = parsed as CacheEnvelope;
-
-      if (envelope.v !== 1) return undefined;
-      if (envelope.encoding === 'json') {
-        return JSON.parse(envelope.payload) as T;
-      }
+      const envelope = JSON.parse(raw) as CacheEnvelope;
+      if (envelope?.v !== 1) return undefined;
+      if (envelope.encoding === 'json') return JSON.parse(envelope.payload) as T;
       if (envelope.encoding === 'gzip+base64') {
-        const buf = Buffer.from(envelope.payload, 'base64');
-        const json = gunzipSync(buf).toString('utf8');
-        return JSON.parse(json) as T;
+        return JSON.parse(gunzipSync(Buffer.from(envelope.payload, 'base64')).toString('utf8')) as T;
       }
       return undefined;
     } catch {
@@ -95,67 +90,41 @@ export class CacheService implements OnModuleDestroy {
     }
   }
 
-  async get<T>(key: string): Promise<T | undefined> {
-    const redis = await this.ensureRedisConnected();
-    if (redis) {
-      const raw = await redis.get(key);
-      if (!raw) return undefined;
-      return this.decode<T>(raw);
-    }
+  // ── Public API ─────────────────────────────────────────────────────────────
 
-    const entry = this.store.get(key) as CacheEntry<T> | undefined;
-    if (!entry) return undefined;
-    if (Date.now() > entry.expiresAt) {
-      this.store.delete(key);
-      return undefined;
-    }
-    return entry.value;
+  async get<T>(key: string): Promise<T | undefined> {
+    const raw = await this.redis.get(this.k(key));
+    if (!raw) return undefined;
+    return this.decode<T>(raw);
   }
 
   async set<T>(key: string, value: T, options?: { ttlSeconds?: number }): Promise<void> {
-    const ttlSeconds = options?.ttlSeconds ?? 86400;
-    const redis = await this.ensureRedisConnected();
-    if (redis) {
-      await redis.set(key, this.encode(value), 'EX', ttlSeconds);
-      return;
-    }
-
-    this.store.set(key, { value, expiresAt: Date.now() + ttlSeconds * 1000 });
+    const ttl = options?.ttlSeconds ?? 86400;
+    await this.redis.set(this.k(key), this.encode(value), 'EX', ttl);
   }
 
   async del(key: string): Promise<void> {
-    const redis = await this.ensureRedisConnected();
-    if (redis) {
-      await redis.del(key);
-      return;
-    }
-    this.store.delete(key);
+    await this.redis.del(this.k(key));
+    await this.redis.publish(CACHE_INVALIDATION_CHANNEL, key);
   }
 
   async delPattern(pattern: string): Promise<number> {
-    const redis = await this.ensureRedisConnected();
-    if (redis) {
-      let cursor = '0';
-      let deleted = 0;
-      do {
-        const [nextCursor, keys] = await redis.scan(cursor, 'MATCH', pattern, 'COUNT', 250);
-        cursor = nextCursor;
-        if (keys.length) {
-          deleted += await redis.del(...keys);
-        }
-      } while (cursor !== '0');
-      return deleted;
-    }
-
-    // In-memory fallback supports simple prefix patterns like "foo:*".
-    if (!pattern.endsWith('*')) return 0;
-    const prefix = pattern.slice(0, -1);
+    const nsPattern = this.k(pattern);
+    let cursor = '0';
     let deleted = 0;
-    for (const key of this.store.keys()) {
-      if (key.startsWith(prefix)) {
-        this.store.delete(key);
-        deleted += 1;
+    const invalidated: string[] = [];
+
+    do {
+      const [nextCursor, keys] = await this.redis.scan(cursor, 'MATCH', nsPattern, 'COUNT', 250);
+      cursor = nextCursor;
+      if (keys.length) {
+        deleted += await this.redis.del(...keys);
+        invalidated.push(...keys.map((k) => this.stripNs(k)));
       }
+    } while (cursor !== '0');
+
+    if (invalidated.length) {
+      await this.redis.publish(CACHE_INVALIDATION_CHANNEL, JSON.stringify(invalidated));
     }
     return deleted;
   }

--- a/backend/src/common/entities/base.entity.ts
+++ b/backend/src/common/entities/base.entity.ts
@@ -1,0 +1,1 @@
+export class BaseEntity {}

--- a/backend/src/common/guards/super-admin.guard.ts
+++ b/backend/src/common/guards/super-admin.guard.ts
@@ -1,0 +1,13 @@
+import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { User, UserRole } from '../../users/entities/user.entity';
+
+@Injectable()
+export class SuperAdminGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const user = context.switchToHttp().getRequest<{ user: User }>().user;
+    if (user?.role !== UserRole.SUPERADMIN) {
+      throw new ForbiddenException('SuperAdmin access required');
+    }
+    return true;
+  }
+}

--- a/backend/src/cron/cron-job.service.spec.ts
+++ b/backend/src/cron/cron-job.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { CronJobService } from './cron-job.service';
 import { CronJobLog, CronJobStatus } from './entities/cron-job-log.entity';
-import { TimeoutException } from '@nestjs/common';
+import { RequestTimeoutException } from '@nestjs/common';
 
 describe('CronJobService', () => {
   let service: CronJobService;
@@ -54,7 +54,7 @@ describe('CronJobService', () => {
     const promise = service.run('timeout-job', mockFn);
     jest.advanceTimersByTime(5 * 60 * 1000 + 1);
 
-    await expect(promise).rejects.toThrow(TimeoutException);
+    await expect(promise).rejects.toThrow(RequestTimeoutException);
     expect(mockRepo.save).toHaveBeenCalledWith(expect.objectContaining({
       status: CronJobStatus.FAILED,
     }));

--- a/backend/src/cron/cron-job.service.ts
+++ b/backend/src/cron/cron-job.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, TimeoutException } from '@nestjs/common';
+import { Injectable, Logger, RequestTimeoutException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CronJobLog, CronJobStatus } from './entities/cron-job-log.entity';
@@ -26,7 +26,7 @@ export class CronJobService {
       const result = await Promise.race([
         fn(),
         new Promise<never>((_, reject) =>
-          setTimeout(() => reject(new TimeoutException(`Cron job ${jobName} exceeded 5min`)), 5 * 60 * 1000),
+          setTimeout(() => reject(new RequestTimeoutException(`Cron job ${jobName} exceeded 5min`)), 5 * 60 * 1000),
         ),
       ]);
 

--- a/backend/src/database/migrations/1700000000005-CreateAppConfig.ts
+++ b/backend/src/database/migrations/1700000000005-CreateAppConfig.ts
@@ -1,0 +1,24 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateAppConfig1700000000005 implements MigrationInterface {
+  name = 'CreateAppConfig1700000000005';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "app_configs" (
+        "id"          uuid          NOT NULL DEFAULT uuid_generate_v4(),
+        "key"         varchar(100)  NOT NULL,
+        "value"       jsonb         NOT NULL,
+        "description" varchar(255)  DEFAULT NULL,
+        "updated_by"  uuid          DEFAULT NULL,
+        "updated_at"  TIMESTAMPTZ   NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_app_configs_id"  PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_app_configs_key" UNIQUE ("key")
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "app_configs"`);
+  }
+}

--- a/backend/src/database/migrations/1772200000003-ExpandPaymentNetworkEnum.ts
+++ b/backend/src/database/migrations/1772200000003-ExpandPaymentNetworkEnum.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class ExpandPaymentNetworkEnum1772200000001 implements MigrationInterface {
-  name = 'ExpandPaymentNetworkEnum1772200000001';
+export class ExpandPaymentNetworkEnum1772200000003 implements MigrationInterface {
+  name = 'ExpandPaymentNetworkEnum1772200000003';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`

--- a/backend/src/database/migrations/1772200000010-CreateMvDailyPaymentVolume.ts
+++ b/backend/src/database/migrations/1772200000010-CreateMvDailyPaymentVolume.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateMvDailyPaymentVolume1772200000010 implements MigrationInterface {
+  name = 'CreateMvDailyPaymentVolume1772200000010';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE MATERIALIZED VIEW IF NOT EXISTS mv_daily_payment_volume AS
+      SELECT
+        DATE_TRUNC('day', p."createdAt") AS day,
+        p."merchantId",
+        COUNT(*)::bigint                 AS payment_count,
+        COALESCE(SUM(p."amountUsd"), 0)  AS volume_usd
+      FROM payments p
+      WHERE p.status = 'settled'
+        AND p."deletedAt" IS NULL
+      GROUP BY DATE_TRUNC('day', p."createdAt"), p."merchantId"
+    `);
+
+    // Unique index is required for REFRESH CONCURRENTLY
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS uidx_mv_daily_payment_volume
+        ON mv_daily_payment_volume (day, "merchantId")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP MATERIALIZED VIEW IF EXISTS mv_daily_payment_volume`);
+  }
+}

--- a/backend/src/database/seeds/app-config.seed.ts
+++ b/backend/src/database/seeds/app-config.seed.ts
@@ -1,0 +1,22 @@
+import { DataSource } from 'typeorm';
+import { AppConfig } from '../../app-config/entities/app-config.entity';
+
+const DEFAULTS: Array<{ key: string; value: unknown; description: string }> = [
+  { key: 'maintenance_mode',         value: false,   description: 'Put the app in maintenance mode' },
+  { key: 'staking_enabled',          value: true,    description: 'Enable/disable staking features' },
+  { key: 'fiat_settlement_enabled',  value: true,    description: 'Enable/disable fiat settlement' },
+  { key: 'virtual_accounts_enabled', value: true,    description: 'Enable/disable virtual accounts' },
+  { key: 'referral_reward_usdc',     value: '1.00',  description: 'USDC reward per referral' },
+  { key: 'max_daily_deposit_usdc',   value: '10000', description: 'Max USDC deposit per user per day' },
+];
+
+export async function seedAppConfigs(dataSource: DataSource): Promise<void> {
+  const repo = dataSource.getRepository(AppConfig);
+  for (const seed of DEFAULTS) {
+    await repo.upsert(
+      { key: seed.key, value: seed.value, description: seed.description },
+      { conflictPaths: ['key'], skipUpdateIfNoValuesChanged: true },
+    );
+  }
+  console.log('App configs seeded.');
+}

--- a/backend/src/rates/entities/rate-snapshot.entity.ts
+++ b/backend/src/rates/entities/rate-snapshot.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('rate_snapshots')
+export class RateSnapshot {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  pair: string;
+
+  @Column('float')
+  rate: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/rates/rates.module.ts
+++ b/backend/src/rates/rates.module.ts
@@ -3,6 +3,7 @@ import { BullModule } from '@nestjs/bull';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CacheModule } from '../cache/cache.module';
 import { CronModule } from '../cron/cron.module';
+import { StellarModule } from '../stellar/stellar.module';
 import { RateSnapshot } from './entities/rate-snapshot.entity';
 import { RatesService } from './rates.service';
 import { RatesProcessor } from './rates.processor';
@@ -11,6 +12,7 @@ import { RatesProcessor } from './rates.processor';
   imports: [
     TypeOrmModule.forFeature([RateSnapshot]),
     CacheModule,
+    StellarModule,
     BullModule.registerQueue({ name: 'rates' }),
     CronModule,
   ],

--- a/backend/src/rates/rates.service.spec.ts
+++ b/backend/src/rates/rates.service.spec.ts
@@ -1,0 +1,63 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RatesService, RATE_CACHE_KEY, RATE_TTL_SECONDS } from './rates.service';
+import { CacheService } from '../cache/cache.service';
+import { StellarService } from '../stellar/stellar.service';
+
+const mockCache = {
+  getOrSet: jest.fn(),
+  set: jest.fn(),
+};
+
+const mockStellar = {
+  getXlmUsdRate: jest.fn(),
+};
+
+describe('RatesService', () => {
+  let service: RatesService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RatesService,
+        { provide: CacheService, useValue: mockCache },
+        { provide: StellarService, useValue: mockStellar },
+      ],
+    }).compile();
+    service = module.get(RatesService);
+  });
+
+  describe('getXlmUsdRate', () => {
+    it('returns cached rate on cache hit', async () => {
+      mockCache.getOrSet.mockResolvedValue({ value: 0.12, cacheHit: true });
+      const rate = await service.getXlmUsdRate();
+      expect(rate).toBe(0.12);
+      expect(mockCache.getOrSet).toHaveBeenCalledWith(
+        RATE_CACHE_KEY,
+        expect.any(Function),
+        { ttlSeconds: RATE_TTL_SECONDS },
+      );
+    });
+
+    it('fetches fresh rate on cache miss', async () => {
+      mockStellar.getXlmUsdRate.mockResolvedValue(0.15);
+      mockCache.getOrSet.mockImplementation(async (_key, fetchFn, _opts) => ({
+        value: await fetchFn(),
+        cacheHit: false,
+      }));
+      const rate = await service.getXlmUsdRate();
+      expect(rate).toBe(0.15);
+      expect(mockStellar.getXlmUsdRate).toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchAndCache', () => {
+    it('fetches from stellar and writes to cache with 30s TTL', async () => {
+      mockStellar.getXlmUsdRate.mockResolvedValue(0.2);
+      mockCache.set.mockResolvedValue(undefined);
+      const rate = await service.fetchAndCache();
+      expect(rate).toBe(0.2);
+      expect(mockCache.set).toHaveBeenCalledWith(RATE_CACHE_KEY, 0.2, { ttlSeconds: RATE_TTL_SECONDS });
+    });
+  });
+});

--- a/backend/src/rates/rates.service.ts
+++ b/backend/src/rates/rates.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { CacheService } from '../cache/cache.service';
+import { StellarService } from '../stellar/stellar.service';
+
+export const RATE_CACHE_KEY = 'rate:xlm:usd';
+export const RATE_TTL_SECONDS = 30;
+
+@Injectable()
+export class RatesService {
+  private readonly logger = new Logger(RatesService.name);
+
+  constructor(
+    private readonly cache: CacheService,
+    private readonly stellar: StellarService,
+  ) {}
+
+  async getXlmUsdRate(): Promise<number> {
+    const { value, cacheHit } = await this.cache.getOrSet<number>(
+      RATE_CACHE_KEY,
+      () => this.stellar.getXlmUsdRate(),
+      { ttlSeconds: RATE_TTL_SECONDS },
+    );
+    this.logger.debug(`XLM/USD rate ${cacheHit ? 'cache hit' : 'cache miss'}: ${value}`);
+    return value;
+  }
+
+  async fetchAndCache(): Promise<number> {
+    const rate = await this.stellar.getXlmUsdRate();
+    await this.cache.set(RATE_CACHE_KEY, rate, { ttlSeconds: RATE_TTL_SECONDS });
+    this.logger.debug(`XLM/USD rate refreshed: ${rate}`);
+    return rate;
+  }
+}

--- a/backend/src/runtime-config/app-config.controller.ts
+++ b/backend/src/runtime-config/app-config.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get, Patch, Param, Body, UseGuards, Request } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { AppConfigService } from './app-config.service';
+import { SuperAdminGuard } from '../common/guards/super-admin.guard';
+import { User } from '../users/entities/user.entity';
+
+@ApiTags('admin/config')
+@ApiBearerAuth()
+@UseGuards(SuperAdminGuard)
+@Controller('admin/config')
+export class AppConfigController {
+  constructor(private readonly appConfigService: AppConfigService) {}
+
+  @Get()
+  getAll() {
+    return this.appConfigService.getAll();
+  }
+
+  @Patch(':key')
+  update(
+    @Param('key') key: string,
+    @Body('value') value: unknown,
+    @Request() req: { user: User },
+  ) {
+    return this.appConfigService.set(key, value, req.user.id);
+  }
+}

--- a/backend/src/runtime-config/entities/runtime-config.entity.ts
+++ b/backend/src/runtime-config/entities/runtime-config.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, Column, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity('runtime_config')
+export class RuntimeConfig {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ unique: true })
+  key!: string;
+
+  @Column({ type: 'jsonb' })
+  value: any;
+
+  @Column({ nullable: true })
+  description?: string;
+
+  @Column({ name: 'updated_by' })
+  updatedBy!: string;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt!: Date;
+}

--- a/backend/src/runtime-config/maintenance-mode.middleware.ts
+++ b/backend/src/runtime-config/maintenance-mode.middleware.ts
@@ -1,0 +1,34 @@
+import { Injectable, NestMiddleware, ServiceUnavailableException, Inject } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { REDIS_CLIENT } from '../cache/redis.module';
+import Redis from 'ioredis';
+
+const MAINTENANCE_KEY = 'config:maintenance_mode';
+
+@Injectable()
+export class MaintenanceModeMiddleware implements NestMiddleware {
+  constructor(@Inject(REDIS_CLIENT) private readonly redis: Redis) {}
+
+  async use(req: Request, _res: Response, next: NextFunction): Promise<void> {
+    const path: string = req.path ?? '';
+
+    if (path.startsWith('/admin') || path.startsWith('/health')) {
+      return next();
+    }
+
+    const raw = await this.redis.get(MAINTENANCE_KEY);
+    if (raw !== null) {
+      try {
+        if (JSON.parse(raw) === true) {
+          throw new ServiceUnavailableException(
+            "Cheese is under maintenance. We'll be back soon.",
+          );
+        }
+      } catch (e) {
+        if (e instanceof ServiceUnavailableException) throw e;
+      }
+    }
+
+    next();
+  }
+}

--- a/backend/src/runtime-config/middleware/maintenance-mode.middleware.ts
+++ b/backend/src/runtime-config/middleware/maintenance-mode.middleware.ts
@@ -1,0 +1,31 @@
+import {
+  Injectable,
+  NestMiddleware,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { CacheService } from '../../cache/cache.service';
+
+@Injectable()
+export class MaintenanceModeMiddleware implements NestMiddleware {
+  constructor(private readonly cacheService: CacheService) {}
+
+  async use(req: Request, res: Response, next: NextFunction) {
+    // 1. Check if it's an admin or health route
+    const isExcluded = req.path.startsWith('/admin') || req.path.startsWith('/health');
+    if (isExcluded) {
+      return next();
+    }
+
+    // 2. Read from Redis ONLY (no DB call)
+    const maintenanceMode = await this.cacheService.get<boolean>('config:maintenance_mode');
+
+    if (maintenanceMode === true) {
+      throw new ServiceUnavailableException({
+        message: "Cheese is under maintenance. We'll be back soon.",
+      });
+    }
+
+    next();
+  }
+}

--- a/backend/src/runtime-config/runtime-config-admin.controller.ts
+++ b/backend/src/runtime-config/runtime-config-admin.controller.ts
@@ -1,0 +1,41 @@
+import {
+  Controller,
+  Get,
+  Patch,
+  Param,
+  Body,
+  UseGuards,
+  Req,
+} from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import { RuntimeConfigService } from './runtime-config.service';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { UserRole } from '../users/entities/user.entity';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Request } from 'express';
+
+@ApiTags('admin / config')
+@ApiBearerAuth()
+@UseGuards(RolesGuard)
+@Roles(UserRole.SUPERADMIN)
+@Controller('admin/config')
+export class RuntimeConfigController {
+  constructor(private readonly runtimeConfigService: RuntimeConfigService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all runtime configurations' })
+  async getAll() {
+    return this.runtimeConfigService.getAll();
+  }
+
+  @Patch(':key')
+  @ApiOperation({ summary: 'Update a runtime configuration' })
+  async update(
+    @Param('key') key: string,
+    @Body() body: { value: any; description?: string },
+    @Req() req: Request,
+  ) {
+    const adminId = (req as any).user.id;
+    return this.runtimeConfigService.set(key, body.value, adminId, body.description);
+  }
+}

--- a/backend/src/runtime-config/runtime-config.module.ts
+++ b/backend/src/runtime-config/runtime-config.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { RuntimeConfig } from './entities/runtime-config.entity';
+import { RuntimeConfigService } from './runtime-config.service';
+import { RuntimeConfigController } from './runtime-config-admin.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([RuntimeConfig])],
+  providers: [RuntimeConfigService],
+  controllers: [RuntimeConfigController],
+  exports: [RuntimeConfigService],
+})
+export class RuntimeConfigModule {}

--- a/backend/src/runtime-config/runtime-config.service.ts
+++ b/backend/src/runtime-config/runtime-config.service.ts
@@ -1,0 +1,75 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { RuntimeConfig } from './entities/runtime-config.entity';
+import { CacheService } from '../cache/cache.service';
+import { AuditService } from '../audit/audit.service';
+
+@Injectable()
+export class RuntimeConfigService {
+  private readonly CACHE_PREFIX = 'config:';
+  private readonly CACHE_TTL = 60; // 60 seconds
+
+  constructor(
+    @InjectRepository(RuntimeConfig)
+    private readonly configRepo: Repository<RuntimeConfig>,
+    private readonly cacheService: CacheService,
+    private readonly auditService: AuditService,
+  ) {}
+
+  async get<T>(key: string, defaultValue?: T): Promise<T | undefined> {
+    const cacheKey = `${this.CACHE_PREFIX}${key}`;
+    
+    // 1. Try Redis
+    const cached = await this.cacheService.get<T>(cacheKey);
+    if (cached !== null) {
+      return cached;
+    }
+
+    // 2. Try DB
+    const config = await this.configRepo.findOne({ where: { key } });
+    if (config) {
+      const value = config.value as T;
+      // Cache for 60s
+      await this.cacheService.set(cacheKey, value, this.CACHE_TTL);
+      return value;
+    }
+
+    // 3. Not in DB, return default
+    return defaultValue;
+  }
+
+  async set(key: string, value: any, adminId: string, description?: string): Promise<RuntimeConfig> {
+    try {
+      JSON.stringify(value);
+    } catch {
+      throw new BadRequestException('Invalid JSON value');
+    }
+
+    const cacheKey = `${this.CACHE_PREFIX}${key}`;
+
+    let config = await this.configRepo.findOne({ where: { key } });
+    if (config) {
+      config.value = value;
+      config.updatedBy = adminId;
+      if (description) config.description = description;
+    } else {
+      config = this.configRepo.create({
+        key,
+        value,
+        updatedBy: adminId,
+        description,
+      });
+    }
+
+    const saved = await this.configRepo.save(config);
+    await this.cacheService.del(cacheKey);
+    await this.auditService.log(adminId, 'config.set', { key, value });
+
+    return saved;
+  }
+
+  async getAll(): Promise<RuntimeConfig[]> {
+    return this.configRepo.find({ order: { key: 'ASC' } });
+  }
+}


### PR DESCRIPTION
… exchange rate cache, distributed cache

closes #745: TypeORM CLI setup with ormconfig.ts, synchronize:false enforced, migration scripts fixed, uncommitted migration CI check

closes #750: mv_daily_payment_volume materialized view, hourly concurrent refresh cron, analytics volume queries read from view

closes #753: RatesService with rate:xlm:usd cache (30s TTL), POST /admin/cache/rates/refresh force-refresh endpoint

closes #757: CacheService rewrite - env-namespaced keys ({env}:cache:), Redis pub/sub invalidation broadcast, in-memory fallback removed