### PR TITLE
feat: implement correlation ID middleware and context management

### DIFF
--- a/backend/src/common/correlation-id.context.ts
+++ b/backend/src/common/correlation-id.context.ts
@@ -1,0 +1,15 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+type CorrelationStore = {
+  correlationId?: string;
+};
+
+const correlationIdStorage = new AsyncLocalStorage<CorrelationStore>();
+
+export function runWithCorrelationId<T>(correlationId: string, callback: () => T): T {
+  return correlationIdStorage.run({ correlationId }, callback);
+}
+
+export function getCorrelationId(): string | undefined {
+  return correlationIdStorage.getStore()?.correlationId;
+}

--- a/backend/src/common/middleware/correlation-id.middleware.ts
+++ b/backend/src/common/middleware/correlation-id.middleware.ts
@@ -1,13 +1,16 @@
 import { Injectable, NestMiddleware } from '@nestjs/common';
 import { Request, Response, NextFunction } from 'express';
 import { v4 as uuidv4 } from 'uuid';
+import { runWithCorrelationId } from '../correlation-id.context';
 
 @Injectable()
 export class CorrelationIdMiddleware implements NestMiddleware {
   use(req: Request & { correlationId?: string }, res: Response, next: NextFunction) {
-    const id = (req.headers['x-correlation-id'] as string) || uuidv4();
+    const headerValue = req.headers['x-correlation-id'];
+    const clientCorrelationId = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+    const id = (clientCorrelationId && clientCorrelationId.trim()) || uuidv4();
     req.correlationId = id;
-    res.setHeader('X-Correlation-Id', id);
-    next();
+    res.setHeader('X-Correlation-ID', id);
+    runWithCorrelationId(id, () => next());
   }
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -10,11 +10,20 @@ import { readTelemetryConfig, shutdownTelemetry, startTelemetry } from './teleme
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 import { AllExceptionsFilter } from './core/filters/all-exceptions.filter';
 import { SentryService } from './sentry/sentry.service';
+import { getCorrelationId } from './common/correlation-id.context';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { version } = require('../package.json') as { version: string };
 
 async function bootstrap(): Promise<void> {
   startTelemetry(readTelemetryConfig());
+
+  const correlationIdFormat = winston.format((info) => {
+    const correlationId = getCorrelationId();
+    if (typeof info.correlationId === 'undefined') {
+      info.correlationId = correlationId ?? 'N/A';
+    }
+    return info;
+  });
 
   const app = await NestFactory.create(AppModule, { rawBody: true, logger: WinstonModule.createLogger({
     level: 'silly',
@@ -22,6 +31,7 @@ async function bootstrap(): Promise<void> {
       new winston.transports.Console({
         format: winston.format.combine(
           winston.format.timestamp(),
+          correlationIdFormat(),
           winston.format.json(),
         ),
       }),
@@ -29,6 +39,7 @@ async function bootstrap(): Promise<void> {
         filename: 'logs/app.log',
         format: winston.format.combine(
           winston.format.timestamp(),
+          correlationIdFormat(),
           winston.format.json(),
         ),
       }),
@@ -76,7 +87,8 @@ async function bootstrap(): Promise<void> {
         },
     credentials: true,
     methods: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'x-api-key'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'x-api-key', 'x-correlation-id'],
+    exposedHeaders: ['X-Correlation-ID'],
   });
 
   app.setGlobalPrefix(apiPrefix, {


### PR DESCRIPTION
### Summary
Add end-to-end request correlation ID support to improve distributed traceability and log searchability.

### Changes
- Generate a correlation ID for every incoming request (UUID fallback).
- Respect client-provided `X-Correlation-ID` when present.
- Return `X-Correlation-ID` in the response headers.
- Include `correlationId` in all log entries for request-level tracing.

### Issue Link
- Closes #792 