### PR TITLE
feat: integrate cache metrics and alerts with Prometheus support

### DIFF
--- a/backend/src/cache/cache.module.ts
+++ b/backend/src/cache/cache.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { CacheService } from './cache.service';
+import { PrometheusModule } from '../prometheus/prometheus.module';
 
 @Module({
+  imports: [PrometheusModule],
   providers: [CacheService],
   exports: [CacheService],
 })

--- a/backend/src/cache/cache.service.ts
+++ b/backend/src/cache/cache.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import Redis from 'ioredis';
 import { gzipSync, gunzipSync } from 'node:zlib';
+import { MetricsService } from '../prometheus/metrics.service';
 
 interface CacheEntry<T> {
   value: T;
@@ -20,7 +21,7 @@ export class CacheService implements OnModuleDestroy {
   // Only compress "large" payloads (bytes of JSON string).
   private readonly compressThresholdBytes = 8 * 1024;
 
-  constructor() {
+  constructor(private readonly metrics: MetricsService) {
     const redisUrl = process.env.REDIS_URL;
     const host = process.env.REDIS_HOST;
     const port = process.env.REDIS_PORT ? Number(process.env.REDIS_PORT) : undefined;
@@ -36,6 +37,27 @@ export class CacheService implements OnModuleDestroy {
         maxRetriesPerRequest: 1,
       });
     }
+  }
+
+  private keyPattern(key: string): string {
+    if (key.startsWith('exchange-rate:') || key.startsWith('exchange_rate:') || key.startsWith('rates:')) {
+      return 'exchange-rate';
+    }
+
+    if (key.startsWith('idempotency:payment:')) {
+      return 'idempotency:payment';
+    }
+
+    if (key.startsWith('session:blacklist:')) {
+      return 'session:blacklist';
+    }
+
+    const [prefix] = key.split(':');
+    return prefix || 'unknown';
+  }
+
+  private recordLookup(key: string, result: 'hit' | 'miss'): void {
+    this.metrics.recordCacheLookup(this.keyPattern(key), result);
   }
 
   async onModuleDestroy(): Promise<void> {
@@ -99,16 +121,27 @@ export class CacheService implements OnModuleDestroy {
     const redis = await this.ensureRedisConnected();
     if (redis) {
       const raw = await redis.get(key);
-      if (!raw) return undefined;
-      return this.decode<T>(raw);
+      if (!raw) {
+        this.recordLookup(key, 'miss');
+        return undefined;
+      }
+
+      const value = this.decode<T>(raw);
+      this.recordLookup(key, value === undefined ? 'miss' : 'hit');
+      return value;
     }
 
     const entry = this.store.get(key) as CacheEntry<T> | undefined;
-    if (!entry) return undefined;
-    if (Date.now() > entry.expiresAt) {
-      this.store.delete(key);
+    if (!entry) {
+      this.recordLookup(key, 'miss');
       return undefined;
     }
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(key);
+      this.recordLookup(key, 'miss');
+      return undefined;
+    }
+    this.recordLookup(key, 'hit');
     return entry.value;
   }
 

--- a/backend/src/prometheus/metrics.service.spec.ts
+++ b/backend/src/prometheus/metrics.service.spec.ts
@@ -109,5 +109,19 @@ describe('MetricsService', () => {
       );
     });
   });
+
+  describe('recordCacheLookup', () => {
+    it('should increment cache_requests_total for hit result', () => {
+      const spy = jest.spyOn(service.cacheRequestsTotal, 'inc');
+      service.recordCacheLookup('exchange-rate', 'hit');
+      expect(spy).toHaveBeenCalledWith({ key_pattern: 'exchange-rate', result: 'hit' });
+    });
+
+    it('should increment cache_requests_total for miss result', () => {
+      const spy = jest.spyOn(service.cacheRequestsTotal, 'inc');
+      service.recordCacheLookup('exchange-rate', 'miss');
+      expect(spy).toHaveBeenCalledWith({ key_pattern: 'exchange-rate', result: 'miss' });
+    });
+  });
 });
 

--- a/backend/src/prometheus/metrics.service.ts
+++ b/backend/src/prometheus/metrics.service.ts
@@ -10,6 +10,7 @@ export class MetricsService {
 
   readonly httpRequestsTotal: Counter<string>;
   readonly httpRequestDurationMs: Histogram<string>;
+  readonly cacheRequestsTotal: Counter<string>;
 
   constructor() {
     this.paymentCreatedTotal = new Counter({
@@ -49,6 +50,12 @@ export class MetricsService {
       labelNames: ['method', 'route', 'status'],
       buckets: [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000],
     });
+
+    this.cacheRequestsTotal = new Counter({
+      name: 'cache_requests_total',
+      help: 'Total cache lookups by key pattern and result',
+      labelNames: ['key_pattern', 'result'],
+    });
   }
 
   incrementPaymentCreated(type: string): void {
@@ -76,6 +83,10 @@ export class MetricsService {
     const labels = { method, route, status: String(status) };
     this.httpRequestsTotal.inc(labels);
     this.httpRequestDurationMs.observe(labels, durationMs);
+  }
+
+  recordCacheLookup(keyPattern: string, result: 'hit' | 'miss'): void {
+    this.cacheRequestsTotal.inc({ key_pattern: keyPattern, result });
   }
 }
 

--- a/grafana/dashboards/cache-metrics.json
+++ b/grafana/dashboards/cache-metrics.json
@@ -1,0 +1,87 @@
+{
+  "title": "Cache Performance",
+  "uid": "cheesepay-cache-performance",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "15s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Cache Lookups by Key Pattern (req/s)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(cache_requests_total[1m])) by (key_pattern, result)",
+          "legendFormat": "{{key_pattern}} {{result}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": { "mode": "palette-classic" }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Exchange Rate Cache Hit Rate",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 8, "w": 16, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(cache_requests_total{key_pattern=\"exchange-rate\",result=\"hit\"}[1m])) / sum(rate(cache_requests_total{key_pattern=\"exchange-rate\"}[1m]))",
+          "legendFormat": "exchange-rate hit rate",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.8 },
+              { "color": "green", "value": 0.9 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Exchange Rate Cache Hit Rate (Current)",
+      "type": "stat",
+      "gridPos": { "x": 16, "y": 8, "w": 8, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(cache_requests_total{key_pattern=\"exchange-rate\",result=\"hit\"}[1m])) / sum(rate(cache_requests_total{key_pattern=\"exchange-rate\"}[1m]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.8 },
+              { "color": "green", "value": 0.9 }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/grafana/provisioning/alerting/cache-alerts.yaml
+++ b/grafana/provisioning/alerting/cache-alerts.yaml
@@ -1,0 +1,30 @@
+apiVersion: 1
+
+rules:
+  - orgId: 1
+    name: CachePerformanceAlerts
+    folder: "Backend Alerts"
+    interval: 1m
+    rules:
+      - uid: "exchange-rate-cache-hit-rate-low"
+        title: "Exchange Rate Cache Hit Rate Below 80%"
+        condition: "A"
+        data:
+          - refId: "A"
+            queryType: "range"
+            datasourceUid: "Prometheus"
+            relativeTimeRange:
+              from: 60
+              to: 0
+            model:
+              refId: "A"
+              expr: '((sum(rate(cache_requests_total{key_pattern="exchange-rate",result="hit"}[1m])) / sum(rate(cache_requests_total{key_pattern="exchange-rate"}[1m]))) < 0.8) and (sum(rate(cache_requests_total{key_pattern="exchange-rate"}[1m])) > 0)'
+        noDataState: OK
+        execErrState: Alerting
+        for: 0s
+        annotations:
+          summary: "Exchange rate cache hit rate dropped below 80%"
+          description: "Hit rate for key_pattern=exchange-rate is below 0.80 over the last 1 minute. Value: {{ $values.A.Value }}"
+        labels:
+          severity: "warning"
+          component: "cache"

--- a/grafana/provisioning/datasources/prometheus.yaml
+++ b/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://host.docker.internal:9090
+    isDefault: false


### PR DESCRIPTION
## Summary
Add cache hit/miss metrics by key pattern, export via Prometheus, and add Grafana alerting/dashboard for exchange-rate cache hit rate.

## Issue
Closes #758 
