### PR TITLE
feat: integrate caching mechanism across services and modules

### DIFF
--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -9,9 +9,14 @@ import { FeeConfig } from '../fee-config/entities/fee-config.entity';
 import { FeeHistory } from '../fee-config/entities/fee-history.entity';
 import { CronModule } from '../cron/cron.module';
 import { AuditLog } from './entities/audit-log.entity';
+import { CacheModule } from '../cache/cache.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Merchant, Payment, FeeConfig, FeeHistory, AuditLog]), CronModule],
+  imports: [
+    TypeOrmModule.forFeature([Merchant, Payment, FeeConfig, FeeHistory, AuditLog]),
+    CronModule,
+    CacheModule,
+  ],
   controllers: [AdminController, CronAdminController],
   providers: [AdminService],
   exports: [AdminService],

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -15,9 +15,13 @@ import { FeeHistory, FeeChangeType } from '../fee-config/entities/fee-history.en
 import { AuditLog } from './entities/audit-log.entity';
 import { FilterService } from '../common/filter.service';
 import { PaginationDto, PaginatedResponseDto } from '../common/dto/pagination.dto';
+import { CacheService } from '../cache/cache.service';
 
 @Injectable()
 export class AdminService {
+  private readonly platformFeeCacheKey = 'fee-config:platform:global';
+  private readonly platformFeeTtlSeconds = 300;
+
   constructor(
     @InjectRepository(Merchant)
     private merchantsRepo: Repository<Merchant>,
@@ -30,6 +34,7 @@ export class AdminService {
     @InjectRepository(AuditLog)
     private readonly auditLogRepo: Repository<AuditLog>,
     private readonly filterService: FilterService,
+    private readonly cache: CacheService,
   ) {}
 
   async findAllMerchants(page = 1, limit = 20) {
@@ -105,7 +110,12 @@ export class AdminService {
   // ── Fee Management ─────────────────────────────────────────────────────────
 
   async getGlobalFees(): Promise<FeeConfig[]> {
-    return this.feeConfigRepo.find({ order: { feeType: 'ASC' } });
+    const { value } = await this.cache.getOrSet(
+      this.platformFeeCacheKey,
+      () => this.feeConfigRepo.find({ order: { feeType: 'ASC' } }),
+      { ttlSeconds: this.platformFeeTtlSeconds },
+    );
+    return value;
   }
 
   async updateGlobalFee(
@@ -122,6 +132,7 @@ export class AdminService {
     const previousValue = feeConfig.baseFeeRate;
     feeConfig.baseFeeRate = newRate;
     const updated = await this.feeConfigRepo.save(feeConfig);
+    await this.cache.del(this.platformFeeCacheKey);
 
     await this.recordFeeHistory({
       feeType,

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -33,6 +33,7 @@ import { HttpMetricsInterceptor } from './prometheus/http-metrics.interceptor';
 
 import { MiddlewareConsumer, NestModule } from '@nestjs/common';
 import { CorrelationIdMiddleware } from './common/middleware/correlation-id.middleware';
+import { CacheWarmupService } from './cache/cache-warmup.service';
 
 @Module({
   imports: [
@@ -121,6 +122,7 @@ import { CorrelationIdMiddleware } from './common/middleware/correlation-id.midd
       provide: APP_FILTER,
       useClass: SentryExceptionFilter,
     },
+    CacheWarmupService,
   ],
 })
 export class AppModule implements NestModule {

--- a/backend/src/cache/cache-warmup.service.ts
+++ b/backend/src/cache/cache-warmup.service.ts
@@ -1,0 +1,47 @@
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import { AdminService } from '../admin/admin.service';
+import { MerchantsService } from '../merchants/merchants.service';
+import { StellarService } from '../stellar/stellar.service';
+
+@Injectable()
+export class CacheWarmupService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(CacheWarmupService.name);
+
+  constructor(
+    private readonly stellarService: StellarService,
+    private readonly adminService: AdminService,
+    private readonly merchantsService: MerchantsService,
+  ) {}
+
+  async onApplicationBootstrap(): Promise<void> {
+    if (process.env.NODE_ENV === 'test') {
+      this.logger.log('Cache warm-up skipped in test environment');
+      return;
+    }
+
+    const startedAt = Date.now();
+    const tasks: Array<{ key: string; run: () => Promise<unknown> }> = [
+      { key: 'exchange-rate:xlm-usd', run: () => this.stellarService.getXlmUsdRate() },
+      { key: 'fee-config:platform:global', run: () => this.adminService.getGlobalFees() },
+      { key: 'merchant:active:count', run: () => this.merchantsService.getActiveMerchantCount() },
+    ];
+
+    for (const task of tasks) {
+      const keyStartedAt = Date.now();
+      try {
+        await task.run();
+        this.logger.log(
+          `Cache warm-up key=${task.key} durationMs=${Date.now() - keyStartedAt}`,
+        );
+      } catch (error) {
+        this.logger.warn(
+          `Cache warm-up failed key=${task.key} durationMs=${Date.now() - keyStartedAt} error=${String((error as Error)?.message ?? error)}`,
+        );
+      }
+    }
+
+    this.logger.log(
+      `Cache warm-up completed durationMs=${Date.now() - startedAt}`,
+    );
+  }
+}

--- a/backend/src/merchants/merchants.module.ts
+++ b/backend/src/merchants/merchants.module.ts
@@ -7,9 +7,10 @@ import { Merchant } from './entities/merchant.entity';
 import { AdminAuditLog } from './entities/admin-audit-log.entity';
 import { NotificationPreference } from '../notifications/entities/notification-preference.entity';
 import { NotificationPrefsService } from '../notifications/notification-prefs.service';
+import { CacheModule } from '../cache/cache.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Merchant, AdminAuditLog, NotificationPreference])],
+  imports: [TypeOrmModule.forFeature([Merchant, AdminAuditLog, NotificationPreference]), CacheModule],
   controllers: [MerchantsController, AdminMerchantsController],
   providers: [MerchantsService, NotificationPrefsService],
   exports: [MerchantsService, NotificationPrefsService],

--- a/backend/src/merchants/merchants.service.ts
+++ b/backend/src/merchants/merchants.service.ts
@@ -7,15 +7,29 @@ import { Merchant, MerchantStatus } from './entities/merchant.entity';
 import { AdminAuditLog } from './entities/admin-audit-log.entity';
 import { UpdateMerchantDto } from './dto/create-merchant.dto';
 import { BulkMerchantActionDto, BulkActionResponseDto, BulkActionResultDto } from './dto/bulk-merchant-action.dto';
+import { CacheService } from '../cache/cache.service';
 
 @Injectable()
 export class MerchantsService {
+  private readonly activeMerchantCountCacheKey = 'merchant:active:count';
+  private readonly activeMerchantCountTtlSeconds = 300;
+
   constructor(
     @InjectRepository(Merchant)
     private merchantsRepo: Repository<Merchant>,
     @InjectRepository(AdminAuditLog)
     private auditRepo: Repository<AdminAuditLog>,
+    private readonly cache: CacheService,
   ) {}
+
+  async getActiveMerchantCount(): Promise<number> {
+    const { value } = await this.cache.getOrSet<number>(
+      this.activeMerchantCountCacheKey,
+      () => this.merchantsRepo.count({ where: { status: MerchantStatus.ACTIVE } }),
+      { ttlSeconds: this.activeMerchantCountTtlSeconds },
+    );
+    return value;
+  }
 
   async findOne(id: string): Promise<Merchant> {
     const merchant = await this.merchantsRepo.findOne({ where: { id } });
@@ -26,7 +40,9 @@ export class MerchantsService {
   async update(id: string, dto: UpdateMerchantDto): Promise<Merchant> {
     const merchant = await this.findOne(id);
     Object.assign(merchant, dto);
-    return this.merchantsRepo.save(merchant);
+    const updated = await this.merchantsRepo.save(merchant);
+    await this.cache.del(this.activeMerchantCountCacheKey);
+    return updated;
   }
 
   async bulkUpdateStatus(
@@ -48,6 +64,7 @@ export class MerchantsService {
         const oldStatus = merchant.status;
         merchant.status = status;
         await this.merchantsRepo.save(merchant);
+        await this.cache.del(this.activeMerchantCountCacheKey);
 
         await this.auditRepo.save({
           adminId,
@@ -101,6 +118,8 @@ export class MerchantsService {
     }
 
     merchant.customFeeRate = customFeeRate != null ? String(customFeeRate) : null;
-    return this.merchantsRepo.save(merchant);
+    const updated = await this.merchantsRepo.save(merchant);
+    await this.cache.del(this.activeMerchantCountCacheKey);
+    return updated;
   }
 }

--- a/backend/src/stellar/stellar.module.ts
+++ b/backend/src/stellar/stellar.module.ts
@@ -10,6 +10,7 @@ import { WebhooksModule } from '../webhooks/webhooks.module';
 import { QUEUE_NAMES } from '../queues/queue.constants';
 import { EmailModule } from '../email/email.module';
 import { MerchantsModule } from '../merchants/merchants.module';
+import { CacheModule } from '../cache/cache.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { MerchantsModule } from '../merchants/merchants.module';
     WebhooksModule,
     EmailModule,
     MerchantsModule,
+    CacheModule,
     BullModule.registerQueue({ name: QUEUE_NAMES.stellarMonitor }),
   ],
   providers: [StellarService, StellarMonitorService],

--- a/backend/src/stellar/stellar.service.ts
+++ b/backend/src/stellar/stellar.service.ts
@@ -1,16 +1,22 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as StellarSdk from '@stellar/stellar-sdk';
+import { CacheService } from '../cache/cache.service';
 
 @Injectable()
 export class StellarService implements OnModuleInit {
   private readonly logger = new Logger(StellarService.name);
+  private readonly exchangeRateCacheKey = 'exchange-rate:xlm-usd';
+  private readonly exchangeRateTtlSeconds = 30;
   private server: StellarSdk.Horizon.Server;
   private keypair: StellarSdk.Keypair;
   private networkPassphrase: string;
   private usdcAsset: StellarSdk.Asset;
 
-  constructor(private config: ConfigService) {}
+  constructor(
+    private config: ConfigService,
+    private readonly cacheService: CacheService,
+  ) {}
 
   onModuleInit() {
     const network = this.config.get('STELLAR_NETWORK', 'TESTNET');
@@ -50,18 +56,26 @@ export class StellarService implements OnModuleInit {
   }
 
   async getXlmUsdRate(): Promise<number> {
-    try {
-      const orderbook = await this.server
-        .orderbook(StellarSdk.Asset.native(), this.usdcAsset)
-        .call();
-      const bestAsk = orderbook.asks[0];
-      if (bestAsk) return parseFloat(bestAsk.price);
+    const { value } = await this.cacheService.getOrSet<number>(
+      this.exchangeRateCacheKey,
+      async () => {
+        try {
+          const orderbook = await this.server
+            .orderbook(StellarSdk.Asset.native(), this.usdcAsset)
+            .call();
+          const bestAsk = orderbook.asks[0];
+          if (bestAsk) return parseFloat(bestAsk.price);
 
-      return 0.1;
-    } catch (err) {
-      this.logger.warn('Failed to fetch XLM/USD rate, using fallback');
-      return 0.1;
-    }
+          return 0.1;
+        } catch (err) {
+          this.logger.warn('Failed to fetch XLM/USD rate, using fallback');
+          return 0.1;
+        }
+      },
+      { ttlSeconds: this.exchangeRateTtlSeconds },
+    );
+
+    return value;
   }
 
   async getAccountTransactions(


### PR DESCRIPTION
## Summary
Add startup cache warm-up for critical keys (exchange rate, platform fees, active merchant count) to reduce cold-start latency, with per-key timing logs and test-environment skip.

## Issue
- Closes #756 