### PR TITLE
#754 [Cache] Analytics result caching

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -40,6 +40,7 @@
         "handlebars": "^4.7.8",
         "helmet": "^8.1.0",
         "ioredis": "^5.7.0",
+        "lz4js": "^0.2.0",
         "nest-winston": "^1.10.2",
         "nodemailer": "^6.9.16",
         "passport": "^0.6.0",
@@ -10866,6 +10867,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/lz4js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/lz4js/-/lz4js-0.2.0.tgz",
+      "integrity": "sha512-gY2Ia9Lm7Ep8qMiuGRhvUq0Q7qUereeldZPP1PMEJxPtEWHJLqw9pgX68oHajBH0nzJK4MaZEA/YNV3jT8u8Bg==",
+      "license": "ISC"
     },
     "node_modules/magic-string": {
       "version": "0.30.8",

--- a/backend/package.json
+++ b/backend/package.json
@@ -56,6 +56,7 @@
     "handlebars": "^4.7.8",
     "helmet": "^8.1.0",
     "ioredis": "^5.7.0",
+    "lz4js": "^0.2.0",
     "nest-winston": "^1.10.2",
     "nodemailer": "^6.9.16",
     "passport": "^0.6.0",

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -40,13 +40,13 @@ importers:
         version: 7.4.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.19)(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)
       '@nestjs/terminus':
         specifier: ^11.1.1
-        version: 11.1.1(@grpc/grpc-js@1.14.3)(@grpc/proto-loader@0.8.0)(@nestjs/axios@4.0.1(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(axios@1.15.2)(rxjs@7.8.2))(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.19)(@nestjs/typeorm@10.0.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.2.45(pg@8.20.0)))(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.2.45(pg@8.20.0))
+        version: 11.1.1(@grpc/grpc-js@1.14.3)(@grpc/proto-loader@0.8.0)(@nestjs/axios@4.0.1(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(axios@1.15.2)(rxjs@7.8.2))(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.19)(@nestjs/typeorm@10.0.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.2.45(ioredis@5.10.1)(pg@8.20.0)))(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.2.45(ioredis@5.10.1)(pg@8.20.0))
       '@nestjs/throttler':
         specifier: ^6.0.0
         version: 6.5.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.1.14)
       '@nestjs/typeorm':
         specifier: ^10.0.0
-        version: 10.0.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.2.45(pg@8.20.0))
+        version: 10.0.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.2.45(ioredis@5.10.1)(pg@8.20.0))
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -98,6 +98,12 @@ importers:
       helmet:
         specifier: ^8.1.0
         version: 8.1.0
+      ioredis:
+        specifier: ^5.7.0
+        version: 5.10.1
+      lz4js:
+        specifier: ^0.2.0
+        version: 0.2.0
       nest-winston:
         specifier: ^1.10.2
         version: 1.10.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(winston@3.19.0)
@@ -127,7 +133,7 @@ importers:
         version: 7.8.2
       typeorm:
         specifier: ^0.2.41
-        version: 0.2.45(pg@8.20.0)
+        version: 0.2.45(ioredis@5.10.1)(pg@8.20.0)
       uuid:
         specifier: ^14.0.0
         version: 14.0.0
@@ -177,6 +183,9 @@ importers:
       eslint:
         specifier: ^8.42.0
         version: 8.57.1
+      eslint-plugin-security:
+        specifier: ^4.0.0
+        version: 4.0.0
       jest:
         specifier: ^29.5.0
         version: 29.7.0(@types/node@20.19.39)(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
@@ -2613,6 +2622,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  eslint-plugin-security@4.0.0:
+    resolution: {integrity: sha512-tfuQT8K/Li1ZxhFzyD8wPIKtlzZxqBcPr9q0jFMQ77wWAbKBVEhaMPVQRTMTvCMUDhwBe5vPVqQPwAGk/ASfxQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
@@ -3427,6 +3440,9 @@ packages:
     resolution: {integrity: sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==}
     engines: {node: '>=12'}
 
+  lz4js@0.2.0:
+    resolution: {integrity: sha512-gY2Ia9Lm7Ep8qMiuGRhvUq0Q7qUereeldZPP1PMEJxPtEWHJLqw9pgX68oHajBH0nzJK4MaZEA/YNV3jT8u8Bg==}
+
   magic-string@0.30.8:
     resolution: {integrity: sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==}
     engines: {node: '>=12'}
@@ -3934,6 +3950,10 @@ packages:
   reflect-metadata@0.1.14:
     resolution: {integrity: sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==}
 
+  regexp-tree@0.1.27:
+    resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
+    hasBin: true
+
   repeat-string@1.6.1:
     resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
     engines: {node: '>=0.10'}
@@ -4014,6 +4034,9 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-regex@2.1.1:
+    resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
 
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
@@ -5383,7 +5406,7 @@ snapshots:
       class-transformer: 0.5.1
       class-validator: 0.14.4
 
-  '@nestjs/terminus@11.1.1(@grpc/grpc-js@1.14.3)(@grpc/proto-loader@0.8.0)(@nestjs/axios@4.0.1(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(axios@1.15.2)(rxjs@7.8.2))(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.19)(@nestjs/typeorm@10.0.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.2.45(pg@8.20.0)))(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.2.45(pg@8.20.0))':
+  '@nestjs/terminus@11.1.1(@grpc/grpc-js@1.14.3)(@grpc/proto-loader@0.8.0)(@nestjs/axios@4.0.1(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(axios@1.15.2)(rxjs@7.8.2))(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.19)(@nestjs/typeorm@10.0.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.2.45(ioredis@5.10.1)(pg@8.20.0)))(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.2.45(ioredis@5.10.1)(pg@8.20.0))':
     dependencies:
       '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nestjs/core': 11.1.19(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.1.14)(rxjs@7.8.2)
@@ -5395,8 +5418,8 @@ snapshots:
       '@grpc/grpc-js': 1.14.3
       '@grpc/proto-loader': 0.8.0
       '@nestjs/axios': 4.0.1(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(axios@1.15.2)(rxjs@7.8.2)
-      '@nestjs/typeorm': 10.0.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.2.45(pg@8.20.0))
-      typeorm: 0.2.45(pg@8.20.0)
+      '@nestjs/typeorm': 10.0.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.2.45(ioredis@5.10.1)(pg@8.20.0))
+      typeorm: 0.2.45(ioredis@5.10.1)(pg@8.20.0)
 
   '@nestjs/testing@11.1.19(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.19)(@nestjs/platform-express@10.4.22)':
     dependencies:
@@ -5412,13 +5435,13 @@ snapshots:
       '@nestjs/core': 11.1.19(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       reflect-metadata: 0.1.14
 
-  '@nestjs/typeorm@10.0.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.2.45(pg@8.20.0))':
+  '@nestjs/typeorm@10.0.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.2.45(ioredis@5.10.1)(pg@8.20.0))':
     dependencies:
       '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nestjs/core': 11.1.19(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       reflect-metadata: 0.1.14
       rxjs: 7.8.2
-      typeorm: 0.2.45(pg@8.20.0)
+      typeorm: 0.2.45(ioredis@5.10.1)(pg@8.20.0)
       uuid: 9.0.1
 
   '@noble/hashes@1.8.0': {}
@@ -7665,6 +7688,10 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  eslint-plugin-security@4.0.0:
+    dependencies:
+      safe-regex: 2.1.1
+
   eslint-scope@5.1.1:
     dependencies:
       esrecurse: 4.3.0
@@ -8806,6 +8833,8 @@ snapshots:
 
   luxon@3.5.0: {}
 
+  lz4js@0.2.0: {}
+
   magic-string@0.30.8:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -9281,6 +9310,8 @@ snapshots:
 
   reflect-metadata@0.1.14: {}
 
+  regexp-tree@0.1.27: {}
+
   repeat-string@1.6.1: {}
 
   require-addon@1.2.0:
@@ -9356,6 +9387,10 @@ snapshots:
       tslib: 2.8.1
 
   safe-buffer@5.2.1: {}
+
+  safe-regex@2.1.1:
+    dependencies:
+      regexp-tree: 0.1.27
 
   safe-stable-stringify@2.5.0: {}
 
@@ -9750,7 +9785,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typeorm@0.2.45(pg@8.20.0):
+  typeorm@0.2.45(ioredis@5.10.1)(pg@8.20.0):
     dependencies:
       '@sqltools/formatter': 1.2.5
       app-root-path: 3.1.0
@@ -9770,6 +9805,7 @@ snapshots:
       yargs: 17.7.2
       zen-observable-ts: 1.1.0
     optionalDependencies:
+      ioredis: 5.10.1
       pg: 8.20.0
     transitivePeerDependencies:
       - supports-color

--- a/backend/src/analytics/analytics.service.spec.ts
+++ b/backend/src/analytics/analytics.service.spec.ts
@@ -290,5 +290,88 @@ describe('AnalyticsService', () => {
       expect(settlementQueryBuilder.getRawMany).toHaveBeenCalledTimes(1);
       expect(settlementQueryBuilder.getRawOne).toHaveBeenCalledTimes(2);
     });
+
+    it('should cache merchant revenue for 5 minutes', async () => {
+      settlementQueryBuilder.getRawMany.mockResolvedValueOnce([]);
+      settlementQueryBuilder.getRawOne
+        .mockResolvedValueOnce({ total: '0.000000' })
+        .mockResolvedValueOnce({ total: '0.000000' });
+
+      await service.getRevenue({
+        scope: 'merchant',
+        merchantId: mockMerchantId,
+        period: 'daily',
+        from: '2026-04-01',
+        to: '2026-04-01',
+      });
+
+      expect(cache.getOrSet).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Function),
+        { ttlSeconds: 300 },
+      );
+    });
+
+    it('should cache admin revenue for 10 minutes', async () => {
+      settlementQueryBuilder.getRawMany.mockResolvedValueOnce([]);
+      settlementQueryBuilder.getRawOne
+        .mockResolvedValueOnce({ total: '0.000000' })
+        .mockResolvedValueOnce({ total: '0.000000' });
+
+      await service.getRevenue({
+        scope: 'admin',
+        period: 'daily',
+        from: '2026-04-01',
+        to: '2026-04-01',
+      });
+
+      expect(cache.getOrSet).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Function),
+        { ttlSeconds: 600 },
+      );
+    });
+  });
+
+  describe('analytics cache TTL', () => {
+    it('should cache funnel for 5 minutes', async () => {
+      paymentQueryBuilder.getRawMany.mockResolvedValueOnce([]);
+
+      await service.getFunnel(mockMerchantId);
+
+      expect(cache.getOrSet).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Function),
+        { ttlSeconds: 300 },
+      );
+    });
+
+    it('should cache comparison for 5 minutes', async () => {
+      paymentQueryBuilder.getRawOne
+        .mockResolvedValueOnce({ total: '10' })
+        .mockResolvedValueOnce({ total: '5' });
+
+      await service.getComparison(mockMerchantId, 'daily');
+
+      expect(cache.getOrSet).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Function),
+        { ttlSeconds: 300 },
+      );
+    });
+
+    it('should cache network breakdown for 5 minutes', async () => {
+      paymentQueryBuilder.getRawMany
+        .mockResolvedValueOnce([{ network: 'stellar', count: '1', volumeUsd: '10' }])
+        .mockResolvedValueOnce([{ network: 'stellar', date: '2026-04-01', count: '1', volumeUsd: '10' }]);
+
+      await service.getNetworkBreakdown(mockMerchantId, 'volume', 'daily');
+
+      expect(cache.getOrSet).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Function),
+        { ttlSeconds: 300 },
+      );
+    });
   });
 });

--- a/backend/src/analytics/analytics.service.ts
+++ b/backend/src/analytics/analytics.service.ts
@@ -8,6 +8,8 @@ import { CacheService } from '../cache/cache.service';
 type AnalyticsPeriod = 'daily' | 'monthly';
 type VolumeScope = 'merchant' | 'admin';
 type RevenueScope = 'merchant' | 'admin';
+const MERCHANT_ANALYTICS_TTL_MS = 5 * 60 * 1000;
+const ADMIN_ANALYTICS_TTL_MS = 10 * 60 * 1000;
 
 interface VolumeOptions {
   merchantId?: string;
@@ -73,7 +75,7 @@ export class AnalyticsService {
   private async getCachedData<T extends Record<string, any>>(
     key: string,
     fetchFn: () => Promise<T>,
-    ttlMs = 60_000,
+    ttlMs = MERCHANT_ANALYTICS_TTL_MS,
   ): Promise<T & { cacheHit: boolean }> {
     const { value, cacheHit } = await this.cache.getOrSet(key, fetchFn, {
       ttlSeconds: Math.max(1, Math.floor(ttlMs / 1000)),
@@ -98,6 +100,10 @@ export class AnalyticsService {
     return parseFloat((((current - previous) / previous) * 100).toFixed(2));
   }
 
+  private resolveAnalyticsTtlMs(scope: RevenueScope | VolumeScope): number {
+    return scope === 'admin' ? ADMIN_ANALYTICS_TTL_MS : MERCHANT_ANALYTICS_TTL_MS;
+  }
+
   async getVolume(options: VolumeOptions) {
     const { merchantId, period, scope, dateFrom, dateTo } = options;
     const range = this.resolveVolumeRange(period, dateFrom, dateTo);
@@ -107,7 +113,7 @@ export class AnalyticsService {
       dateRange: `${period}:${range.start.toISOString()}-${range.endExclusive.toISOString()}`,
     });
 
-    const ttlMs = scope === 'admin' ? 10 * 60 * 1000 : 5 * 60 * 1000;
+    const ttlMs = this.resolveAnalyticsTtlMs(scope);
 
     return this.getCachedValue(cacheKey,
       async () => {
@@ -170,7 +176,7 @@ export class AnalyticsService {
           conversionRate: this.pctChange(current.percentages.conversionRate, previous.percentages.conversionRate),
         },
       };
-    });
+    }, MERCHANT_ANALYTICS_TTL_MS);
   }
 
   async getComparison(merchantId: string, period: AnalyticsPeriod) {
@@ -207,7 +213,7 @@ export class AnalyticsService {
         previousPeriod: { start: prevStart, end: prevEnd, volume: prevVolume },
         growth,
       };
-    });
+    }, MERCHANT_ANALYTICS_TTL_MS);
   }
 
   async getRevenue(options: RevenueOptions) {
@@ -218,7 +224,7 @@ export class AnalyticsService {
       endpoint: 'revenue',
       dateRange: `${period}:${current.start.toISOString()}-${current.endExclusive.toISOString()}:${previous.start.toISOString()}-${previous.endExclusive.toISOString()}`,
     });
-    const ttlMs = scope === 'admin' ? 10 * 60 * 1000 : 5 * 60 * 1000;
+    const ttlMs = this.resolveAnalyticsTtlMs(scope);
 
     return this.getCachedData(cacheKey, async () => {
       const [currentRows, currentTotal, previousTotal] = await Promise.all([
@@ -330,7 +336,7 @@ export class AnalyticsService {
       networks.sort((a, b) => (sortBy === 'count' ? b.count - a.count : b.volumeUsd - a.volumeUsd));
 
       return { networks, totals };
-    });
+    }, MERCHANT_ANALYTICS_TTL_MS);
   }
 
   private async getCachedValue<T>(key: string, fetchFn: () => Promise<T>, ttlMs = 60_000): Promise<T> {

--- a/backend/src/cache/cache.service.spec.ts
+++ b/backend/src/cache/cache.service.spec.ts
@@ -1,0 +1,29 @@
+import { CacheService } from './cache.service';
+
+describe('CacheService', () => {
+  let service: CacheService;
+
+  beforeEach(() => {
+    delete process.env.REDIS_URL;
+    delete process.env.REDIS_HOST;
+    delete process.env.REDIS_PORT;
+    service = new CacheService();
+  });
+
+  it('should store small payloads without compression envelope', () => {
+    const raw = (service as any).encode({ ok: true });
+    const envelope = JSON.parse(raw);
+    expect(envelope.encoding).toBe('json');
+  });
+
+  it('should use lz4 compression for large payloads and decode them', () => {
+    const payload = { data: 'x'.repeat(10_000), count: 42 };
+    const raw = (service as any).encode(payload);
+    const envelope = JSON.parse(raw);
+
+    expect(envelope.encoding).toBe('lz4+base64');
+
+    const decoded = (service as any).decode(raw);
+    expect(decoded).toEqual(payload);
+  });
+});

--- a/backend/src/cache/cache.service.ts
+++ b/backend/src/cache/cache.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import Redis from 'ioredis';
-import { gzipSync, gunzipSync } from 'node:zlib';
+import { compress, decompress } from 'lz4js';
 
 interface CacheEntry<T> {
   value: T;
@@ -9,7 +9,7 @@ interface CacheEntry<T> {
 
 type CacheEnvelope =
   | { v: 1; encoding: 'json'; payload: string }
-  | { v: 1; encoding: 'gzip+base64'; payload: string };
+  | { v: 1; encoding: 'lz4+base64'; payload: string };
 
 @Injectable()
 export class CacheService implements OnModuleDestroy {
@@ -67,8 +67,8 @@ export class CacheService implements OnModuleDestroy {
       bytes >= this.compressThresholdBytes
         ? {
             v: 1,
-            encoding: 'gzip+base64',
-            payload: gzipSync(Buffer.from(json, 'utf8')).toString('base64'),
+            encoding: 'lz4+base64',
+            payload: Buffer.from(compress(Buffer.from(json, 'utf8'))).toString('base64'),
           }
         : { v: 1, encoding: 'json', payload: json };
     return JSON.stringify(envelope);
@@ -84,9 +84,9 @@ export class CacheService implements OnModuleDestroy {
       if (envelope.encoding === 'json') {
         return JSON.parse(envelope.payload) as T;
       }
-      if (envelope.encoding === 'gzip+base64') {
+      if (envelope.encoding === 'lz4+base64') {
         const buf = Buffer.from(envelope.payload, 'base64');
-        const json = gunzipSync(buf).toString('utf8');
+        const json = Buffer.from(decompress(buf)).toString('utf8');
         return JSON.parse(json) as T;
       }
       return undefined;

--- a/backend/src/settlements/settlements.service.ts
+++ b/backend/src/settlements/settlements.service.ts
@@ -40,6 +40,11 @@ export class SettlementsService {
     private notificationPrefs: NotificationPrefsService,
   ) {}
 
+  private async invalidateAnalyticsForMerchant(merchantId: string): Promise<void> {
+    await this.cache.delPattern(`analytics:${merchantId}:*`);
+    await this.cache.delPattern('analytics:admin:*');
+  }
+
   async initiateSettlement(payment: Payment): Promise<void> {
     const feeRate = 0.015;
     const feeUsd = payment.amountUsd * feeRate;
@@ -111,9 +116,8 @@ export class SettlementsService {
       payment.status = PaymentStatus.SETTLED;
       await this.paymentsRepo.save(payment);
 
-      // Invalidate analytics caches impacted by new settled payment.
-      await this.cache.delPattern(`analytics:${settlement.merchantId}:*`);
-      await this.cache.delPattern('analytics:admin:*');
+      // Invalidate analytics caches impacted by payment.settled.
+      await this.invalidateAnalyticsForMerchant(settlement.merchantId);
 
       await this.webhooks.dispatch(settlement.merchantId, 'payment.settled', {
         paymentId: payment.id,
@@ -203,9 +207,8 @@ export class SettlementsService {
         payment.status = PaymentStatus.SETTLED;
         await this.paymentsRepo.save(payment);
 
-        // Invalidate analytics caches impacted by new settled payment.
-        await this.cache.delPattern(`analytics:${settlement.merchantId}:*`);
-        await this.cache.delPattern('analytics:admin:*');
+        // Invalidate analytics caches impacted by payment.settled.
+        await this.invalidateAnalyticsForMerchant(settlement.merchantId);
 
         await this.webhooks.dispatch(settlement.merchantId, 'payment.settled', {
           paymentId: payment.id,


### PR DESCRIPTION
Closes #754

---

This PR closes issue #754
Overview
Cache aggregation query results to avoid repeated heavy DB computation.\n\n## Changes\n- Cache key format: analytics:{merchantId}:{endpoint}:{dateRange}
Merchant analytics TTL set to 5 minutes
 Admin analytics TTL set to 10 minutes\n- Invalidate analytics cache on payment.settled settlement success path\n- Compress large cache payloads with LZ4 before Redis storage\n\n## Acceptance Criteria
Cached responses < 20ms
Uncached responses computed within 2 seconds
Cache invalidated when a payment settles
Notes
Added cache service unit coverage for LZ4 envelope encode/decode
/moAdded analytics service TTL coverage for merchant/admin and endpoint defaults