### PR TITLE
fix: batch small merchant settlements

### DIFF
--- a/backend/src/queues/queue.processors.ts
+++ b/backend/src/queues/queue.processors.ts
@@ -7,8 +7,7 @@ import { SettlementsService } from '../settlements/settlements.service';
 import { CacheService } from '../cache/cache.service';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { Settlement, SettlementStatus } from '../settlements/entities/settlement.entity';
-import { Payment } from '../payments/entities/payment.entity';
+import { Settlement } from '../settlements/entities/settlement.entity';
 
 interface QueueDispatchPayload {
   type?: string;
@@ -38,19 +37,18 @@ export class SettlementQueueProcessor extends BaseQueueProcessor {
     private readonly cacheService: CacheService,
     @InjectRepository(Settlement)
     private readonly settlementsRepo: Repository<Settlement>,
-    @InjectRepository(Payment)
-    private readonly paymentsRepo: Repository<Payment>,
   ) {
     super(SettlementQueueProcessor.name);
   }
 
   @Process(DEFAULT_QUEUE_JOB)
-  async handle(job: Job<{ settlementId: string; paymentId: string }>): Promise<void> {
+  async handle(job: Job<{ settlementId: string }>): Promise<void> {
     this.logJob(job);
-    const { settlementId, paymentId } = job.data;
+    const { settlementId } = job.data;
 
     const settlement = await this.settlementsRepo.findOne({
       where: { id: settlementId },
+      relations: ['payments'],
     });
 
     if (!settlement) {
@@ -58,12 +56,8 @@ export class SettlementQueueProcessor extends BaseQueueProcessor {
       return;
     }
 
-    const payment = await this.paymentsRepo.findOne({
-      where: { id: paymentId },
-    });
-
-    if (!payment) {
-      this.logger.error(`Payment ${paymentId} not found`);
+    if (!settlement.payments || settlement.payments.length === 0) {
+      this.logger.error(`Settlement ${settlementId} has no linked payments`);
       return;
     }
 
@@ -84,7 +78,7 @@ export class SettlementQueueProcessor extends BaseQueueProcessor {
     }
 
     try {
-      await this.settlementsService.executeFiatTransfer(settlement, payment);
+      await this.settlementsService.executeFiatTransfer(settlement);
     } finally {
       await (this.cacheService as any).redis.del(`lock:${lockKey}`);
     }

--- a/backend/src/settlements/settlements.service.spec.ts
+++ b/backend/src/settlements/settlements.service.spec.ts
@@ -1,0 +1,172 @@
+import { ConfigService } from '@nestjs/config';
+import { SettlementsService } from './settlements.service';
+import { Settlement, SettlementStatus } from './entities/settlement.entity';
+import { Payment, PaymentStatus } from '../payments/entities/payment.entity';
+import { AdminAlertService } from '../alerts/admin-alert.service';
+import { WebhooksService } from '../webhooks/webhooks.service';
+import { CacheService } from '../cache/cache.service';
+import { EmailService } from '../email/email.service';
+import { MerchantsService } from '../merchants/merchants.service';
+import { NotificationPrefsService } from '../notifications/notification-prefs.service';
+
+describe('SettlementsService batching', () => {
+  let service: SettlementsService;
+  let settlementsRepo: any;
+  let paymentsRepo: any;
+  let settlementQueue: any;
+
+  const deps = () => ({
+    config: { get: jest.fn() } as unknown as ConfigService,
+    webhooks: { dispatch: jest.fn().mockResolvedValue(undefined) } as unknown as WebhooksService,
+    adminAlerts: {
+      raise: jest.fn().mockResolvedValue(null),
+    } as unknown as AdminAlertService,
+    cache: { delPattern: jest.fn().mockResolvedValue(undefined) } as unknown as CacheService,
+    emailService: { queue: jest.fn().mockResolvedValue(undefined) } as unknown as EmailService,
+    merchantsService: { findOne: jest.fn().mockResolvedValue({ email: 'merchant@example.com' }) } as unknown as MerchantsService,
+    notificationPrefs: { isEnabled: jest.fn().mockResolvedValue(false) } as unknown as NotificationPrefsService,
+  });
+
+  beforeEach(() => {
+    settlementsRepo = {
+      create: jest.fn((input) => ({ id: 'settlement-1', ...input } as Settlement)),
+      save: jest.fn(async (settlement: Settlement) => settlement),
+      findOne: jest.fn(),
+      findAndCount: jest.fn(),
+    };
+
+    paymentsRepo = {
+      save: jest.fn(async (payment: Payment) => payment),
+      find: jest.fn(),
+      findOne: jest.fn(),
+      createQueryBuilder: jest.fn(),
+    };
+
+    settlementQueue = {
+      add: jest.fn().mockResolvedValue(undefined),
+    };
+
+    service = new SettlementsService(
+      settlementsRepo as any,
+      paymentsRepo as any,
+      deps().config,
+      deps().webhooks,
+      deps().adminAlerts,
+      deps().cache,
+      deps().emailService,
+      deps().merchantsService,
+      deps().notificationPrefs,
+      settlementQueue as any,
+    );
+
+    jest.restoreAllMocks();
+  });
+
+  it('keeps sub-$10 confirmed payments out of immediate settlement', async () => {
+    const payment = {
+      id: 'payment-small',
+      merchantId: 'merchant-1',
+      amountUsd: 5,
+      status: PaymentStatus.CONFIRMED,
+    } as Payment;
+
+    await service.initiateSettlement(payment);
+
+    expect(settlementsRepo.create).not.toHaveBeenCalled();
+    expect(settlementQueue.add).not.toHaveBeenCalled();
+    expect(payment.status).toBe(PaymentStatus.CONFIRMED);
+  });
+
+  it('batches confirmed small payments per merchant once the threshold is reached', async () => {
+    const now = new Date('2026-04-27T10:00:00Z');
+    jest.spyOn(global.Date, 'now').mockReturnValue(now.getTime());
+
+    const payments = [
+      {
+        id: 'p1',
+        merchantId: 'merchant-1',
+        amountUsd: 4,
+        status: PaymentStatus.CONFIRMED,
+        confirmedAt: new Date('2026-04-27T09:56:00Z'),
+        createdAt: new Date('2026-04-27T09:56:00Z'),
+      },
+      {
+        id: 'p2',
+        merchantId: 'merchant-1',
+        amountUsd: 3,
+        status: PaymentStatus.CONFIRMED,
+        confirmedAt: new Date('2026-04-27T09:57:00Z'),
+        createdAt: new Date('2026-04-27T09:57:00Z'),
+      },
+      {
+        id: 'p3',
+        merchantId: 'merchant-1',
+        amountUsd: 3.5,
+        status: PaymentStatus.CONFIRMED,
+        confirmedAt: new Date('2026-04-27T09:58:00Z'),
+        createdAt: new Date('2026-04-27T09:58:00Z'),
+      },
+      {
+        id: 'p4',
+        merchantId: 'merchant-2',
+        amountUsd: 2,
+        status: PaymentStatus.CONFIRMED,
+        confirmedAt: new Date('2026-04-27T09:59:00Z'),
+        createdAt: new Date('2026-04-27T09:59:00Z'),
+      },
+    ] as Payment[];
+
+    paymentsRepo.find = jest.fn().mockResolvedValue(payments);
+
+    await service.batchSmallConfirmedPayments();
+
+    expect(settlementsRepo.create).toHaveBeenCalledTimes(1);
+    expect(settlementsRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        merchantId: 'merchant-1',
+        totalAmountUsd: 10.5,
+        feeAmountUsd: 10.5 * 0.015,
+        netAmountUsd: 10.5 - 10.5 * 0.015,
+        fiatCurrency: 'NGN',
+        status: SettlementStatus.PROCESSING,
+        requiresApproval: false,
+      }),
+    );
+    expect(paymentsRepo.save).toHaveBeenCalledTimes(3);
+    expect(settlementQueue.add).toHaveBeenCalledTimes(1);
+    expect(settlementQueue.add).toHaveBeenCalledWith('dispatch', { settlementId: 'settlement-1' });
+    expect((payments[0] as Payment).status).toBe(PaymentStatus.SETTLING);
+    expect((payments[1] as Payment).status).toBe(PaymentStatus.SETTLING);
+    expect((payments[2] as Payment).status).toBe(PaymentStatus.SETTLING);
+    expect((payments[3] as Payment).status).toBe(PaymentStatus.CONFIRMED);
+  });
+
+  it('does not flush a merchant batch that is still below the $10 threshold', async () => {
+    const payments = [
+      {
+        id: 'p1',
+        merchantId: 'merchant-1',
+        amountUsd: 4,
+        status: PaymentStatus.CONFIRMED,
+        confirmedAt: new Date('2026-04-27T09:55:00Z'),
+        createdAt: new Date('2026-04-27T09:55:00Z'),
+      },
+      {
+        id: 'p2',
+        merchantId: 'merchant-1',
+        amountUsd: 5,
+        status: PaymentStatus.CONFIRMED,
+        confirmedAt: new Date('2026-04-27T09:56:00Z'),
+        createdAt: new Date('2026-04-27T09:56:00Z'),
+      },
+    ] as Payment[];
+
+    paymentsRepo.find = jest.fn().mockResolvedValue(payments);
+
+    await service.batchSmallConfirmedPayments();
+
+    expect(settlementsRepo.create).not.toHaveBeenCalled();
+    expect(settlementQueue.add).not.toHaveBeenCalled();
+    expect(paymentsRepo.save).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/settlements/settlements.service.ts
+++ b/backend/src/settlements/settlements.service.ts
@@ -1,9 +1,10 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
 import { InjectQueue } from '@nestjs/bull';
 import { Queue } from 'bull';
 import { QUEUE_NAMES, DEFAULT_QUEUE_JOB } from '../queues/queue.constants';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, FindManyOptions, Between } from 'typeorm';
+import { Repository, FindManyOptions, Between, IsNull, LessThan } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
 import axios from 'axios';
 import { AdminAlertService } from '../alerts/admin-alert.service';
@@ -24,6 +25,11 @@ export interface PartnerCallbackPayload {
   status: 'success' | 'failed';
   failureReason?: string;
 }
+
+const SMALL_BATCH_THRESHOLD_USD = 10;
+const MAX_BATCH_PAYMENT_COUNT = 50;
+const BATCH_WINDOW_MINUTES = 15;
+const BATCH_FEE_RATE = 0.015;
 
 @Injectable()
 export class SettlementsService {
@@ -51,14 +57,21 @@ export class SettlementsService {
   }
 
   async initiateSettlement(payment: Payment): Promise<void> {
-    const feeRate = 0.015;
-    const feeUsd = payment.amountUsd * feeRate;
-    const netUsd = payment.amountUsd - feeUsd;
+    const amountUsd = Number(payment.amountUsd);
+    if (amountUsd < SMALL_BATCH_THRESHOLD_USD) {
+      this.logger.debug(
+        `Payment ${payment.id} below ${SMALL_BATCH_THRESHOLD_USD} USD batch threshold; waiting for batch window.`,
+      );
+      return;
+    }
+
+    const feeUsd = amountUsd * BATCH_FEE_RATE;
+    const netUsd = amountUsd - feeUsd;
     const LARGE_SETTLEMENT_THRESHOLD = 10000;
 
     const settlement = this.settlementsRepo.create({
       merchantId: payment.merchantId,
-      totalAmountUsd: payment.amountUsd,
+      totalAmountUsd: amountUsd,
       feeAmountUsd: feeUsd,
       netAmountUsd: netUsd,
       fiatCurrency: 'NGN',
@@ -81,10 +94,7 @@ export class SettlementsService {
     // Only execute transfer if no approval required
     if (!settlement.requiresApproval) {
       this.logger.debug(`Enqueuing settlement job for ${saved.id}`);
-      await this.settlementQueue.add(DEFAULT_QUEUE_JOB, {
-        settlementId: saved.id,
-        paymentId: payment.id,
-      });
+      await this.enqueueSettlement(saved.id);
     } else {
       // Alert admin about large settlement requiring approval
       await this.adminAlerts.raise({
@@ -101,9 +111,128 @@ export class SettlementsService {
     }
   }
 
-  async executeFiatTransfer(settlement: Settlement, payment: Payment): Promise<void> {
+  private async enqueueSettlement(settlementId: string): Promise<void> {
+    await this.settlementQueue.add(DEFAULT_QUEUE_JOB, { settlementId });
+  }
+
+  @Cron('0 */15 * * * *')
+  async batchSmallConfirmedPayments(): Promise<void> {
+    const confirmedPayments = await this.paymentsRepo.find({
+      where: {
+        status: PaymentStatus.CONFIRMED,
+        settlementId: IsNull(),
+        amountUsd: LessThan(SMALL_BATCH_THRESHOLD_USD),
+      },
+      order: {
+        merchantId: 'ASC',
+        confirmedAt: 'ASC',
+        createdAt: 'ASC',
+      },
+    });
+
+    if (confirmedPayments.length === 0) {
+      return;
+    }
+
+    const groups = new Map<string, Payment[]>();
+    for (const payment of confirmedPayments) {
+      const list = groups.get(payment.merchantId) ?? [];
+      list.push(payment);
+      groups.set(payment.merchantId, list);
+    }
+
+    for (const payments of groups.values()) {
+      await this.flushMerchantBatch(payments);
+    }
+  }
+
+  private async flushMerchantBatch(payments: Payment[]): Promise<void> {
+    const ordered = [...payments].sort(
+      (a, b) =>
+        new Date(a.confirmedAt ?? a.createdAt).getTime() -
+        new Date(b.confirmedAt ?? b.createdAt).getTime(),
+    );
+
+    let batch: Payment[] = [];
+    let runningTotal = 0;
+
+    for (const payment of ordered) {
+      batch.push(payment);
+      runningTotal += Number(payment.amountUsd);
+
+      const oldest = batch[0];
+      const oldestAt = new Date(oldest.confirmedAt ?? oldest.createdAt).getTime();
+      const isOldEnough = Date.now() - oldestAt >= BATCH_WINDOW_MINUTES * 60 * 1000;
+      const shouldFlush =
+        runningTotal >= SMALL_BATCH_THRESHOLD_USD ||
+        batch.length >= MAX_BATCH_PAYMENT_COUNT ||
+        isOldEnough;
+
+      if (shouldFlush) {
+        await this.createBatchSettlement(batch);
+        batch = [];
+        runningTotal = 0;
+      }
+    }
+  }
+
+  private async createBatchSettlement(payments: Payment[]): Promise<void> {
+    if (payments.length === 0) {
+      return;
+    }
+
+    const totalAmountUsd = payments.reduce((sum, payment) => sum + Number(payment.amountUsd), 0);
+    const feeAmountUsd = totalAmountUsd * BATCH_FEE_RATE;
+    const netAmountUsd = totalAmountUsd - feeAmountUsd;
+
+    const settlement = this.settlementsRepo.create({
+      merchantId: payments[0].merchantId,
+      totalAmountUsd,
+      feeAmountUsd,
+      netAmountUsd,
+      fiatCurrency: 'NGN',
+      status: netAmountUsd >= 10000 ? SettlementStatus.PENDING_APPROVAL : SettlementStatus.PROCESSING,
+      requiresApproval: netAmountUsd >= 10000,
+    });
+
+    const saved = await this.settlementsRepo.save(settlement);
+
+    for (const payment of payments) {
+      payment.status = PaymentStatus.SETTLING;
+      payment.feeUsd = Number((Number(payment.amountUsd) * BATCH_FEE_RATE).toFixed(6));
+      payment.settlementId = saved.id;
+      await this.paymentsRepo.save(payment);
+    }
+
+    this.logger.debug(
+      `Created batch settlement ${saved.id} for merchant ${saved.merchantId} with ${payments.length} payments totaling $${totalAmountUsd.toFixed(2)}`,
+    );
+
+    if (saved.status === SettlementStatus.PROCESSING) {
+      await this.enqueueSettlement(saved.id);
+    } else {
+      await this.adminAlerts.raise({
+        type: AdminAlertType.SETTLEMENT_FAILURE,
+        dedupeKey: `large-settlement:${saved.id}`,
+        message: `Batch settlement ${saved.id} requires manual approval: $${netAmountUsd.toFixed(2)}`,
+        metadata: {
+          merchantId: saved.merchantId,
+          paymentCount: payments.length,
+          amount: netAmountUsd,
+        },
+        thresholdValue: 1,
+      });
+    }
+  }
+
+  async executeFiatTransfer(settlement: Settlement): Promise<void> {
     const partnerUrl = this.config.get('PARTNER_API_URL');
     const partnerKey = this.config.get('PARTNER_API_KEY');
+    const payments = settlement.payments ?? [];
+
+    if (payments.length === 0) {
+      throw new Error(`Settlement ${settlement.id} has no linked payments`);
+    }
 
     try {
       const response = await axios.post(
@@ -122,28 +251,32 @@ export class SettlementsService {
       settlement.completedAt = new Date();
       await this.settlementsRepo.save(settlement);
 
-      payment.status = PaymentStatus.SETTLED;
-      await this.paymentsRepo.save(payment);
+      for (const payment of payments) {
+        payment.status = PaymentStatus.SETTLED;
+        await this.paymentsRepo.save(payment);
+      }
 
       // Invalidate analytics caches impacted by payment.settled.
       await this.invalidateAnalyticsForMerchant(settlement.merchantId);
 
-      await this.webhooks.dispatch(settlement.merchantId, 'payment.settled', {
-        paymentId: payment.id,
-        settlementId: settlement.id,
-        amount: settlement.netAmountUsd,
-      });
-
-      await this.sendSettlementEmail(
-        settlement.merchantId,
-        NotificationEventType.PAYMENT_SETTLED,
-        'settlement-completed',
-        {
-          settlementId: settlement.id,
-          netAmountUsd: Number(settlement.netAmountUsd).toFixed(2),
+      for (const payment of payments) {
+        await this.webhooks.dispatch(settlement.merchantId, 'payment.settled', {
           paymentId: payment.id,
-        },
-      );
+          settlementId: settlement.id,
+          amount: payment.amountUsd,
+        });
+
+        await this.sendSettlementEmail(
+          settlement.merchantId,
+          NotificationEventType.PAYMENT_SETTLED,
+          'settlement-completed',
+          {
+            settlementId: settlement.id,
+            netAmountUsd: Number(settlement.netAmountUsd).toFixed(2),
+            paymentId: payment.id,
+          },
+        );
+      }
     } catch (err) {
       this.logger.error(`Settlement failed for ${settlement.id}`, err.message);
       await this.adminAlerts.raise({
@@ -152,7 +285,7 @@ export class SettlementsService {
         message: `Settlement failed for ${settlement.id}: ${err.message}`,
         metadata: {
           merchantId: settlement.merchantId,
-          paymentId: payment.id,
+          paymentIds: payments.map((payment) => payment.id),
         },
         thresholdValue: 1,
       });
@@ -161,24 +294,28 @@ export class SettlementsService {
       settlement.failureReason = err.message;
       await this.settlementsRepo.save(settlement);
 
-      payment.status = PaymentStatus.FAILED;
-      await this.paymentsRepo.save(payment);
+      for (const payment of payments) {
+        payment.status = PaymentStatus.FAILED;
+        await this.paymentsRepo.save(payment);
+      }
 
-      await this.webhooks.dispatch(settlement.merchantId, 'payment.failed', {
-        paymentId: payment.id,
-        reason: err.message,
-      });
-
-      await this.sendSettlementEmail(
-        settlement.merchantId,
-        NotificationEventType.SETTLEMENT_FAILED,
-        'payment-failed',
-        {
-          settlementId: settlement.id,
+      for (const payment of payments) {
+        await this.webhooks.dispatch(settlement.merchantId, 'payment.failed', {
           paymentId: payment.id,
           reason: err.message,
-        },
-      );
+        });
+
+        await this.sendSettlementEmail(
+          settlement.merchantId,
+          NotificationEventType.SETTLEMENT_FAILED,
+          'payment-failed',
+          {
+            settlementId: settlement.id,
+            paymentId: payment.id,
+            reason: err.message,
+          },
+        );
+      }
     }
   }
 
@@ -196,6 +333,7 @@ export class SettlementsService {
   async handlePartnerCallback(payload: PartnerCallbackPayload): Promise<void> {
     const settlement = await this.settlementsRepo.findOne({
       where: { id: payload.reference },
+      relations: ['payments'],
     });
 
     if (!settlement) {
@@ -203,26 +341,26 @@ export class SettlementsService {
       return;
     }
 
-    const payment = await this.paymentsRepo.findOne({
-      where: { settlementId: settlement.id },
-    });
+    const payments = settlement.payments ?? [];
 
     if (payload.status === 'success') {
       settlement.status = SettlementStatus.COMPLETED;
       settlement.completedAt = new Date();
       await this.settlementsRepo.save(settlement);
 
-      if (payment) {
+      for (const payment of payments) {
         payment.status = PaymentStatus.SETTLED;
         await this.paymentsRepo.save(payment);
+      }
 
-        // Invalidate analytics caches impacted by payment.settled.
-        await this.invalidateAnalyticsForMerchant(settlement.merchantId);
+      // Invalidate analytics caches impacted by payment.settled.
+      await this.invalidateAnalyticsForMerchant(settlement.merchantId);
 
+      for (const payment of payments) {
         await this.webhooks.dispatch(settlement.merchantId, 'payment.settled', {
           paymentId: payment.id,
           settlementId: settlement.id,
-          amount: settlement.netAmountUsd,
+          amount: payment.amountUsd,
         });
 
         await this.sendSettlementEmail(
@@ -241,9 +379,12 @@ export class SettlementsService {
       settlement.failureReason = payload.failureReason ?? 'Partner reported failure';
       await this.settlementsRepo.save(settlement);
 
-      if (payment) {
+      for (const payment of payments) {
         payment.status = PaymentStatus.FAILED;
         await this.paymentsRepo.save(payment);
+      }
+
+      for (const payment of payments) {
         await this.webhooks.dispatch(settlement.merchantId, 'payment.failed', {
           paymentId: payment.id,
           reason: settlement.failureReason,
@@ -360,10 +501,7 @@ export class SettlementsService {
 
     // Retry the fiat transfer
     if (settlement.payments.length > 0) {
-      await this.settlementQueue.add(DEFAULT_QUEUE_JOB, {
-        settlementId: settlement.id,
-        paymentId: settlement.payments[0].id,
-      });
+      await this.enqueueSettlement(settlement.id);
     }
 
     this.logger.log(`Settlement ${id} retry initiated by admin`);
@@ -402,10 +540,7 @@ export class SettlementsService {
 
     // Execute the fiat transfer
     if (settlement.payments.length > 0) {
-      await this.settlementQueue.add(DEFAULT_QUEUE_JOB, {
-        settlementId: settlement.id,
-        paymentId: settlement.payments[0].id,
-      });
+      await this.enqueueSettlement(settlement.id);
     }
 
     this.logger.log(`Large settlement ${id} approved and processed by admin`);


### PR DESCRIPTION
## Summary
- Hold confirmed payments under $10 until the 15-minute batching job can combine them by merchant
- Create one settlement record per merchant batch and enqueue it once
- Update settlement processing to handle settlements with multiple linked payments
- Add a regression spec covering the small-payment batching behavior

## Verification
- `node -r ts-node/register/transpile-only` smoke test: sub-$10 payment stays unbatched, three small confirmed payments batch into one settlement, and a sub-$10 total below threshold does not flush
- Note: the repo's Jest/TypeScript path currently hits pre-existing compile issues in unrelated files (`src/cache/cache.service.ts`) when using `ts-jest`, so I verified the new behavior with a transpile-only runtime script instead

Closes #666