### PR TITLE
feat: add PCI-DSS compliance reporting endpoints (closes #704)

### DIFF
--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -243,3 +243,105 @@ export class AdminController {
     return this.adminService.deleteRecord(entity, id, isHard, req.user.role);
   }
 }
+
+  // ── PCI-DSS Compliance Reports (#704) ─────────────────────────────────────
+
+  @Get('reports/compliance')
+  @ApiOperation({ summary: 'Generate PCI-DSS compliance report' })
+  async getComplianceReport(
+    @Query('from') from: string,
+    @Query('to') to: string,
+    @Query('type') type: string = 'full',
+    @Query('format') format: string = 'json',
+    @Res() res: Response,
+  ) {
+    const fromDate = from ? new Date(from) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const toDate = to ? new Date(to) : new Date();
+
+    let data: any;
+    switch (type) {
+      case 'access-control':
+        data = await this.adminService.getAccessControlReport(fromDate, toDate);
+        break;
+      case 'failed-auth':
+        data = await this.adminService.getFailedAuthReport(fromDate, toDate);
+        break;
+      case 'data-retention':
+        data = await this.adminServicents':
+        data = await this.adminService.getSettlementReconciliationReport(fromDate, toDate);
+        break;
+      default:
+        data = await this.adminService.getFullComplianceReport(fromDate, toDate);
+    }
+
+    if (format === 'pdf') {
+      const PDFDocument = require('pdfkit');
+      const doc = new PDFDocument({ margin: 50 });
+      res.setHeader('Content-Type', 'application/pdf');
+      res.setHeader('Content-Disposition', `attachment; filename="compliance-report-${type}-${fromDate.toISOString().split('T')[0]}.pdf"`);
+      doc.pipe(res);
+      doc.fontSize(20).text('PCI-DSS Compliance Report', { align: 'center' });
+      doc.moveDown();
+      doc.fontSize(12).text(`Report Type: ${type}`);
+      doc.text(`Generated: ${new Date().toISOString()}`);
+      doc.text(`Period: ${fromDate.toISOString()} — ${toDate.toISOString()}`);
+      doc.moveDown();
+      doc.fontSize(10).text(JSON.stringify(data, null, 2), { lineGap: 2 });
+      doc.end();
+      return;
+    }
+
+    return res.json({ status: 'sucss', data });
+  }
+}
+
+  // ── PCI-DSS Compliance Reports (#704) ─────────────────────────────────────
+
+  @Get('reports/compliance')
+  @ApiOperation({ summary: 'Generate PCI-DSS compliance report' })
+  async getComplianceReport(
+    @Query('from') from: string,
+    @Query('to') to: string,
+    @Query('type') type: string = 'full',
+    @Query('format') format: string = 'json',
+    @Res() res: Response,
+  ) {
+    const fromDate = from ? new Date(from) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const toDate = to ? new Date(to) : new Date();
+
+    let data: any;
+    switch (type) {
+      case 'access-control':
+        data = await this.adminService.getAccessControlReport(fromDate, toDate);
+        break;
+      case 'failed-auth':
+        data = await this.adminService.getFailedAuthReport(fromDate, toDate);
+        break;
+      case 'data-retention':
+        data = await this.adminServicents':
+        data = await this.adminService.getSettlementReconciliationReport(fromDate, toDate);
+        break;
+      default:
+        data = await this.adminService.getFullComplianceReport(fromDate, toDate);
+    }
+
+    if (format === 'pdf') {
+      const PDFDocument = require('pdfkit');
+      const doc = new PDFDocument({ margin: 50 });
+      res.setHeader('Content-Type', 'application/pdf');
+      res.setHeader('Content-Disposition', `attachment; filename="compliance-report-${type}-${fromDate.toISOString().split('T')[0]}.pdf"`);
+      doc.pipe(res);
+      doc.fontSize(20).text('PCI-DSS Compliance Report', { align: 'center' });
+      doc.moveDown();
+      doc.fontSize(12).text(`Report Type: ${type}`);
+      doc.text(`Generated: ${new Date().toISOString()}`);
+      doc.text(`Period: ${fromDate.toISOString()} — ${toDate.toISOString()}`);
+      doc.moveDown();
+      doc.fontSize(10).text(JSON.stringify(data, null, 2), { lineGap: 2 });
+      doc.end();
+      return;
+    }
+
+    return res.json({ status: 'sucss', data });
+  }
+}

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -491,3 +491,75 @@ export class AdminService {
   }
 }
 
+
+  // ── PCI-DSS Compliance Reports (#704) ─────────────────────────────────────
+
+  async getAccessControlReport(from: Date, to: Date) {
+    return this.auditLogRepo
+      .createQueryBuilder('log')
+      .select(['log.id', 'log.actor', 'log.action', 'log.resourceType', 'log.resourceId', 'log.createdAt'])
+      .where('log.createdAt BETWEEN :from AND :to', { from, to })
+      .orderBy('log.createdAt', 'DESC')
+      .getMany();
+  }
+
+  async getFailedAuthReport(from: Date, to: Date) {
+    return this.auditLogRepo
+      .createQueryBuilder('log')
+      .where('log.action IN (:...actions)', { actions: ['LOGIN_FAILED', 'AUTH_FAILED', 'TOTP_FAILED', 'INVALID_TOKEN'] })
+      .andWhere('log.createdAt BETWEEN :from AND :to', { from, to })
+      .orderBy('log.createdAt', 'DESC')
+      .getMany();
+  }
+
+  async getDataRetentionReport(from: Date, to: Date) {
+    return this.auditLogRepo{ actions: ['RECORD_DELETED', 'RECORD_HARD_DELETED', 'RECORD_RESTORED', 'DATA_PURGED'] })
+      .andWhere('log.createdAt BETWEEN :from AND :to', { from, to })
+      .orderBy('log.createdAt', 'DESC')
+      .getMany();
+  }
+
+  async getSettlementReconciliationReport(from: Date, to: Date) {
+    return this.paymentsRepo
+      .createQueryBuilder('payment')
+      .leftJoinAndSelect('payment.merchant', 'merchant')
+      .select([
+        'payment.id',
+        'payment.status',
+        'payment.amountUsd',
+        'payment.txHash',
+        'payment.network',
+        'payment.createdAt',
+        'merchant.id',
+        'merchant.businessName',
+        'merchant.email',
+      ])
+      .where('payment.createdAt BETWEEN :from AND :to', { from, to })
+      .andWhere('payment.status IN (:...statuses)', { statuses: ['completed', 'settled', 'failed'] })
+      .orderBy('payment.createdAt', 'DESC')
+      .getMany();
+  }
+
+  async getFullComplianceReport(from: Date, to: Date) {
+    const [accessControl, failedAuth, dataRetention, settlements] = await Promise.all([
+      this.getAccessControlReport(from, to),
+      this.getFailedAuthReport(from, to),
+      this.getDataRetentionReport(from, to),
+      this.getSettlementReconciliationReport(from, to),
+    ]);
+
+    return {
+      generatedAt: new Date().toISOString(),
+      period: { from: from.toISOString(), to: to.toISOString() },
+      summary: {
+        totalAccessEvents: accessControl.length,
+        totalFailedAuths: failedAuth.length,
+        totalDataRetentionEvents: dataRetention.length,
+        totalSettlements: settlements.length,
+      },
+      accessControl,
+      failedAuth,
+      dataRetention,
+      settlements,
+    };
+  }


### PR DESCRIPTION
## Summary
Resolves #704

Adds compliance reporting endpoints to the admin module covering all PCI-DSS required report types, exportable as JSON or PDF.

## Changes

### admin.service.ts
- `getAccessControlReport(from, to)` — who accessed what and when from audit logs
- `getFailedAuthReport(from, to)` — failed login/auth/TOTP events
- `getDataRetentionReport(from, to)` — record deletions, restores, and purges
- `getSettlementReconciliationReport(from, to)` — completed/settled/failed payments with merchant info
- `getFullComplianceReport(from, to)` — aggregates all four reports with summary counts

### admin.controller.ts
- `GET /admin/reports/compliance` — generates compliance report on demand
- Query params:
  - `from` / `to` — date range (defaults to last 30 days)
  - `type` — `full` | `access-control` | `failed-auth` | `data-retention` | `settlements`
  - `format` — `json` (default) | `pdf`
- PDF export streams directly as a downloadable file for auditors

## Usage