### PR TITLE
feat: implement URL-based API versioning and deprecation headers

### DIFF
--- a/backend/test/payment-lifecycle.e2e-spec.ts
+++ b/backend/test/payment-lifecycle.e2e-spec.ts
@@ -1,0 +1,70 @@
+/**
+ * E2E: Full Payment Lifecycle Integration Test (#782)
+ *
+ * Flow: create merchant → login → create payment → simulate Stellar confirmation
+ *       → verify settlement triggered → assert webhooks dispatched at each stage
+ *       → assert settlement record created with correct amounts
+ *
+ * All external dependencies (DB, Redis, Stellar, partner API) are mocked via
+ * nock + jest so this runs in CI without any infrastructure.
+ */
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import * as nock from 'nock';
+
+import { AuthModule } from '../src/auth/auth.module';
+import { AuthService } from '../src/auth/auth.service';
+import { PaymentsModule } from '../src/payments/payments.module';
+import { PaymentsService } from '../src/payments/payments.service';
+import { SettlementsModule } from '../src/settlements/settlements.module';ttlementsService } from '../src/settlements/settlements.service';
+import { WebhooksService } from '../src/webhooks/webhooks.service';
+import { JwtAuthGuard } from '../src/auth/guards/jwt.guard';
+import { PaymentStatus, PaymentNetwork } from '../src/payments/entities/payment.entity';
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const MOCK_MERCHANT_ID = 'merchant-lifecycle-uuid';
+const MOCK_ACCESS_TOKEN = 'mock-lifecycle-token';
+const MOCK_PAYMENT_ID = 'payment-lifecycle-uuid';
+const MOCK_SETTLEMENT_ID = 'settlement-lifecycle-uuid';
+const MOCK_TX_HASH = 'stellar-tx-hash-abc123';
+const MOCK_AMOUNT_USD = 200.0;
+const FEE_RATE = 0.015;
+
+// ── Mock Data ────────────────────────────────────────────────────────────────amountUsd: MOCK_AMOUNT_USD,
+  network: PaymentNetwork.STELLAR,
+  status: PaymentStatus.PENDING,
+  txHash: null,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+};
+
+const MOCK_PAYMENT_CONFIRMED = {
+  ...MOCK_PAYMENT_PENDING,
+  status: PaymentStatus.CONFIRMED,
+  txHash: MOCK_TX_HASH,
+};
+
+const MOCK_PAYMENT_SETTLING = {
+  ...MOCK_PAYMENT_CONFIRMED,
+  status: PaymentStatus.SETTLING,
+};
+
+const MOCK_PAYMENT_SETTLED = {
+  ...MOCK_PAYMENT_SETTLING,
+  status: PaymentStatus.SETTLED,
+};
+
+const MOCK_SETTLEMENT = {
+  id: MOCK_SETTLEMENT_ID,
+  merchantId: MOCK_MERCHANT_ID,
+  paymentId: MOCK_PAYMENT_ID,
+  amountUsd: MOCK_AMOUNT_USD,
+  feeUsd: MOCK_AMOUNT_USD * FEE_RATE,
+  netUsd: MOCK_AMOUNT_USD - MOCK_AMOUNT_USD * FEE_RATE,
+  status: 'pending',
+  createdAt: new Date('2026-01-01T00:01:00Z'),
+};
+
+// ── Guard Mock ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Resolves #768

Implements API versioning infrastructure for backward-compatible platform evolution.

## Changes

### VersioningInterceptor (new)
- Added to global interceptors in main.ts
- Sets `X-API-Version: v1` and `X-Supported-Versions: v1` on every response
- Validates `Accept: application/vnd.cheesepay.v1+json` header
- Returns 406 Not Acceptable for unsupported versions

### DeprecationInterceptor (new)
- Added to global interceptors in main.ts
- Works with `@Deprecated()` decorator on any endpoint
- Adds RFC 8594 `Deprecation` header, `Sunset` date, `Link` to successor, and `X-Deprecation-Notice`

### @Deprecated() decorator (new)
- `sunsetDate` — ISO date when endpoint will be removed
- `link` — URL to migration docs or replacement endpoint  
- `message` — human-readable deprecation notice

### docs/api-versioning.md (new)
- Documents URL-based and Accept-header versioning
- Documents all response headers
- Migration path for v2
- Usage example for `@Deprecated()`

## Usage

```typescript
// Mark an endpoint as deprecated
@Deprecated({
  sunsetDate: '2027-01-01',
  link: '/docs/api-versioning',
  message: 'Use POST /api/v2/payments instead.',
})
@Post('old-endpoint')
oldEndpoint() {}
```

## Notes
- Global prefix `api/v1` was already set via `API_PREFIX` env — this PR adds the versioning headers and decorator layer on top
- No breaking changes — all existing routes continue to work as before