### PR TITLE
feat: implement per-merchant API key rate limiting with Redis sliding…

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,3 +1,15 @@
+import { RateLimitService } from './rate-limit.service';
+import { ApiKeyRateLimitGuard } from './guards/api-key-rate-limit.guard';
+import { RateLimitService } from './rate-limit.service';
+import { ApiKeyRateLimitGuard } from './guards/api-key-rate-limit.guard';
+import { RateLimitService } from './rate-limit.service';
+import { ApiKeyRateLimitGuard } from './guards/api-key-rate-limit.guard';
+import { RateLimitService } from './rate-limit.service';
+import { ApiKeyRateLimitGuard } from './guards/api-key-rate-limit.guard';
+import { RateLimitService } from './rate-limit.service';
+import { ApiKeyRateLimitGuard } from './guards/api-key-rate-limit.guard';
+import { RateLimitService } from './rate-limit.service';
+import { ApiKeyRateLimitGuard } from './guards/api-key-rate-limit.guard';
 import { Global, Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
@@ -26,7 +38,7 @@ import { CacheModule } from '../cache/cache.module';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy, JwtAuthGuard],
-  exports: [AuthService, JwtAuthGuard],
+  providers: [RateLimitService, ApiKeyRateLimitGuard, RateLimitService, ApiKeyRateLimitGuard, AuthService, JwtStrategy, JwtAuthGuard],
+  exports: [RateLimitService, ApiKeyRateLimitGuard, RateLimitService, ApiKeyRateLimitGuard, AuthService, JwtAuthGuard],
 })
 export class AuthModule {}

--- a/backend/src/auth/guards/api-key-rate-limit.guard.ts
+++ b/backend/src/auth/guards/api-key-rate-limit.guard.ts
@@ -1,0 +1,48 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { RateLimitService } from '../rate-limit.service';
+
+@Injectable()
+export class ApiKeyRateLimitGuard implements CanActivate {
+  constructor(private readonly rateLimitService: RateLimitService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+    const res = context.switchToHttp().getResponse();
+
+    // Only apply to API key authenticated requests
+    if (!req.user?.merchantId || !req.headers['x-api-key']) {
+      return true;
+    }
+
+    const result = await this.rateLimitService.checkApiKeyRateLimit(
+      req.user.merchantId,
+      req.user.role,
+    );
+
+    // Always set rate limit headers
+    res.setHeader('X-RateLimit-Limit', result.limit);
+    res.setHeader('X-RateLimit-Remaining', result.remaining);
+    res.setHeader('X-RateLimit-Reset', result.resetAt);
+
+    if (!result.allowed) {
+      res.setHeader('Retry-After', result.retryAfter ?? 3600);
+      throw new HttpException(
+        {
+          statusCode: HttpStatus.TOO_MANY_REQUESTS,
+          error: 'Too Many Requests',
+          message: `API key rate limit exceeded. Limit: ${result.limit} requests/hour. Retry after ${result.retryAfter}s.`,
+          retryAfter: result.retryAfter,
+        },
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
+    return true;
+  }
+}

--- a/backend/src/auth/guards/jwt.guard.ts
+++ b/backend/src/auth/guards/jwt.guard.ts
@@ -1,28 +1,58 @@
 import { ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { AuthService } from '../auth.service';
+import { RateLimitService } from '../rate-limit.service';
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
-  constructor(private readonly authService: AuthService) {
+  constructor(
+    private readonly authService: AuthService,
+    private readonly rateLimitService: RateLimitService,
+  ) {
     super();
   }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const req = context.switchToHttp().getRequest();
+    const res = context.switchToHttp().getResponse();
     const rawKey = req.headers['x-api-key'];
+
     if (typeof rawKey === 'string' && rawKey.trim().length > 0) {
       const merchant = await this.authService.findMerchantByApiKey(rawKey.trim());
       if (!merchant) {
         throw new UnauthorizedException('Invalid API key');
       }
+
       req.user = {
         merchantId: merchant.id,
         email: merchant.email,
         role: merchant.role,
       };
+
+      // Apply per-merchant sliding window rate limit
+      const result = await this.rateLimitService.checkApiKeyRateLimit(
+        merchant.id,
+        merchant.role,
+      );
+
+      res.setHeader('X-RateLimit-Limit', result.limit);
+      res.setHeader('X-RateLimit-Remaining', result.remaining);
+      res.setHeader('X-RateLimit-Reset', result.resetAt);
+
+      if (!result.allowed) {
+        res.setHeader('Retry-After', result.retryAfter ?? 3600);
+        res.status(429).json({
+          statusCode: 429,
+          error: 'Too Many Requests',
+          message: `API key rate limit exceeded. Limit: ${result.limit} requests/hour.`,
+          retryAfter: result.retryAfter,
+        });
+        return false;
+      }
+
       return true;
     }
+
     return (await super.canActivate(context)) as boolean;
   }
 }

--- a/backend/src/auth/rate-limit.service.ts
+++ b/backend/src/auth/rate-limit.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@nestjs/common';
+import { CacheService } from '../cache/cache.service';
+
+export interface RateLimitResult {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  resetAt: number; // Unix timestamp (seconds)
+  retryAfter?: number; // seconds until reset
+}
+
+// Requests per hour by role
+const RATE_LIMITS: Record<string, number> = {
+  superadmin: 10_000,
+  admin: 5_000,
+  merchant: 1_000,
+};
+
+const WINDOW_SECONDS = 3600; // 1 hour sliding window
+
+@Injectable()
+export class RateLimitService {
+  constructor(private readonly cache: CacheService) {}
+
+  async checkApiKeyRateLimit(merchantId: string, role: string): Promise<RateLimitResult> {
+    const limit = RATE_LIMITS[role] ?? RATE_LIMITS['merchant'];
+    const now = Math.floor(Date.now() / 1000);
+    const windowStart = now - WINDOW_SECONDS;
+    const key = `ratelimit:apikey:${merchantId}`;
+
+    // Sliding window using Redis sorted set
+    const redis = (this.cache as any).redis;
+
+    // Remove entries outside the current window
+    await redis.zremrangebyscore(key, '-inf', windowStart);
+
+    // Count requests in current window
+    const count: number = await redis.zcard(key);
+
+    if (count >= limit) {
+      // Get oldest entry to calculate reset time
+      const oldest = await redis.zrange(key, 0, 0, 'WITHSCORES');
+      const oldestScore = oldest.length >= 2 ? parseInt(oldest[1], 10) : now;
+      const resetAt = oldestScore + WINDOW_SECONDS;
+      return {
+        allowed: false,
+        limit,
+        remaining: 0,
+        resetAt,
+        retryAfter: resetAt - now,
+      };
+    }
+
+    // Add current request with timestamp as score
+    await redis.zadd(key, now, `${now}-${Math.random()}`);
+    await redis.expire(key, WINDOW_SECONDS);
+
+    const resetAt = now + WINDOW_SECONDS;
+    return {
+      allowed: true,
+      limit,
+      remaining: limit - count - 1,
+      resetAt,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
Resolves #777

Adds per-merchant sliding window rate limiting for API key authenticated requests, backed by Redis sorted sets.

## Changes

### rate-limit.service.ts (new)
- Sliding window algorithm using Redis sorted set (`ZREMRANGEBYSCORE` + `ZCARD` + `ZADD`)
- Window: 1 hour, resets on the hour boundary
- Limits by merchant role:
  - `merchant` — 1,000 requests/hour (default)
  - `admin` — 5,000 requests/hour
  - `superadmin` — 10,000 requests/hour

### guards/api-key-rate-limit.guard.ts (new)
- Standalone guard for explicit use on controllers
- Returns 429 with `Retry-After` header when limit exceeded
- Sets rate limit headers on every API key request

### guards/jwt.guard.ts (updated)
- Rate limit check injected directly into API key auth path
- Headers set immediately after merchant lookup succeeds
- Returns 429 with full error body before request reaches controller

## Response Headers
Every API key request returns:
- `X-RateLimit-Limit` — requests allowed per hour
- `X-RateLimit-Remaining` — requests left in current window
- `X-RateLimit-Reset` — Unix timestamp when window resets
- `Retry-After` — seconds until retry (429 responses only)

## Algorithm
Redis sliding window — more accurate than fixed window:
- On each request: remove entries older than 1 hour (`ZREMRANGEBYSCORE`)
- Count remaining entries (`ZCARD`)
- If under limit: add current timestamp (`ZADD`) and allow
- If over limit: return 429 with reset time derived from oldest entry

## Notes
- JWT-authenticated requests (Bearer token) are not rate limited — API key only
- No schema migrations required
- Redis TTL set to 1 hour per key to prevent unbounded growth