### PR TITLE
feat(soroban): global pause switch for emergency contract halt

### DIFF
--- a/backend/src/blockchain-wallet/soroban-pause.service.spec.ts
+++ b/backend/src/blockchain-wallet/soroban-pause.service.spec.ts
@@ -1,0 +1,162 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { SorobanService, ContractPausedError } from './soroban.service';
+
+describe('SorobanService — global pause switch', () => {
+  let service: SorobanService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SorobanService,
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get(SorobanService);
+  });
+
+  // ── Initial state ─────────────────────────────────────────────────────────
+
+  it('starts unpaused', () => {
+    expect(service.isPaused()).toBe(false);
+  });
+
+  // ── pause() ───────────────────────────────────────────────────────────────
+
+  it('pause() sets paused to true', () => {
+    service.pause('admin-1');
+    expect(service.isPaused()).toBe(true);
+  });
+
+  it('pause() emits a ContractPaused event', () => {
+    service.pause('admin-1');
+    const events = service.getEventLog();
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('ContractPaused');
+    expect(events[0].admin).toBe('admin-1');
+    expect(events[0].timestamp).toBeInstanceOf(Date);
+  });
+
+  it('calling pause() twice is idempotent — only one event emitted', () => {
+    service.pause('admin-1');
+    service.pause('admin-1');
+    expect(service.isPaused()).toBe(true);
+    expect(service.getEventLog()).toHaveLength(1);
+  });
+
+  // ── unpause() ─────────────────────────────────────────────────────────────
+
+  it('unpause() sets paused to false', () => {
+    service.pause('admin-1');
+    service.unpause('admin-1');
+    expect(service.isPaused()).toBe(false);
+  });
+
+  it('unpause() emits a ContractUnpaused event', () => {
+    service.pause('admin-1');
+    service.unpause('admin-1');
+    const events = service.getEventLog();
+    expect(events).toHaveLength(2);
+    expect(events[1].type).toBe('ContractUnpaused');
+    expect(events[1].admin).toBe('admin-1');
+  });
+
+  it('calling unpause() when already unpaused is idempotent', () => {
+    service.unpause('admin-1');
+    expect(service.isPaused()).toBe(false);
+    expect(service.getEventLog()).toHaveLength(0);
+  });
+
+  // ── Mutable operations blocked while paused ───────────────────────────────
+
+  it('deposit() throws ContractPausedError while paused', async () => {
+    service.pause('admin-1');
+    await expect(service.deposit('GABC', '100')).rejects.toThrow(ContractPausedError);
+  });
+
+  it('release() throws ContractPausedError while paused', async () => {
+    service.pause('admin-1');
+    await expect(service.release('pay-1', 'GMERCHANT')).rejects.toThrow(ContractPausedError);
+  });
+
+  it('refund() throws ContractPausedError while paused', async () => {
+    service.pause('admin-1');
+    await expect(service.refund('pay-1', 'GCUSTOMER')).rejects.toThrow(ContractPausedError);
+  });
+
+  // ── View functions remain accessible while paused ─────────────────────────
+
+  it('getBalance() works while paused', async () => {
+    service.pause('admin-1');
+    await expect(service.getBalance('GABC')).resolves.toBe('0');
+  });
+
+  it('getStakeBalance() works while paused', async () => {
+    service.pause('admin-1');
+    await expect(service.getStakeBalance('GABC')).resolves.toBe('0');
+  });
+
+  it('isPaused() works while paused', () => {
+    service.pause('admin-1');
+    expect(service.isPaused()).toBe(true);
+  });
+
+  it('getEventLog() works while paused', () => {
+    service.pause('admin-1');
+    expect(service.getEventLog()).toHaveLength(1);
+  });
+
+  // ── Operations resume after unpause ──────────────────────────────────────
+
+  it('deposit() succeeds after unpause', async () => {
+    service.pause('admin-1');
+    service.unpause('admin-1');
+    await expect(service.deposit('GABC', '100')).resolves.toBeUndefined();
+  });
+
+  it('release() succeeds after unpause', async () => {
+    service.pause('admin-1');
+    service.unpause('admin-1');
+    await expect(service.release('pay-1', 'GMERCHANT')).resolves.toBeUndefined();
+  });
+
+  it('refund() succeeds after unpause', async () => {
+    service.pause('admin-1');
+    service.unpause('admin-1');
+    await expect(service.refund('pay-1', 'GCUSTOMER')).resolves.toBeUndefined();
+  });
+
+  // ── Full incident scenario ────────────────────────────────────────────────
+
+  it('full incident: normal ops → pause → all writes blocked → reads ok → unpause → normal ops', async () => {
+    // Normal operations before incident
+    await service.deposit('GABC', '50');
+    await service.release('pay-1', 'GMERCHANT');
+
+    // Security incident — admin halts everything
+    service.pause('security-admin');
+    expect(service.isPaused()).toBe(true);
+
+    // All writes blocked
+    await expect(service.deposit('GATTACKER', '9999')).rejects.toThrow(ContractPausedError);
+    await expect(service.release('pay-exploit', 'GATTACKER')).rejects.toThrow(ContractPausedError);
+    await expect(service.refund('pay-exploit', 'GATTACKER')).rejects.toThrow(ContractPausedError);
+
+    // Monitoring reads still work
+    await expect(service.getBalance('GABC')).resolves.toBe('0');
+    await expect(service.getStakeBalance('GABC')).resolves.toBe('0');
+
+    // Incident resolved — admin resumes
+    service.unpause('security-admin');
+    expect(service.isPaused()).toBe(false);
+
+    // Normal operations resume
+    await expect(service.deposit('GABC', '50')).resolves.toBeUndefined();
+    await expect(service.release('pay-2', 'GMERCHANT')).resolves.toBeUndefined();
+
+    // Event log tells the full story
+    const events = service.getEventLog();
+    expect(events.map((e) => e.type)).toEqual(['ContractPaused', 'ContractUnpaused']);
+  });
+});

--- a/backend/src/blockchain-wallet/soroban.service.ts
+++ b/backend/src/blockchain-wallet/soroban.service.ts
@@ -1,24 +1,194 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, ForbiddenException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+
+// ── Events ────────────────────────────────────────────────────────────────────
+
+export interface ContractPausedEvent {
+  type: 'ContractPaused';
+  admin: string;
+  timestamp: Date;
+}
+
+export interface ContractUnpausedEvent {
+  type: 'ContractUnpaused';
+  admin: string;
+  timestamp: Date;
+}
+
+export type ContractEvent = ContractPausedEvent | ContractUnpausedEvent;
+
+// ── Error ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Thrown when a state-changing operation is attempted while the contract
+ * is paused. Maps to HTTP 403 if surfaced through a controller.
+ */
+export class ContractPausedError extends ForbiddenException {
+  constructor() {
+    super('ContractPaused: all state-changing operations are currently halted');
+  }
+}
+
+// ── Service ───────────────────────────────────────────────────────────────────
 
 /**
  * SorobanService wraps the CheesePay Soroban smart contract.
- * registerUser, getBalance, and getStakeBalance are the three
- * contract entry points used by BlockchainWalletService.
  *
- * Full Soroban contract invocation (signing, XDR submission) is
- * handled here so BlockchainWalletService stays focused on wallet logic.
+ * ## Global pause switch
+ * An admin can call pause() to instantly halt all deposits, releases, and
+ * refunds during a security incident. View functions (getBalance,
+ * getStakeBalance) remain callable while paused so monitoring is unaffected.
+ *
+ * The `paused` flag mirrors a persistent storage key in the real Soroban
+ * contract. pause() / unpause() emit ContractPaused / ContractUnpaused events
+ * that can be forwarded to an audit log or alert system.
+ *
+ * ## Reentrancy guard
+ * A mutex-style `locked` flag prevents cross-contract reentrant calls from
+ * exploiting the escrow release flow (separate concern, both guards coexist).
  */
 @Injectable()
 export class SorobanService {
   private readonly logger = new Logger(SorobanService.name);
 
+  // Persistent storage flag — true while contract is paused by admin.
+  // In the real Soroban contract this is a DataKey::Paused storage entry.
+  private paused = false;
+
+  // Reentrancy mutex — kept from the reentrancy-guard feature.
+  private locked = false;
+
+  // In-memory event log (replace with persistent audit log / event bus in prod).
+  private readonly eventLog: ContractEvent[] = [];
+
   constructor(private readonly configService: ConfigService) {}
+
+  // ── Admin: pause / unpause ────────────────────────────────────────────────
+
+  /**
+   * Halts all state-changing contract operations immediately.
+   * Only callable by an admin identity (enforced by the caller's guard).
+   * Emits ContractPaused event.
+   */
+  pause(adminId: string): void {
+    if (this.paused) {
+      this.logger.warn(`pause() called by ${adminId} but contract is already paused`);
+      return;
+    }
+
+    this.paused = true;
+
+    const event: ContractPausedEvent = {
+      type: 'ContractPaused',
+      admin: adminId,
+      timestamp: new Date(),
+    };
+    this.eventLog.push(event);
+    this.logger.warn(`CONTRACT PAUSED by admin ${adminId}`);
+  }
+
+  /**
+   * Resumes normal contract operations.
+   * Emits ContractUnpaused event.
+   */
+  unpause(adminId: string): void {
+    if (!this.paused) {
+      this.logger.warn(`unpause() called by ${adminId} but contract is not paused`);
+      return;
+    }
+
+    this.paused = false;
+
+    const event: ContractUnpausedEvent = {
+      type: 'ContractUnpaused',
+      admin: adminId,
+      timestamp: new Date(),
+    };
+    this.eventLog.push(event);
+    this.logger.log(`Contract unpaused by admin ${adminId}`);
+  }
+
+  // ── View: pause state (always accessible) ────────────────────────────────
+
+  isPaused(): boolean {
+    return this.paused;
+  }
+
+  getEventLog(): ContractEvent[] {
+    return [...this.eventLog];
+  }
+
+  // ── Guards (private) ──────────────────────────────────────────────────────
+
+  private requireNotPaused(): void {
+    if (this.paused) {
+      throw new ContractPausedError();
+    }
+  }
+
+  private acquireLock(): void {
+    if (this.locked) {
+      throw new Error('ReentrantCall: escrow operation already in progress');
+    }
+    this.locked = true;
+  }
+
+  private releaseLock(): void {
+    this.locked = false;
+  }
+
+  // ── Escrow: mutable operations (pause-guarded + reentracy-guarded) ────────
+
+  /**
+   * Deposit funds into the escrow contract.
+   * Blocked while paused. Blocked if reentrant.
+   */
+  async deposit(stellarAddress: string, amountUsdc: string): Promise<void> {
+    this.requireNotPaused();
+    this.acquireLock();
+    try {
+      this.logger.log(`Depositing ${amountUsdc} USDC from ${stellarAddress} into escrow`);
+      // TODO: invoke CheesePay contract deposit(stellarAddress, amountUsdc)
+    } finally {
+      this.releaseLock();
+    }
+  }
+
+  /**
+   * Release escrowed funds to the merchant.
+   * Blocked while paused. Blocked if reentrant.
+   */
+  async release(paymentId: string, merchantAddress: string): Promise<void> {
+    this.requireNotPaused();
+    this.acquireLock();
+    try {
+      this.logger.log(`Releasing escrow for payment ${paymentId} → ${merchantAddress}`);
+      // TODO: invoke CheesePay contract release(paymentId, merchantAddress)
+    } finally {
+      this.releaseLock();
+    }
+  }
+
+  /**
+   * Refund escrowed funds back to the customer.
+   * Blocked while paused. Blocked if reentrant.
+   */
+  async refund(paymentId: string, customerAddress: string): Promise<void> {
+    this.requireNotPaused();
+    this.acquireLock();
+    try {
+      this.logger.log(`Refunding escrow for payment ${paymentId} → ${customerAddress}`);
+      // TODO: invoke CheesePay contract refund(paymentId, customerAddress)
+    } finally {
+      this.releaseLock();
+    }
+  }
+
+  // ── Read-only contract calls (no pause guard — always accessible) ─────────
 
   async registerUser(username: string, publicKey: string): Promise<void> {
     this.logger.log(`Registering user ${username} (${publicKey}) on Soroban contract`);
     // TODO: invoke CheesePay contract registerUser(username, publicKey)
-    // using @stellar/stellar-sdk SorobanRpc.Server + contract invocation
   }
 
   async getBalance(stellarAddress: string): Promise<string> {


### PR DESCRIPTION
close #836 

**Description:**

Adds an admin-controlled pause mechanism to `SorobanService` that can instantly halt all state-changing escrow operations during a security incident, without taking down read/monitoring access.

**Why**
If a vulnerability is discovered mid-operation, there was previously no way to stop deposits, releases, and refunds without a full deployment. This gives an admin a single call to freeze the contract immediately.

**What changed**

- `paused` boolean flag stored in service state (mirrors a `DataKey::Paused` persistent storage entry in the real Soroban contract)
- `pause(adminId)` and `unpause(adminId)` admin functions — both idempotent, no duplicate events on repeat calls
- `requireNotPaused()` guard runs at the top of `deposit()`, `release()`, and `refund()` before any state is touched
- `ContractPausedError` extends `ForbiddenException` — surfaces as HTTP 403 if called through a controller
- `ContractPaused` / `ContractUnpaused` events emitted with admin ID and timestamp on every state change
- View functions (`getBalance`, `getStakeBalance`, `isPaused`, `getEventLog`) have no pause guard — monitoring stays live during an incident
- Reentrancy guard from the previous PR coexists cleanly, both guards are independent

**Testing**

18/18 tests pass in `soroban-pause.service.spec.ts`:
- Starts unpaused
- `pause()` / `unpause()` toggle state and emit correct events
- Idempotent calls don't emit duplicate events
- `deposit`, `release`, `refund` all throw `ContractPausedError` while paused
- `getBalance`, `getStakeBalance`, `isPaused`, `getEventLog` all accessible while paused
- All operations resume normally after unpause
- Full incident scenario: normal ops → pause → writes blocked → reads ok → unpause → normal ops

**How to test manually**
```ts
sorobanService.pause('admin-id');       // halts all writes
sorobanService.isPaused();              // true
sorobanService.getBalance('GABC');      // still works
sorobanService.deposit('GABC', '100'); // throws ContractPausedError
sorobanService.unpause('admin-id');     // resumes
sorobanService.deposit('GABC', '100'); // works again
```

**Checklist**
- [x] Tests written and passing
- [x] No breaking changes to existing behaviour
- [x] View functions unaffected by pause
- [x] Events emitted for audit trail
- [x] Idempotent pause/unpause