### PR TITLE
feat(payments): batch payment creation endpoint — up to 20 per invoca…

### DIFF
--- a/backend/src/cache/cache.service.ts
+++ b/backend/src/cache/cache.service.ts
@@ -142,13 +142,7 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
   }
 
   async flushAll(): Promise<void> {
-    const redis = await this.ensureRedisConnected();
-    if (redis) {
-      await redis.flushdb();
-      return;
-    }
-
-    this.store.clear();
+    await this.redis.flushdb();
   }
 
   async getOrSet<T>(

--- a/backend/src/payments/dto/batch-create-payment.dto.ts
+++ b/backend/src/payments/dto/batch-create-payment.dto.ts
@@ -1,0 +1,70 @@
+import {
+  IsNumber,
+  IsPositive,
+  IsString,
+  IsOptional,
+  IsEmail,
+  IsObject,
+  IsArray,
+  ArrayMinSize,
+  ArrayMaxSize,
+  ValidateNested,
+  IsNotEmpty,
+  MinLength,
+} from 'class-validator';
+import { Type, Transform } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class BatchPaymentItemDto {
+  @ApiProperty({ example: 50.0, description: 'Amount in USD — must be greater than 0' })
+  @IsNumber()
+  @IsPositive()
+  amountUsd: number;
+
+  @ApiProperty({ example: 'Order #123', description: 'Non-empty memo for this payment' })
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(1)
+  @Transform(({ value }) => value?.trim())
+  memo: string;
+
+  @ApiPropertyOptional({ example: 'customer@example.com' })
+  @IsOptional()
+  @IsEmail()
+  @Transform(({ value }) => value?.trim())
+  customerEmail?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>;
+
+  @ApiPropertyOptional({ example: 30, description: 'Expiry in minutes (default 30)' })
+  @IsOptional()
+  @IsNumber()
+  @IsPositive()
+  expiryMinutes?: number;
+}
+
+export class BatchCreatePaymentDto {
+  @ApiProperty({
+    type: [BatchPaymentItemDto],
+    description: 'Between 1 and 20 payment requests to create atomically',
+    minItems: 1,
+    maxItems: 20,
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(20)
+  @ValidateNested({ each: true })
+  @Type(() => BatchPaymentItemDto)
+  payments: BatchPaymentItemDto[];
+}
+
+export class BatchPaymentResultDto {
+  @ApiProperty({ description: 'IDs of all created payments in order' })
+  paymentIds: string[];
+
+  @ApiProperty({ description: 'Total number of payments created' })
+  count: number;
+}

--- a/backend/src/payments/payments-batch.service.spec.ts
+++ b/backend/src/payments/payments-batch.service.spec.ts
@@ -1,0 +1,196 @@
+jest.mock('uuid', () => ({ v4: () => 'mock-uuid' }));
+jest.mock('qrcode', () => ({ toDataURL: jest.fn().mockResolvedValue('data:image/png;base64,mock') }));
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BadRequestException } from '@nestjs/common';
+import { PaymentsService } from './payments.service';
+import { Payment, PaymentStatus } from './entities/payment.entity';
+import { StellarService } from '../stellar/stellar.service';
+import { WebhooksService } from '../webhooks/webhooks.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { MerchantsService } from '../merchants/merchants.service';
+import { BatchCreatePaymentDto, BatchPaymentItemDto } from './dto/batch-create-payment.dto';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeItem(overrides: Partial<BatchPaymentItemDto> = {}): BatchPaymentItemDto {
+  return {
+    amountUsd: 10,
+    memo: 'Order #1',
+    ...overrides,
+  };
+}
+
+function makeDto(count: number, overrides: Partial<BatchPaymentItemDto> = {}): BatchCreatePaymentDto {
+  return { payments: Array.from({ length: count }, (_, i) => makeItem({ memo: `Order #${i + 1}`, ...overrides })) };
+}
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
+
+describe('PaymentsService — createBatch', () => {
+  let service: PaymentsService;
+  let repoSave: jest.Mock;
+  let repoCreate: jest.Mock;
+
+  beforeEach(async () => {
+    repoCreate = jest.fn().mockImplementation((data) => ({ ...data, id: 'mock-uuid' }));
+    repoSave = jest.fn().mockImplementation((records) =>
+      Promise.resolve(Array.isArray(records) ? records : [records]),
+    );
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PaymentsService,
+        {
+          provide: getRepositoryToken(Payment),
+          useValue: {
+            findOne: jest.fn(),
+            create: repoCreate,
+            save: repoSave,
+            findAndCount: jest.fn(),
+            createQueryBuilder: jest.fn(),
+          },
+        },
+        {
+          provide: StellarService,
+          useValue: {
+            getXlmUsdRate: jest.fn().mockResolvedValue(0.1),
+            getDepositAddress: jest.fn().mockReturnValue('GDEPOSITADDR'),
+            generateMemo: jest.fn().mockReturnValue('MEMO1234'),
+            getUsdcAsset: jest.fn().mockReturnValue({ code: 'USDC' }),
+            sendPayment: jest.fn(),
+          },
+        },
+        {
+          provide: WebhooksService,
+          useValue: { dispatch: jest.fn() },
+        },
+        {
+          provide: NotificationsService,
+          useValue: { enqueueEmail: jest.fn() },
+        },
+        {
+          provide: MerchantsService,
+          useValue: { findOne: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get(PaymentsService);
+  });
+
+  // ── Batch sizes ───────────────────────────────────────────────────────────
+
+  it('creates a batch of 1 payment', async () => {
+    const result = await service.createBatch('merchant-1', makeDto(1));
+    expect(result.count).toBe(1);
+    expect(result.paymentIds).toHaveLength(1);
+    expect(repoSave).toHaveBeenCalledTimes(1);
+    const savedRecords = repoSave.mock.calls[0][0];
+    expect(savedRecords).toHaveLength(1);
+  });
+
+  it('creates a batch of 10 payments', async () => {
+    const result = await service.createBatch('merchant-1', makeDto(10));
+    expect(result.count).toBe(10);
+    expect(result.paymentIds).toHaveLength(10);
+    const savedRecords = repoSave.mock.calls[0][0];
+    expect(savedRecords).toHaveLength(10);
+  });
+
+  it('creates a batch of 20 payments (max allowed)', async () => {
+    const result = await service.createBatch('merchant-1', makeDto(20));
+    expect(result.count).toBe(20);
+    expect(result.paymentIds).toHaveLength(20);
+    const savedRecords = repoSave.mock.calls[0][0];
+    expect(savedRecords).toHaveLength(20);
+  });
+
+  it('all payments in batch have PENDING status', async () => {
+    await service.createBatch('merchant-1', makeDto(5));
+    const savedRecords: Payment[] = repoSave.mock.calls[0][0];
+    for (const p of savedRecords) {
+      expect(p.status).toBe(PaymentStatus.PENDING);
+    }
+  });
+
+  it('each payment gets the correct merchantId', async () => {
+    await service.createBatch('merchant-abc', makeDto(3));
+    const savedRecords: Payment[] = repoSave.mock.calls[0][0];
+    for (const p of savedRecords) {
+      expect(p.merchantId).toBe('merchant-abc');
+    }
+  });
+
+  it('each payment description matches its memo', async () => {
+    const dto = makeDto(3);
+    await service.createBatch('merchant-1', dto);
+    const savedRecords: Payment[] = repoSave.mock.calls[0][0];
+    for (let i = 0; i < savedRecords.length; i++) {
+      expect(savedRecords[i].description).toBe(dto.payments[i].memo);
+    }
+  });
+
+  it('repo.save is called exactly once for the whole batch (atomic)', async () => {
+    await service.createBatch('merchant-1', makeDto(10));
+    expect(repoSave).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Validation: entire batch reverts on any invalid input ─────────────────
+
+  it('reverts entire batch if one item has amountUsd = 0', async () => {
+    const dto = makeDto(5);
+    dto.payments[2].amountUsd = 0;
+    await expect(service.createBatch('merchant-1', dto)).rejects.toThrow(BadRequestException);
+    expect(repoSave).not.toHaveBeenCalled();
+  });
+
+  it('reverts entire batch if one item has negative amountUsd', async () => {
+    const dto = makeDto(5);
+    dto.payments[4].amountUsd = -1;
+    await expect(service.createBatch('merchant-1', dto)).rejects.toThrow(BadRequestException);
+    expect(repoSave).not.toHaveBeenCalled();
+  });
+
+  it('reverts entire batch if one item has empty memo', async () => {
+    const dto = makeDto(5);
+    dto.payments[1].memo = '';
+    await expect(service.createBatch('merchant-1', dto)).rejects.toThrow(BadRequestException);
+    expect(repoSave).not.toHaveBeenCalled();
+  });
+
+  it('reverts entire batch if one item has whitespace-only memo', async () => {
+    const dto = makeDto(5);
+    dto.payments[3].memo = '   ';
+    await expect(service.createBatch('merchant-1', dto)).rejects.toThrow(BadRequestException);
+    expect(repoSave).not.toHaveBeenCalled();
+  });
+
+  it('error message includes the failing item index', async () => {
+    const dto = makeDto(5);
+    dto.payments[2].amountUsd = 0;
+    await expect(service.createBatch('merchant-1', dto)).rejects.toThrow('[2]');
+  });
+
+  it('valid batch after a previously rejected one still works', async () => {
+    const bad = makeDto(3);
+    bad.payments[0].memo = '';
+    await expect(service.createBatch('merchant-1', bad)).rejects.toThrow(BadRequestException);
+
+    const good = makeDto(3);
+    const result = await service.createBatch('merchant-1', good);
+    expect(result.count).toBe(3);
+  });
+
+  // ── PaymentCreated events ─────────────────────────────────────────────────
+
+  it('logs a PaymentCreated event for each item in the batch', async () => {
+    const logSpy = jest.spyOn((service as any).logger, 'log').mockImplementation(() => {});
+    await service.createBatch('merchant-1', makeDto(3));
+    const paymentCreatedLogs = logSpy.mock.calls.filter(([msg]) =>
+      String(msg).includes('PaymentCreated'),
+    );
+    expect(paymentCreatedLogs).toHaveLength(3);
+  });
+});

--- a/backend/src/payments/payments.controller.ts
+++ b/backend/src/payments/payments.controller.ts
@@ -14,6 +14,7 @@ import {
 import { PaymentsService } from './payments.service';
 import { CreatePaymentDto } from './dto/create-payment.dto';
 import { RefundPaymentDto } from './dto/refund-payment.dto';
+import { BatchCreatePaymentDto, BatchPaymentResultDto } from './dto/batch-create-payment.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt.guard';
 import { PaginationDto } from '../common/dto/pagination.dto';
 import { IdempotencyInterceptor } from '../payment/idempotency.interceptor';
@@ -34,6 +35,24 @@ export class PaymentsController {
   @ApiResponse({ status: 500, description: 'Internal server error' })
   create(@Request() req: { user: { merchantId: string } }, @Body() dto: CreatePaymentDto) {
     return this.paymentsService.create(req.user.merchantId, dto);
+  }
+
+  @Post('batch')
+  @ApiOperation({
+    summary: 'Create up to 20 payment requests in a single contract invocation',
+    description:
+      'Mirrors the Soroban contract create_batch(). All inputs are validated before ' +
+      'any payment is written — the entire batch reverts if any single entry is invalid.',
+  })
+  @ApiOkResponse({ type: BatchPaymentResultDto, description: 'IDs of all created payments' })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT' })
+  @ApiBadRequestResponse({ description: 'Validation failed — entire batch rejected' })
+  @ApiResponse({ status: 500, description: 'Internal server error' })
+  createBatch(
+    @Request() req: { user: { merchantId: string } },
+    @Body() dto: BatchCreatePaymentDto,
+  ): Promise<BatchPaymentResultDto> {
+    return this.paymentsService.createBatch(req.user.merchantId, dto);
   }
 
   @Get()

--- a/backend/src/payments/payments.service.ts
+++ b/backend/src/payments/payments.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
@@ -7,14 +7,27 @@ import * as StellarSdk from '@stellar/stellar-sdk';
 import { Payment, PaymentStatus } from './entities/payment.entity';
 import { CreatePaymentDto } from './dto/create-payment.dto';
 import { RefundPaymentDto } from './dto/refund-payment.dto';
+import { BatchCreatePaymentDto, BatchPaymentResultDto } from './dto/batch-create-payment.dto';
 import { StellarService } from '../stellar/stellar.service';
 import { WebhooksService } from '../webhooks/webhooks.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { MerchantsService } from '../merchants/merchants.service';
 import { PaginatedResponseDto } from '../common/dto/pagination.dto';
 
+// Events emitted per payment in a batch — mirrors contract PaymentCreated events
+export interface PaymentCreatedEvent {
+  type: 'PaymentCreated';
+  paymentId: string;
+  merchantId: string;
+  amountUsd: number;
+  memo: string;
+  timestamp: Date;
+}
+
 @Injectable()
 export class PaymentsService {
+  private readonly logger = new Logger(PaymentsService.name);
+
   constructor(
     @InjectRepository(Payment)
     private paymentsRepo: Repository<Payment>,
@@ -54,6 +67,101 @@ export class PaymentsService {
     });
 
     return this.paymentsRepo.save(payment);
+  }
+
+  /**
+   * create_batch — mirrors the Soroban contract's create_batch(payments: Vec<PaymentInput>).
+   *
+   * Creates up to 20 payment requests atomically. Validates every entry first
+   * so the entire batch reverts (throws) if any single input is invalid —
+   * no partial writes ever reach the database.
+   *
+   * Emits a PaymentCreated event for each entry, matching the contract event log.
+   */
+  async createBatch(
+    merchantId: string,
+    dto: BatchCreatePaymentDto,
+  ): Promise<BatchPaymentResultDto> {
+    const { payments: items } = dto;
+
+    // ── Validate all inputs before touching the DB (atomic revert on failure) ──
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (!item.amountUsd || item.amountUsd <= 0) {
+        throw new BadRequestException(
+          `Batch item [${i}]: amountUsd must be greater than 0`,
+        );
+      }
+      if (!item.memo || item.memo.trim().length === 0) {
+        throw new BadRequestException(
+          `Batch item [${i}]: memo must not be empty`,
+        );
+      }
+    }
+
+    // ── Build all payment records in memory ───────────────────────────────────
+    const xlmRate = await this.stellar.getXlmUsdRate();
+    const depositAddress = this.stellar.getDepositAddress();
+    const now = Date.now();
+
+    const records: Payment[] = [];
+    const events: PaymentCreatedEvent[] = [];
+
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      const amountXlm = item.amountUsd / xlmRate;
+      const memo = this.stellar.generateMemo();
+
+      const stellarUri =
+        `web+stellar:pay?destination=${depositAddress}` +
+        `&amount=${amountXlm.toFixed(7)}&memo=${memo}&memo_type=text`;
+      const qrCode = await QRCode.toDataURL(stellarUri);
+
+      const expiresAt = new Date();
+      expiresAt.setMinutes(expiresAt.getMinutes() + (item.expiryMinutes ?? 30));
+
+      const payment = this.paymentsRepo.create({
+        id: uuidv4(),
+        // Unique reference per item — suffix with batch index to avoid collisions
+        reference: `PAY-${now}-${Math.random().toString(36).substring(2, 6).toUpperCase()}-B${i}`,
+        merchantId,
+        amountUsd: item.amountUsd,
+        amountXlm: parseFloat(amountXlm.toFixed(7)),
+        description: item.memo,
+        customerEmail: item.customerEmail,
+        metadata: item.metadata,
+        stellarDepositAddress: depositAddress,
+        stellarMemo: memo,
+        qrCode,
+        expiresAt,
+        status: PaymentStatus.PENDING,
+      });
+
+      records.push(payment);
+      events.push({
+        type: 'PaymentCreated',
+        paymentId: payment.id,
+        merchantId,
+        amountUsd: item.amountUsd,
+        memo: item.memo,
+        timestamp: new Date(),
+      });
+    }
+
+    // ── Persist all records in one shot (atomic) ──────────────────────────────
+    const saved = await this.paymentsRepo.save(records);
+
+    // ── Emit PaymentCreated event for each entry (mirrors contract event log) ─
+    for (const event of events) {
+      this.logger.log(
+        `PaymentCreated: id=${event.paymentId} merchant=${merchantId} amount=${event.amountUsd} memo="${event.memo}"`,
+      );
+    }
+
+    return {
+      paymentIds: saved.map((p) => p.id),
+      count: saved.length,
+    };
   }
 
   async findAll(merchantId: string, page = 1, limit = 20) {


### PR DESCRIPTION
close #822 

summary

BatchPaymentItemDto — amountUsd > 0, memo non-empty, optional customerEmail, metadata, expiryMinutes

BatchCreatePaymentDto — array of 1–20 items with @ValidateNested deep validation

PaymentsService.createBatch() — validates every item first (throws with the failing index if anything is wrong), then builds all records in memory, persists in a single repo.save(records[]) call, logs a PaymentCreated event per entry

POST /payments/batch — authenticated, Swagger documented, returns { paymentIds[], count }

Atomicity — validation runs before any DB write. One bad item = zero payments saved.

Bonus fix — CacheService.flushAll() had dead references to ensureRedisConnected and store from a previous refactor that was breaking the entire payments test suite on main. Fixed as part of this PR. 